### PR TITLE
Return Job from database after database update

### DIFF
--- a/src/main/java/marquez/core/services/JobService.java
+++ b/src/main/java/marquez/core/services/JobService.java
@@ -59,7 +59,7 @@ public class JobService {
                 job.getInputDatasetUrns(),
                 job.getOutputDatasetUrns());
         jobDAO.insertJobAndVersion(newJob, JobService.createJobVersion(newJob));
-        return newJob;
+        return jobDAO.findByID(newJob.getGuid());
       } else {
         Job existingJobWithNewUri =
             new Job(
@@ -74,10 +74,9 @@ public class JobService {
         JobVersion existingJobVersion = this.jobVersionDAO.findByVersion(versionID);
         if (existingJobVersion == null) {
           jobVersionDAO.insert(JobService.createJobVersion(existingJobWithNewUri));
-          return existingJobWithNewUri;
-        } else {
-          return existingJob;
+          return jobDAO.findByID(existingJob.getGuid());
         }
+        return existingJob;
       }
     } catch (UnableToExecuteStatementException e) {
       String err = "failed to create new job";

--- a/src/test/java/marquez/core/services/JobServiceIntegrationTest.java
+++ b/src/test/java/marquez/core/services/JobServiceIntegrationTest.java
@@ -66,7 +66,8 @@ public class JobServiceIntegrationTest {
   @Test
   public void testCreate() throws UnexpectedException {
     Job job = Generator.genJob(namespaceID);
-    jobService.createJob(namespaceName, job);
+    Job jobReturned = jobService.createJob(namespaceName, job);
+    assertNotNull(jobReturned.getCreatedAt());
     Optional<Job> jobFound = jobService.getJob(namespaceName, job.getName());
     assertTrue(jobFound.isPresent());
     assertEquals(job.getName(), jobFound.get().getName());


### PR DESCRIPTION
Initially, createJob would short-circuit a database read after inserting a new job.
With this change, the Job is always re-read from the database to capture any implicitly
updated fields.

Closes #188.