### PR TITLE
Bump dropwizard to 1.3.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ repositories {
 
 dependencies {
   compile 'io.dropwizard.modules:dropwizard-flyway:1.3.0-4'
-  compile 'io.dropwizard:dropwizard-core:1.3.5'
-  compile 'io.dropwizard:dropwizard-jdbi3:1.3.5'
+  compile 'io.dropwizard:dropwizard-core:1.3.6'
+  compile 'io.dropwizard:dropwizard-jdbi3:1.3.6'
   compile 'org.jdbi:jdbi3-postgres:3.4.0'
   compile 'org.jdbi:jdbi3-sqlobject:3.4.0'
   compile 'org.postgresql:postgresql:42.2.4'


### PR DESCRIPTION
This PR bumps version `1.3.5` of dropwizard to `1.3.6`, patching a security vulnerability in Jackson (see [dropwizard v1.3.6](https://github.com/dropwizard/dropwizard/releases/tag/v1.3.6))