### PR TITLE
Use openjdk 8 in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:9-jdk-slim AS base
+FROM openjdk:8-jdk AS base
 WORKDIR /usr/src/app
 COPY gradle gradle
 COPY gradlew gradlew
@@ -10,7 +10,7 @@ WORKDIR /usr/src/app
 COPY . .
 RUN ./gradlew --no-daemon shadowJar
 
-FROM openjdk:9-jdk-slim
+FROM openjdk:8-jre
 WORKDIR /usr/src/app
 COPY --from=build /usr/src/app/build/libs/marquez-all.jar marquez-all.jar
 COPY --from=build /usr/src/app/docker/entrypoint.sh entrypoint.sh


### PR DESCRIPTION
This PR uses jdk8 when building the image for marquez to address jdk9 compatibility issues with Jersey (TL;DR libs in jdk8 were removed in jdk9) .