### PR TITLE
Copy example config on docker-compose up [skip ci]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - POSTGRES_USER=buendia
       - POSTGRES_PASSWORD=macondo
     volumes:
-      - ./config.yml:/usr/src/app/config.yml
+      - ./config.example.yml:/usr/src/app/config.yml
     depends_on:
       - db
 


### PR DESCRIPTION
This PR patches `docker-compose` to use `config.example.yml`, eliminating the need to copy it manually as a pre-configuration step #170