### PR TITLE
Add --no-daemon flag on CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,12 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: ./gradlew clean build -x test checkstyleTest --stacktrace
+      - run: ./gradlew --no-daemon --stacktrace clean build check -x test checkstyleTest
   test:
     <<: *defaults
     steps:
       - checkout
-      - run: ./gradlew test --stacktrace
+      - run: ./gradlew --no-daemon --stacktrace clean test
       - run: ./gradlew jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)
 


### PR DESCRIPTION
This PR disabled the gradle daemon in CI as it provides no additional benefit and decreases performance (see [gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:why_the_daemon))