### PR TITLE
[MARQUEZ-84]: Remove test steps from circleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,12 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: ./gradlew clean build --stacktrace
+      - run: ./gradlew clean build -x test checkstyleTest --stacktrace
   test:
     <<: *defaults
     steps:
       - checkout
-      - run: ./gradlew test
+      - run: ./gradlew test --stacktrace
       - run: ./gradlew jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)
 


### PR DESCRIPTION
- Also adds --stacktrace to the circleCI build test