### PR TITLE
Bump mockito-core to 2.23.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
   testCompile 'io.dropwizard:dropwizard-testing:1.3.7'
   testCompile 'junit:junit:4.12'
   testCompile 'org.jdbi:jdbi3-testing:3.3.0'
-  testCompile 'org.mockito:mockito-core:2.21.0'
+  testCompile 'org.mockito:mockito-core:2.23.4'
 }
 
 compileJava {


### PR DESCRIPTION
A number of bugfixes, etc in mockito-core [2.23.4](https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md) since [2.21.0](https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md#2210)