### PR TITLE
Bump spotless plugin to 3.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'application'
   id 'checkstyle'
-  id 'com.diffplug.gradle.spotless' version '3.14.0'
+  id 'com.diffplug.gradle.spotless' version '3.16.0'
   id 'com.github.johnrengelman.shadow' version '2.0.4'
   id 'jacoco'
   id 'java'


### PR DESCRIPTION
see releases:

* [3.15.0](https://github.com/diffplug/spotless/releases/tag/gradle%2F3.15.0)
* [3.16.0](https://github.com/diffplug/spotless/releases/tag/gradle%2F3.16.0)