### PR TITLE
List env vars in configuration section [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To run Marquez, you will have to define `config.yml`. The configuration file is 
 $ cp config.example.yml config.yml
 ```
 
-You will then need to set the following environment variables (we recommend adding them to your `.bashrc` or equivalent): `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD`.
+You will then need to set the following environment variables (we recommend adding them to your `.bashrc`): `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD`.
 
 **Note:** All environment variables in `config.yml` are accessed with [`${VAR_NAME}`](https://www.dropwizard.io/1.3.5/docs/manual/core.html#environment-variables).
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The executable can be found under `build/libs/`
 
 ## Configuration
 
-To run Marquez, you will have to define `config.yml`. The configuration file is passed to the application and used to specify your database connection. When creating your database, we recommend calling it `marquez`. Please copy [`config.example.yml`](config.example.yml):
+To run Marquez, you will have to define `config.yml`. The configuration file is passed to the application and used to specify your database connection. When creating your database, we recommend calling it `marquez`. Please copy [`config.example.yml`](https://github.com/MarquezProject/marquez/blob/master/config.example.yml):
 
 ```bash
 $ cp config.example.yml config.yml

--- a/README.md
+++ b/README.md
@@ -35,15 +35,9 @@ To run Marquez, you will have to define `config.yml`. The configuration file is 
 $ cp config.example.yml config.yml
 ```
 
-You will then need to edit it and specify your database information.
+You will then need to set the following environment variables (we recommend adding them to your `.bashrc` or equivalent): `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD`.
 
-**Note:** As an optional step, you can manually run the database migration with:
-
-```bash
-$ ./gradlew run --args 'db migrate config.yml'
-```
-
-**Tip:** You can access environment variables from `config.yml` with [`${VAR_NAME}`](https://www.dropwizard.io/1.3.5/docs/manual/core.html#environment-variables).
+**Note:** All environment variables in `config.yml` are accessed with [`${VAR_NAME}`](https://www.dropwizard.io/1.3.5/docs/manual/core.html#environment-variables).
 
 ## Running the [Application](https://github.com/MarquezProject/marquez/blob/master/src/main/java/marquez/MarquezApp.java)
 


### PR DESCRIPTION
This PR updates the _Configuration_ section in `README.md` to explicitly list the env variables needed to run `./gradlew run --args 'server config.yml'`

closes #138 