### PR TITLE
Use openjdk 8 as base image for ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/marquez
   docker:
-    - image: circleci/openjdk:9-jdk
+    - image: circleci/openjdk:8-jdk
 
 version: 2
 jobs:


### PR DESCRIPTION
This PR updates the CI base image to `circleci/openjdk:8-jdk` (see #86)