### PR TITLE
Increase gradle HTTP timeouts on build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: ./gradlew clean build --stacktrace
+      - run: ./gradlew clean build --stacktrace -Dhttp.socketTimeout=20000 -Dhttp.connectionTimeout=20000
   test:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: ./gradlew clean build --stacktrace -Dhttp.socketTimeout=20000 -Dhttp.connectionTimeout=20000
+      - run: ./gradlew clean build --stacktrace
   test:
     <<: *defaults
     steps:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-http.socketTimeout=20000
-http.connectionTimeout=20000
+org.gradle.internal.http.connectionTimeout=60000
+org.gradle.internal.http.socketTimeout=60000

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+http.socketTimeout=20000
+http.connectionTimeout=20000


### PR DESCRIPTION
Trying to reduce the number of spurious build failures when a dependency / plugin download times out.