### PR TITLE
replace compile with implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,16 +21,16 @@ if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
 }
 
 dependencies {
-  compile 'io.dropwizard.modules:dropwizard-flyway:1.3.0-4'
-  compile 'io.dropwizard:dropwizard-core:1.3.5'
-  compile 'io.dropwizard:dropwizard-jdbi3:1.3.5'
-  compile 'org.jdbi:jdbi3-postgres:3.3.0'
-  compile 'org.jdbi:jdbi3-sqlobject:3.3.0'
-  compile 'org.postgresql:postgresql:42.2.4'
+  implementation 'io.dropwizard.modules:dropwizard-flyway:1.3.0-4'
+  implementation 'io.dropwizard:dropwizard-core:1.3.5'
+  implementation 'io.dropwizard:dropwizard-jdbi3:1.3.5'
+  implementation 'org.jdbi:jdbi3-postgres:3.3.0'
+  implementation 'org.jdbi:jdbi3-sqlobject:3.3.0'
+  implementation 'org.postgresql:postgresql:42.2.4'
 
-  testCompile 'io.dropwizard:dropwizard-testing:1.3.5'
-  testCompile 'junit:junit:4.12'
-  testCompile 'org.mockito:mockito-core:2.19.0'
+  testImplementation 'io.dropwizard:dropwizard-testing:1.3.5'
+  testImplementation 'junit:junit:4.12'
+  testImplementation 'org.mockito:mockito-core:2.19.0'
 }
 
 shadowJar {


### PR DESCRIPTION
`compile` and `testCompile` are deprecated as of gradle 3

https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#new_configurations

Since all of the dependencies used in the project are for internal use only (this is an app not a lib), I've updated the configuration to use `implementation` and `testImplementation`.