### PR TITLE
Filter files on new Docker image creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,13 @@ RUN ./gradlew --version
 
 FROM base AS build
 WORKDIR /usr/src/app
-COPY . .
+COPY src ./src
+COPY build.gradle build.gradle
 RUN ./gradlew --no-daemon shadowJar
 
 FROM openjdk:8-jre
 WORKDIR /usr/src/app
 COPY --from=build /usr/src/app/build/libs/marquez-all.jar marquez-all.jar
-COPY --from=build /usr/src/app/docker/entrypoint.sh entrypoint.sh
+COPY docker/entrypoint.sh entrypoint.sh
 EXPOSE 5000
 ENTRYPOINT ["/usr/src/app/entrypoint.sh"]


### PR DESCRIPTION
This PR updates [Dockerfile](https://github.com/MarquezProject/marquez/blob/docker-filter-files/Dockerfile) to copy only required files and directories on image creation.  For example, `src/` to build the executable and  [`entrypoint.sh`](https://github.com/MarquezProject/marquez/blob/master/docker/entrypoint.sh) to run it.  