### PR TITLE
Add the stacktrace flag to the CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: ./gradlew clean build
+      - run: ./gradlew clean build --stacktrace
   test:
     <<: *defaults
     steps:


### PR DESCRIPTION
This PR adds the `--stacktrace` flag to help us debug failed builds. We did this b/c normally test failures don't include the stack trace and accessing the local test report is tricky.