### PR TITLE
Bump postgresql to 42.2.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ dependencies {
   compile 'io.dropwizard:dropwizard-jdbi3:1.3.7'
   compile 'org.jdbi:jdbi3-postgres:3.5.1'
   compile 'org.jdbi:jdbi3-sqlobject:3.5.1'
-  compile 'org.postgresql:postgresql:42.2.4'
+  compile 'org.postgresql:postgresql:42.2.5'
 
   testCompile 'io.dropwizard:dropwizard-testing:1.3.7'
   testCompile 'junit:junit:4.12'


### PR DESCRIPTION
Version [42.2.5](https://github.com/pgjdbc/pgjdbc/blob/master/docs/_posts/2018-08-27-42.2.5-release.md) applies a security patch for server hostname verification.