### PR TITLE
Bump jacoco to 0.8.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ checkstyleTest {
 def coverageDir = "${reportsDir}/coverage";
 
 jacoco {
-  toolVersion = '0.8.1'
+  toolVersion = '0.8.2'
   reportsDir = file(coverageDir)
 }
 


### PR DESCRIPTION
This PR bumps jacoco to 0.8.2 (see: [release notes](https://github.com/jacoco/jacoco/releases/tag/v0.8.2))