### PR TITLE
Add support to enable variable substitution with environment variables

### DIFF
--- a/src/main/java/marquez/MarquezApp.java
+++ b/src/main/java/marquez/MarquezApp.java
@@ -1,6 +1,8 @@
 package marquez;
 
 import io.dropwizard.Application;
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.flyway.FlywayBundle;
 import io.dropwizard.flyway.FlywayFactory;
@@ -46,6 +48,11 @@ public class MarquezApp extends Application<MarquezConfig> {
 
   @Override
   public void initialize(Bootstrap<MarquezConfig> bootstrap) {
+    // Enable variable substitution with environment variables.
+    bootstrap.setConfigurationSourceProvider(
+        new SubstitutingSourceProvider(
+            bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false)));
+
     bootstrap.addBundle(
         new FlywayBundle<MarquezConfig>() {
           @Override

--- a/src/main/java/marquez/MarquezApp.java
+++ b/src/main/java/marquez/MarquezApp.java
@@ -51,7 +51,7 @@ public class MarquezApp extends Application<MarquezConfig> {
     // Enable variable substitution with environment variables.
     bootstrap.setConfigurationSourceProvider(
         new SubstitutingSourceProvider(
-            bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false)));
+            bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor()));
 
     bootstrap.addBundle(
         new FlywayBundle<MarquezConfig>() {

--- a/src/main/java/marquez/MarquezApp.java
+++ b/src/main/java/marquez/MarquezApp.java
@@ -13,7 +13,6 @@ import marquez.db.dao.DatasetDAO;
 import marquez.db.dao.JobDAO;
 import marquez.db.dao.JobRunDAO;
 import marquez.db.dao.JobRunDefinitionDAO;
-import marquez.db.dao.JobRunStateDAO;
 import marquez.db.dao.JobVersionDAO;
 import marquez.db.dao.OwnerDAO;
 import marquez.resources.DatasetResource;
@@ -111,8 +110,6 @@ public class MarquezApp extends Application<MarquezConfig> {
 
     final JobRunDAO jobRunDAO = jdbi.onDemand(JobRunDAO.class);
     env.jersey().register(new JobRunResource(jobRunDAO));
-
-    final JobRunStateDAO jobRunStateDAO = jdbi.onDemand(JobRunStateDAO.class);
 
     final DatasetDAO datasetDAO = jdbi.onDemand(DatasetDAO.class);
     env.jersey().register(new DatasetResource(datasetDAO));


### PR DESCRIPTION
This PR now allows environment variable access from `config.yml`. For example:

```yaml
database:
  driverClass: org.postgresql.Driver
  url: jdbc:postgresql://${POSTGRESQL_HOST:localhost}:${POSTGRESQL_PORT:5432}/${POSTGRESQL_DB_NAME}
  user: ${POSTGRESQL_USER}
  password: ${POSTGRESQL_PASSWORD}
```

A [UndefinedEnvironmentVariableException](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-configuration/src/main/java/io/dropwizard/configuration/UndefinedEnvironmentVariableException.java) is thrown when a variable defined in `config.yml` cannot be interpolated. An example error message might be:


> The environment variable 'POSTGRESQL_PASSWORD' is not defined; could not substitute the expression '${POSTGRESQL_PASSWORD}'.
