### PR TITLE
Add env var default value support

### DIFF
--- a/src/main/java/marquez/MarquezApp.java
+++ b/src/main/java/marquez/MarquezApp.java
@@ -35,6 +35,7 @@ public class MarquezApp extends Application<MarquezConfig> {
 
   private static final String APP_NAME = "MarquezApp";
   private static final String POSTGRESQL_DB = "postgresql";
+  private static final boolean ERROR_ON_UNDEFINED = false;
 
   public static void main(String[] args) throws Exception {
     new MarquezApp().run(args);
@@ -50,7 +51,8 @@ public class MarquezApp extends Application<MarquezConfig> {
     // Enable variable substitution with environment variables.
     bootstrap.setConfigurationSourceProvider(
         new SubstitutingSourceProvider(
-            bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor()));
+            bootstrap.getConfigurationSourceProvider(),
+            new EnvironmentVariableSubstitutor(ERROR_ON_UNDEFINED)));
 
     bootstrap.addBundle(
         new FlywayBundle<MarquezConfig>() {


### PR DESCRIPTION
This PR allows for default values to be provided in `config.yml` on undefined env vars. For example, using the `:-` notation,

```bash
db_host: ${POSTGRESQL_HOST:-localhost}
```

will default to `localhost` if the `POSTGRESQL_HOST` is not set.