### PR TITLE
Bump dropwizard to 1.3.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,13 +13,13 @@ repositories {
 
 dependencies {
   compile 'io.dropwizard.modules:dropwizard-flyway:1.3.0-4'
-  compile 'io.dropwizard:dropwizard-core:1.3.6'
-  compile 'io.dropwizard:dropwizard-jdbi3:1.3.6'
+  compile 'io.dropwizard:dropwizard-core:1.3.7'
+  compile 'io.dropwizard:dropwizard-jdbi3:1.3.7'
   compile 'org.jdbi:jdbi3-postgres:3.4.0'
   compile 'org.jdbi:jdbi3-sqlobject:3.4.0'
   compile 'org.postgresql:postgresql:42.2.4'
 
-  testCompile 'io.dropwizard:dropwizard-testing:1.3.5'
+  testCompile 'io.dropwizard:dropwizard-testing:1.3.7'
   testCompile 'junit:junit:4.12'
   testCompile 'org.jdbi:jdbi3-testing:3.3.0'
   testCompile 'org.mockito:mockito-core:2.21.0'


### PR DESCRIPTION
Another attempt at resolving Jackson vulnerabilities (see [snyk report](https://snyk.io/test/github/MarquezProject/marquez))