### PR TITLE
Add optional method to mapper

### DIFF
--- a/src/main/java/marquez/api/ListNamespacesResponse.java
+++ b/src/main/java/marquez/api/ListNamespacesResponse.java
@@ -22,7 +22,7 @@ public class ListNamespacesResponse {
     // TODO: simplify to just: return namespaces;
     return namespaces
         .stream()
-        .map(namespaceMapper::mapIfPresent)
+        .map(namespaceMapper::mapAsOptional)
         .filter(Optional::isPresent)
         .map(Optional::get)
         .collect(Collectors.toList());

--- a/src/main/java/marquez/api/ListNamespacesResponse.java
+++ b/src/main/java/marquez/api/ListNamespacesResponse.java
@@ -20,7 +20,7 @@ public class ListNamespacesResponse {
   public List<marquez.api.Namespace> getNamespaces() {
     return namespaces
         .stream()
-        .map(namespaceMapper::map)
+        .map(namespaceMapper::mapIfPresent)
         .filter(Optional::isPresent)
         .map(Optional::get)
         .collect(Collectors.toList());

--- a/src/main/java/marquez/api/ListNamespacesResponse.java
+++ b/src/main/java/marquez/api/ListNamespacesResponse.java
@@ -8,16 +8,18 @@ import marquez.core.mappers.CoreNamespaceToApiNamespaceMapper;
 import marquez.core.models.Namespace;
 
 public class ListNamespacesResponse {
-
+  // TODO: Remove use of CoreNamespaceToApiNamespaceMapper
   CoreNamespaceToApiNamespaceMapper namespaceMapper = new CoreNamespaceToApiNamespaceMapper();
   private final List<Namespace> namespaces;
 
-  public ListNamespacesResponse(@JsonProperty("namespaces") List<Namespace> namespaceList) {
-    this.namespaces = namespaceList;
+  // TODO: Constructor should accept marquez.api.models.Namespace instead
+  public ListNamespacesResponse(@JsonProperty("namespaces") List<Namespace> namespaces) {
+    this.namespaces = namespaces;
   }
 
   @JsonProperty("namespaces")
   public List<marquez.api.Namespace> getNamespaces() {
+    // TODO: simplify to just: return namespaces;
     return namespaces
         .stream()
         .map(namespaceMapper::mapIfPresent)

--- a/src/main/java/marquez/core/mappers/CoreNamespaceToApiNamespaceMapper.java
+++ b/src/main/java/marquez/core/mappers/CoreNamespaceToApiNamespaceMapper.java
@@ -1,13 +1,17 @@
 package marquez.core.mappers;
 
-import javax.validation.constraints.NotNull;
+import static java.util.Objects.requireNonNull;
 
 // TODO: Move to marquez.api.mappers pgk
 // TODO: Rename class to NamespaceMapper
 public class CoreNamespaceToApiNamespaceMapper
     extends Mapper<marquez.core.models.Namespace, marquez.api.Namespace> {
-  public marquez.api.Namespace map(@NotNull marquez.core.models.Namespace value) {
+  public marquez.api.Namespace map(marquez.core.models.Namespace namespace) {
+    requireNonNull(namespace, "namespace must not be null");
     return new marquez.api.Namespace(
-        value.getName(), value.getCreatedAt(), value.getOwnerName(), value.getDescription());
+        namespace.getName(),
+        namespace.getCreatedAt(),
+        namespace.getOwnerName(),
+        namespace.getDescription());
   }
 }

--- a/src/main/java/marquez/core/mappers/CoreNamespaceToApiNamespaceMapper.java
+++ b/src/main/java/marquez/core/mappers/CoreNamespaceToApiNamespaceMapper.java
@@ -2,6 +2,8 @@ package marquez.core.mappers;
 
 import javax.validation.constraints.NotNull;
 
+// TODO: Move to marquez.api.mappers pgk
+// TODO: Rename class to NamespaceMapper
 public class CoreNamespaceToApiNamespaceMapper
     extends Mapper<marquez.core.models.Namespace, marquez.api.Namespace> {
   public marquez.api.Namespace map(@NotNull marquez.core.models.Namespace value) {

--- a/src/main/java/marquez/core/mappers/CoreNamespaceToApiNamespaceMapper.java
+++ b/src/main/java/marquez/core/mappers/CoreNamespaceToApiNamespaceMapper.java
@@ -1,18 +1,11 @@
 package marquez.core.mappers;
 
-import java.util.Optional;
+import javax.validation.constraints.NotNull;
 
 public class CoreNamespaceToApiNamespaceMapper
-    implements Mapper<marquez.core.models.Namespace, marquez.api.Namespace> {
-  @Override
-  public Optional<marquez.api.Namespace> map(marquez.core.models.Namespace value) {
-    if (value == null) {
-      return Optional.empty();
-    }
-
-    marquez.api.Namespace toValue =
-        new marquez.api.Namespace(
-            value.getName(), value.getCreatedAt(), value.getOwnerName(), value.getDescription());
-    return Optional.of(toValue);
+    extends Mapper<marquez.core.models.Namespace, marquez.api.Namespace> {
+  public marquez.api.Namespace map(@NotNull marquez.core.models.Namespace value) {
+    return new marquez.api.Namespace(
+        value.getName(), value.getCreatedAt(), value.getOwnerName(), value.getDescription());
   }
 }

--- a/src/main/java/marquez/core/mappers/GetNamespaceResponseMapper.java
+++ b/src/main/java/marquez/core/mappers/GetNamespaceResponseMapper.java
@@ -1,6 +1,7 @@
 package marquez.core.mappers;
 
-import javax.validation.constraints.NotNull;
+import static java.util.Objects.requireNonNull;
+
 import marquez.api.GetNamespaceResponse;
 import marquez.core.models.Namespace;
 
@@ -11,7 +12,8 @@ public class GetNamespaceResponseMapper extends Mapper<Namespace, GetNamespaceRe
       new CoreNamespaceToApiNamespaceMapper();
 
   // TODO: GetNamespaceResponseMapper.map() should accept marquez.api.models.Namespace instead
-  public GetNamespaceResponse map(@NotNull Namespace namespace) {
+  public GetNamespaceResponse map(Namespace namespace) {
+    requireNonNull(namespace, "namespace must not be null");
     return new GetNamespaceResponse(namespaceMapper.map(namespace));
   }
 }

--- a/src/main/java/marquez/core/mappers/GetNamespaceResponseMapper.java
+++ b/src/main/java/marquez/core/mappers/GetNamespaceResponseMapper.java
@@ -9,6 +9,6 @@ public class GetNamespaceResponseMapper extends Mapper<Namespace, GetNamespaceRe
       new CoreNamespaceToApiNamespaceMapper();
 
   public GetNamespaceResponse map(@NotNull Namespace namespace) {
-    return new GetNamespaceResponse(namespaceMapper.mapIfPresent(namespace).get());
+    return new GetNamespaceResponse(namespaceMapper.map(namespace));
   }
 }

--- a/src/main/java/marquez/core/mappers/GetNamespaceResponseMapper.java
+++ b/src/main/java/marquez/core/mappers/GetNamespaceResponseMapper.java
@@ -6,9 +6,11 @@ import marquez.core.models.Namespace;
 
 // TODO: Move to marquez.api.mappers pgk
 public class GetNamespaceResponseMapper extends Mapper<Namespace, GetNamespaceResponse> {
+  // TODO: Remove use of CoreNamespaceToApiNamespaceMapper
   private final CoreNamespaceToApiNamespaceMapper namespaceMapper =
       new CoreNamespaceToApiNamespaceMapper();
 
+  // TODO: GetNamespaceResponseMapper.map() should accept marquez.api.models.Namespace instead
   public GetNamespaceResponse map(@NotNull Namespace namespace) {
     return new GetNamespaceResponse(namespaceMapper.map(namespace));
   }

--- a/src/main/java/marquez/core/mappers/GetNamespaceResponseMapper.java
+++ b/src/main/java/marquez/core/mappers/GetNamespaceResponseMapper.java
@@ -1,21 +1,14 @@
 package marquez.core.mappers;
 
-import java.util.Optional;
+import javax.validation.constraints.NotNull;
 import marquez.api.GetNamespaceResponse;
 import marquez.core.models.Namespace;
 
-public class GetNamespaceResponseMapper implements Mapper<Namespace, GetNamespaceResponse> {
+public class GetNamespaceResponseMapper extends Mapper<Namespace, GetNamespaceResponse> {
+  private final CoreNamespaceToApiNamespaceMapper namespaceMapper =
+      new CoreNamespaceToApiNamespaceMapper();
 
-  CoreNamespaceToApiNamespaceMapper namespaceMapper = new CoreNamespaceToApiNamespaceMapper();
-
-  @Override
-  public Optional<GetNamespaceResponse> map(Namespace namespace) {
-    if (namespace == null) {
-      return Optional.empty();
-    }
-
-    GetNamespaceResponse response = new GetNamespaceResponse(namespaceMapper.map(namespace).get());
-    // TODO: make this more defensive use optional correctly
-    return Optional.of(response);
+  public GetNamespaceResponse map(@NotNull Namespace namespace) {
+    return new GetNamespaceResponse(namespaceMapper.mapIfPresent(namespace).get());
   }
 }

--- a/src/main/java/marquez/core/mappers/GetNamespaceResponseMapper.java
+++ b/src/main/java/marquez/core/mappers/GetNamespaceResponseMapper.java
@@ -4,6 +4,7 @@ import javax.validation.constraints.NotNull;
 import marquez.api.GetNamespaceResponse;
 import marquez.core.models.Namespace;
 
+// TODO: Move to marquez.api.mappers pgk
 public class GetNamespaceResponseMapper extends Mapper<Namespace, GetNamespaceResponse> {
   private final CoreNamespaceToApiNamespaceMapper namespaceMapper =
       new CoreNamespaceToApiNamespaceMapper();

--- a/src/main/java/marquez/core/mappers/Mapper.java
+++ b/src/main/java/marquez/core/mappers/Mapper.java
@@ -1,16 +1,14 @@
 package marquez.core.mappers;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.Optional;
 
 public abstract class Mapper<A, B> {
   public Optional<B> mapAsOptional(A value) {
-    return Optional.ofNullable(map(requireNonNull(value)));
+    return Optional.ofNullable(map(value));
   }
 
   public Optional<B> mapIfPresent(Optional<A> value) {
-    return requireNonNull(value).map(this::map);
+    return value.map(this::map);
   }
 
   public abstract B map(A value);

--- a/src/main/java/marquez/core/mappers/Mapper.java
+++ b/src/main/java/marquez/core/mappers/Mapper.java
@@ -2,6 +2,7 @@ package marquez.core.mappers;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
 import java.util.Optional;
 
 public abstract class Mapper<A, B> {
@@ -14,4 +15,6 @@ public abstract class Mapper<A, B> {
   }
 
   public abstract B map(A value);
+
+  public abstract List<B> map(List<A> value);
 }

--- a/src/main/java/marquez/core/mappers/Mapper.java
+++ b/src/main/java/marquez/core/mappers/Mapper.java
@@ -9,7 +9,7 @@ public abstract class Mapper<A, B> {
     return Optional.ofNullable(map(value));
   }
 
-  public Optional<B> map(Optional<A> value) {
+  public Optional<B> mapIfPresent(Optional<A> value) {
     return requireNonNull(value).map(this::map);
   }
 

--- a/src/main/java/marquez/core/mappers/Mapper.java
+++ b/src/main/java/marquez/core/mappers/Mapper.java
@@ -9,7 +9,7 @@ public abstract class Mapper<A, B> {
     return Optional.ofNullable(map(value));
   }
 
-  public Optional<B> mapIfPresent(Optional<A> value) {
+  public Optional<B> map(Optional<A> value) {
     return requireNonNull(value).map(this::map);
   }
 

--- a/src/main/java/marquez/core/mappers/Mapper.java
+++ b/src/main/java/marquez/core/mappers/Mapper.java
@@ -1,9 +1,12 @@
 package marquez.core.mappers;
 
 import java.util.Optional;
+import javax.validation.constraints.NotNull;
 
-interface Mapper<A, B> {
-  B map(A value);
+public abstract class Mapper<A, B> {
+  public Optional<B> mapIfPresent(@NotNull A value) {
+    return Optional.ofNullable(map(value));
+  }
 
-  Optional<B> mapIfPresent(A value);
+  public abstract B map(A value);
 }

--- a/src/main/java/marquez/core/mappers/Mapper.java
+++ b/src/main/java/marquez/core/mappers/Mapper.java
@@ -1,12 +1,13 @@
 package marquez.core.mappers;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Optional;
-import javax.validation.constraints.NotNull;
 
 public abstract class Mapper<A, B> {
-  public Optional<B> mapIfPresent(@NotNull A value) {
-    return Optional.ofNullable(map(value));
+  public Optional<B> mapIfPresent(A value) {
+    return Optional.ofNullable(map(requireNonNull(value)));
   }
 
-  public abstract B map(@NotNull A value);
+  public abstract B map(A value);
 }

--- a/src/main/java/marquez/core/mappers/Mapper.java
+++ b/src/main/java/marquez/core/mappers/Mapper.java
@@ -9,5 +9,9 @@ public abstract class Mapper<A, B> {
     return Optional.ofNullable(map(requireNonNull(value)));
   }
 
+  public Optional<B> mapIfPresent(Optional<A> value) {
+    return requireNonNull(value).map(this::map);
+  }
+
   public abstract B map(A value);
 }

--- a/src/main/java/marquez/core/mappers/Mapper.java
+++ b/src/main/java/marquez/core/mappers/Mapper.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 
 public abstract class Mapper<A, B> {
-  public Optional<B> mapIfPresent(A value) {
+  public Optional<B> mapAsOptional(A value) {
     return Optional.ofNullable(map(requireNonNull(value)));
   }
 

--- a/src/main/java/marquez/core/mappers/Mapper.java
+++ b/src/main/java/marquez/core/mappers/Mapper.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public abstract class Mapper<A, B> {
   public Optional<B> mapAsOptional(A value) {
@@ -14,7 +15,9 @@ public abstract class Mapper<A, B> {
     return requireNonNull(value).map(this::map);
   }
 
-  public abstract B map(A value);
+  public List<B> map(List<A> value) {
+    return requireNonNull(value).stream().map(this::map).collect(Collectors.toList());
+  }
 
-  public abstract List<B> map(List<A> value);
+  public abstract B map(A value);
 }

--- a/src/main/java/marquez/core/mappers/Mapper.java
+++ b/src/main/java/marquez/core/mappers/Mapper.java
@@ -3,5 +3,7 @@ package marquez.core.mappers;
 import java.util.Optional;
 
 interface Mapper<A, B> {
-  Optional<B> map(A value);
+  B map(A value);
+
+  Optional<B> mapIfPresent(A value);
 }

--- a/src/main/java/marquez/core/mappers/Mapper.java
+++ b/src/main/java/marquez/core/mappers/Mapper.java
@@ -8,5 +8,5 @@ public abstract class Mapper<A, B> {
     return Optional.ofNullable(map(value));
   }
 
-  public abstract B map(A value);
+  public abstract B map(@NotNull A value);
 }

--- a/src/main/java/marquez/core/mappers/Mapper.java
+++ b/src/main/java/marquez/core/mappers/Mapper.java
@@ -1,5 +1,7 @@
 package marquez.core.mappers;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Optional;
 
 public abstract class Mapper<A, B> {
@@ -8,7 +10,7 @@ public abstract class Mapper<A, B> {
   }
 
   public Optional<B> mapIfPresent(Optional<A> value) {
-    return value.map(this::map);
+    return requireNonNull(value).map(this::map);
   }
 
   public abstract B map(A value);

--- a/src/main/java/marquez/resources/NamespaceResource.java
+++ b/src/main/java/marquez/resources/NamespaceResource.java
@@ -72,7 +72,7 @@ public class NamespaceResource extends BaseResource {
       if (n.isPresent()) {
         Namespace returnedNamespace = n.get();
         return Response.status(Response.Status.OK)
-            .entity(getNamespaceResponseMapper.mapIfPresent(returnedNamespace).get())
+            .entity(getNamespaceResponseMapper.map(returnedNamespace))
             .type(APPLICATION_JSON)
             .build();
       } else {

--- a/src/main/java/marquez/resources/NamespaceResource.java
+++ b/src/main/java/marquez/resources/NamespaceResource.java
@@ -53,7 +53,7 @@ public class NamespaceResource extends BaseResource {
       Namespace n =
           namespaceService.create(namespace, request.getOwner(), request.getDescription());
       return Response.status(Response.Status.OK)
-          .entity(new CreateNamespaceResponse(namespaceMapper.map(n).get()))
+          .entity(new CreateNamespaceResponse(namespaceMapper.mapIfPresent(n).get()))
           .type(APPLICATION_JSON)
           .build();
     } catch (UnexpectedException e) {
@@ -72,7 +72,7 @@ public class NamespaceResource extends BaseResource {
       if (n.isPresent()) {
         Namespace returnedNamespace = n.get();
         return Response.status(Response.Status.OK)
-            .entity(getNamespaceResponseMapper.map(returnedNamespace).get())
+            .entity(getNamespaceResponseMapper.mapIfPresent(returnedNamespace).get())
             .type(APPLICATION_JSON)
             .build();
       } else {

--- a/src/main/java/marquez/resources/NamespaceResource.java
+++ b/src/main/java/marquez/resources/NamespaceResource.java
@@ -53,7 +53,7 @@ public class NamespaceResource extends BaseResource {
       Namespace n =
           namespaceService.create(namespace, request.getOwner(), request.getDescription());
       return Response.status(Response.Status.OK)
-          .entity(new CreateNamespaceResponse(namespaceMapper.mapIfPresent(n).get()))
+          .entity(new CreateNamespaceResponse(namespaceMapper.map(n)))
           .type(APPLICATION_JSON)
           .build();
     } catch (UnexpectedException e) {

--- a/src/test/java/marquez/core/mappers/MapperTest.java
+++ b/src/test/java/marquez/core/mappers/MapperTest.java
@@ -23,14 +23,14 @@ public class MapperTest {
   @Test
   public void testMapFromOptional() {
     Optional<A> optA = Optional.of(new A());
-    Optional<B> optB = B_MAPPER.map(optA);
+    Optional<B> optB = B_MAPPER.mapIfPresent(optA);
     assertTrue(optB.isPresent());
   }
 
   @Test(expected = NullPointerException.class)
   public void testMapThrowOnNull() {
     Optional<A> nullOptA = null;
-    B_MAPPER.map(nullOptA);
+    B_MAPPER.mapIfPresent(nullOptA);
   }
 
   private static final Mapper<A, B> B_MAPPER =

--- a/src/test/java/marquez/core/mappers/MapperTest.java
+++ b/src/test/java/marquez/core/mappers/MapperTest.java
@@ -1,4 +1,40 @@
 package marquez.core.mappers;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Optional;
+import org.junit.Test;
+
 public class MapperTest {
+  @Test
+  public void testMapAsOptional() {
+    Optional<B> optB = B_MAPPER.mapAsOptional(new A());
+    assertTrue(optB.isPresent());
+  }
+
+  @Test
+  public void testMapAsOptionalFromNull() {
+    A nullA = null;
+    Optional<B> optB = B_MAPPER.mapAsOptional(nullA);
+    assertFalse(optB.isPresent());
+  }
+
+  @Test
+  public void testMapIfPresent() {
+    Optional<A> optA = Optional.of(new A());
+    Optional<B> optB = B_MAPPER.mapIfPresent(optA);
+    assertTrue(optB.isPresent());
+  }
+
+  private static final Mapper<A, B> B_MAPPER =
+      new Mapper<A, B>() {
+        public B map(A value) {
+          return value == null ? null : new B();
+        }
+      };
+
+  static final class A {}
+
+  static final class B {}
 }

--- a/src/test/java/marquez/core/mappers/MapperTest.java
+++ b/src/test/java/marquez/core/mappers/MapperTest.java
@@ -27,6 +27,12 @@ public class MapperTest {
     assertTrue(optB.isPresent());
   }
 
+  @Test(expected = NullPointerException.class)
+  public void testMapIfPresentFromNull() {
+    Optional<A> nullOptA = null;
+    B_MAPPER.mapIfPresent(nullOptA);
+  }
+
   private static final Mapper<A, B> B_MAPPER =
       new Mapper<A, B>() {
         public B map(A value) {

--- a/src/test/java/marquez/core/mappers/MapperTest.java
+++ b/src/test/java/marquez/core/mappers/MapperTest.java
@@ -1,0 +1,4 @@
+package marquez.core.mappers;
+
+public class MapperTest {
+}

--- a/src/test/java/marquez/core/mappers/MapperTest.java
+++ b/src/test/java/marquez/core/mappers/MapperTest.java
@@ -1,8 +1,11 @@
 package marquez.core.mappers;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -14,14 +17,14 @@ public class MapperTest {
   }
 
   @Test
-  public void testMapAsOptionalFromNull() {
+  public void testMapAsOptionalNull() {
     A nullA = null;
     Optional<B> optB = B_MAPPER.mapAsOptional(nullA);
     assertFalse(optB.isPresent());
   }
 
   @Test
-  public void testMapFromOptional() {
+  public void testMapOptional() {
     Optional<A> optA = Optional.of(new A());
     Optional<B> optB = B_MAPPER.mapIfPresent(optA);
     assertTrue(optB.isPresent());
@@ -31,6 +34,13 @@ public class MapperTest {
   public void testMapThrowOnNull() {
     Optional<A> nullOptA = null;
     B_MAPPER.mapIfPresent(nullOptA);
+  }
+
+  @Test
+  public void testMapList() {
+    List<A> listA = Arrays.asList(new A());
+    List<B> listB = B_MAPPER.map(listA);
+    assertEquals(1, listB.size());
   }
 
   private static final Mapper<A, B> B_MAPPER =

--- a/src/test/java/marquez/core/mappers/MapperTest.java
+++ b/src/test/java/marquez/core/mappers/MapperTest.java
@@ -40,7 +40,7 @@ public class MapperTest {
         }
       };
 
-  static final class A {}
+  private static final class A {}
 
-  static final class B {}
+  private static final class B {}
 }

--- a/src/test/java/marquez/core/mappers/MapperTest.java
+++ b/src/test/java/marquez/core/mappers/MapperTest.java
@@ -21,16 +21,16 @@ public class MapperTest {
   }
 
   @Test
-  public void testMapIfPresent() {
+  public void testMapFromOptional() {
     Optional<A> optA = Optional.of(new A());
-    Optional<B> optB = B_MAPPER.mapIfPresent(optA);
+    Optional<B> optB = B_MAPPER.map(optA);
     assertTrue(optB.isPresent());
   }
 
   @Test(expected = NullPointerException.class)
-  public void testMapIfPresentFromNull() {
+  public void testMapThrowOnNull() {
     Optional<A> nullOptA = null;
-    B_MAPPER.mapIfPresent(nullOptA);
+    B_MAPPER.map(nullOptA);
   }
 
   private static final Mapper<A, B> B_MAPPER =

--- a/src/test/java/marquez/resources/NamespaceResourceTest.java
+++ b/src/test/java/marquez/resources/NamespaceResourceTest.java
@@ -96,7 +96,7 @@ public class NamespaceResourceTest extends NamespaceBaseTest {
     Response res = namespaceResource.listNamespaces();
     ListNamespacesResponse responseBody = (ListNamespacesResponse) res.getEntity();
 
-    marquez.api.Namespace expectedApiNamespace = namespaceMapper.mapIfPresent(TEST_NAMESPACE).get();
+    marquez.api.Namespace expectedApiNamespace = namespaceMapper.map(TEST_NAMESPACE);
     assertThat(responseBody.getNamespaces()).contains(expectedApiNamespace);
   }
 
@@ -138,8 +138,8 @@ public class NamespaceResourceTest extends NamespaceBaseTest {
 
     Response res = namespaceResource.listNamespaces();
     ListNamespacesResponse responseBody = (ListNamespacesResponse) res.getEntity();
-    marquez.api.Namespace nsResponse = namespaceMapper.mapIfPresent(TEST_NAMESPACE).get();
-    marquez.api.Namespace secondNsResponse = namespaceMapper.mapIfPresent(secondNamespace).get();
+    marquez.api.Namespace nsResponse = namespaceMapper.map(TEST_NAMESPACE);
+    marquez.api.Namespace secondNsResponse = namespaceMapper.map(secondNamespace);
 
     assertThat(responseBody.getNamespaces()).containsExactly(nsResponse, secondNsResponse);
   }

--- a/src/test/java/marquez/resources/NamespaceResourceTest.java
+++ b/src/test/java/marquez/resources/NamespaceResourceTest.java
@@ -96,7 +96,7 @@ public class NamespaceResourceTest extends NamespaceBaseTest {
     Response res = namespaceResource.listNamespaces();
     ListNamespacesResponse responseBody = (ListNamespacesResponse) res.getEntity();
 
-    marquez.api.Namespace expectedApiNamespace = namespaceMapper.map(TEST_NAMESPACE).get();
+    marquez.api.Namespace expectedApiNamespace = namespaceMapper.mapIfPresent(TEST_NAMESPACE).get();
     assertThat(responseBody.getNamespaces()).contains(expectedApiNamespace);
   }
 
@@ -138,8 +138,8 @@ public class NamespaceResourceTest extends NamespaceBaseTest {
 
     Response res = namespaceResource.listNamespaces();
     ListNamespacesResponse responseBody = (ListNamespacesResponse) res.getEntity();
-    marquez.api.Namespace nsResponse = namespaceMapper.map(TEST_NAMESPACE).get();
-    marquez.api.Namespace secondNsResponse = namespaceMapper.map(secondNamespace).get();
+    marquez.api.Namespace nsResponse = namespaceMapper.mapIfPresent(TEST_NAMESPACE).get();
+    marquez.api.Namespace secondNsResponse = namespaceMapper.mapIfPresent(secondNamespace).get();
 
     assertThat(responseBody.getNamespaces()).containsExactly(nsResponse, secondNsResponse);
   }


### PR DESCRIPTION
This PR makes the `Mapper` abstract and adds `mapAsOptional()` that maps type `A` to `Optional<B>`.

```java
final Bar bar = new Bar();  // A
final FooMapper fooMapper = new FooMapper();
Optional<Foo> fooOpt = fooMapper.mapAsOptional(bar);  // A => Optional<B>
Optional<Foo> fooOpt = fooMapper.mapIfPresent(Optional.of(bar));  // Optional<A> => Optional<B>
Foo foo = fooMapper.map(bar);  // A => B
List<Foo> foo = fooMapper.map(List.of(bar));  // List(A) => List(B)
```