### PR TITLE
Add build info to jar manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,11 @@ mainClassName = 'marquez.MarquezApp'
 shadowJar {
   transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer)
   manifest {
-    attributes 'Main-Class': mainClassName
+    attributes(
+      'Created-By': "Gradle ${gradle.gradleVersion}",
+      'Built-By': System.getProperty('user.name'),
+      'Build-Jdk': System.getProperty('java.version'),
+      'Main-Class': mainClassName)
   }
 }
 


### PR DESCRIPTION
This PR adds build information to the `manifest` file on `./gradlew shadowJar`:

- `Created-By`: The Java project build manager application
- `Built-By`: The author
- `Build-Jdk`: The version of the JDK

**Example:**

```bash
$ ./gradlew shadowJar
$ unzip -q -c build/libs/marquez-all.jar META-INF/MANIFEST.MF
Manifest-Version: 1.0
Built-By: willy.lulciuc
Created-By: Gradle 4.10.2
Build-Jdk: 1.8.0_181
Main-Class: marquez.MarquezApp
```

see: https://maven.apache.org/shared/maven-archiver/examples/manifest.html