### PR TITLE
Bump jdbi3 to 3.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ dependencies {
   compile 'io.dropwizard.modules:dropwizard-flyway:1.3.0-4'
   compile 'io.dropwizard:dropwizard-core:1.3.7'
   compile 'io.dropwizard:dropwizard-jdbi3:1.3.7'
-  compile 'org.jdbi:jdbi3-postgres:3.4.0'
-  compile 'org.jdbi:jdbi3-sqlobject:3.4.0'
+  compile 'org.jdbi:jdbi3-postgres:3.5.1'
+  compile 'org.jdbi:jdbi3-sqlobject:3.5.1'
   compile 'org.postgresql:postgresql:42.2.4'
 
   testCompile 'io.dropwizard:dropwizard-testing:1.3.7'


### PR DESCRIPTION
Some sweet additions in [3.5.1](https://github.com/jdbi/jdbi/blob/master/RELEASE_NOTES#L20): for example, EnumSet mapping support!