### PR TITLE
Add job row classes

### DIFF
--- a/src/main/java/marquez/db/models/JobRow.java
+++ b/src/main/java/marquez/db/models/JobRow.java
@@ -16,11 +16,11 @@ import lombok.ToString;
 @Builder
 public final class JobRow {
   @Getter @NonNull private final UUID uuid;
-  @Getter @NonNull private final Instant createdAt;
-  @Getter @NonNull private final Instant updatedAt;
   @Getter @NonNull private final UUID namespaceUuid;
   @Getter @NonNull private final String job;
   @Getter @NonNull private final UUID currentVersionUuid;
+  @Getter private final Instant createdAt;
+  @Getter private final Instant updatedAt;
   private final String description;
 
   public Optional<String> getDescription() {

--- a/src/main/java/marquez/db/models/JobRow.java
+++ b/src/main/java/marquez/db/models/JobRow.java
@@ -16,12 +16,16 @@ import lombok.ToString;
 @Builder
 public final class JobRow {
   @Getter @NonNull private final UUID uuid;
+  @Getter @NonNull private final Instant createdAt;
   @Getter @NonNull private final UUID namespaceUuid;
   @Getter @NonNull private final String job;
   @Getter @NonNull private final UUID currentVersionUuid;
-  @Getter private final Instant createdAt;
-  @Getter private final Instant updatedAt;
+  private final Instant updatedAt;
   private final String description;
+
+  public Optional<Instant> getUpdatedAt() {
+    return Optional.ofNullable(updatedAt);
+  }
 
   public Optional<String> getDescription() {
     return Optional.ofNullable(description);

--- a/src/main/java/marquez/db/models/JobRow.java
+++ b/src/main/java/marquez/db/models/JobRow.java
@@ -1,0 +1,29 @@
+package marquez.db.models;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+@Builder
+public final class JobRow {
+  @Getter @NonNull private final UUID uuid;
+  @Getter @NonNull private final Instant createdAt;
+  @Getter @NonNull private final Instant updatedAt;
+  @Getter @NonNull private final UUID namespaceUuid;
+  @Getter @NonNull private final String job;
+  @Getter @NonNull private final UUID currentVersionUuid;
+  private final String description;
+
+  public Optional<String> getDescription() {
+    return Optional.ofNullable(description);
+  }
+}

--- a/src/main/java/marquez/db/models/JobRow.java
+++ b/src/main/java/marquez/db/models/JobRow.java
@@ -17,15 +17,11 @@ import lombok.ToString;
 public final class JobRow {
   @Getter @NonNull private final UUID uuid;
   @Getter @NonNull private final Instant createdAt;
+  @Getter @NonNull private final Instant updatedAt;
   @Getter @NonNull private final UUID namespaceUuid;
-  @Getter @NonNull private final String job;
+  @Getter @NonNull private final String name;
   @Getter @NonNull private final UUID currentVersionUuid;
-  private final Instant updatedAt;
   private final String description;
-
-  public Optional<Instant> getUpdatedAt() {
-    return Optional.ofNullable(updatedAt);
-  }
 
   public Optional<String> getDescription() {
     return Optional.ofNullable(description);

--- a/src/main/java/marquez/db/models/JobRunArgsRow.java
+++ b/src/main/java/marquez/db/models/JobRunArgsRow.java
@@ -3,20 +3,15 @@ package marquez.db.models;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 
-@RequiredArgsConstructor
-@EqualsAndHashCode
-@ToString
+@Data
 @Builder
 public final class JobRunArgsRow {
   @Getter @NonNull private final UUID uuid;
+  @Getter @NonNull private final Instant createdAt;
   @Getter @NonNull private final UUID jobRunUuid;
   @Getter @NonNull private final Long hash;
   @Getter @NonNull private final String args;
-  @Getter private final Instant createdAt;
 }

--- a/src/main/java/marquez/db/models/JobRunArgsRow.java
+++ b/src/main/java/marquez/db/models/JobRunArgsRow.java
@@ -3,15 +3,15 @@ package marquez.db.models;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NonNull;
 
 @Data
 @Builder
 public final class JobRunArgsRow {
-  @Getter @NonNull private final UUID uuid;
-  @Getter @NonNull private final Instant createdAt;
-  @Getter @NonNull private final UUID jobRunUuid;
-  @Getter @NonNull private final Long hash;
-  @Getter @NonNull private final String args;
+  @NonNull private final UUID uuid;
+  @NonNull private final Instant createdAt;
+  @NonNull private final UUID jobRunUuid;
+  @NonNull private final Long hash;
+  @NonNull private final String args;
 }

--- a/src/main/java/marquez/db/models/JobRunArgsRow.java
+++ b/src/main/java/marquez/db/models/JobRunArgsRow.java
@@ -12,6 +12,6 @@ public final class JobRunArgsRow {
   @NonNull private final UUID uuid;
   @NonNull private final Instant createdAt;
   @NonNull private final UUID jobRunUuid;
-  @NonNull private final Long hash;
-  @NonNull private final String args;
+  @NonNull private final String runArgs;
+  @NonNull private final Long checksum;
 }

--- a/src/main/java/marquez/db/models/JobRunArgsRow.java
+++ b/src/main/java/marquez/db/models/JobRunArgsRow.java
@@ -1,0 +1,22 @@
+package marquez.db.models;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+@Builder
+public final class JobRunArgsRow {
+  @Getter @NonNull private final UUID uuid;
+  @Getter @NonNull private final UUID jobRunUuid;
+  @Getter @NonNull private final Long hash;
+  @Getter @NonNull private final String args;
+  @Getter private final Instant createdAt;
+}

--- a/src/main/java/marquez/db/models/JobRunRow.java
+++ b/src/main/java/marquez/db/models/JobRunRow.java
@@ -18,9 +18,9 @@ import lombok.ToString;
 public final class JobRunRow {
   @Getter @NonNull private final UUID uuid;
   @Getter @NonNull private final Instant createdAt;
+  @Getter @NonNull private final Instant updatedAt;
   @Getter @NonNull private final UUID jobVersionUuid;
-  @Getter @NonNull private final UUID jobRunArgsUuid;
-  @Getter @NonNull private final String currentState;
+  @Getter @NonNull private final String currentRunState;
   @Getter @NonNull private final List<UUID> inputDatasetVersionUuids;
   @Getter @NonNull private final List<UUID> outputDatasetVersionUuids;
   private final Instant nominalStartTime;

--- a/src/main/java/marquez/db/models/JobRunRow.java
+++ b/src/main/java/marquez/db/models/JobRunRow.java
@@ -1,0 +1,35 @@
+package marquez.db.models;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+@Builder
+public final class JobRunRow {
+  @Getter @NonNull private final UUID uuid;
+  @Getter @NonNull private final UUID jobVersionUuid;
+  @Getter @NonNull private final UUID jobRunArgsUuid;
+  @Getter @NonNull private final String currentState;
+  @Getter @NonNull private final List<UUID> inputDatasetVersionUuids;
+  @Getter @NonNull private final List<UUID> outputDatasetVersionUuids;
+  private final Instant nominalStartTime;
+  private final Instant nominalEndTime;
+
+  public Optional<Instant> getNominalStartTime() {
+    return Optional.ofNullable(nominalStartTime);
+  }
+
+  public Optional<Instant> getNominalEndTime() {
+    return Optional.ofNullable(nominalEndTime);
+  }
+}

--- a/src/main/java/marquez/db/models/JobRunRow.java
+++ b/src/main/java/marquez/db/models/JobRunRow.java
@@ -17,6 +17,7 @@ import lombok.ToString;
 @Builder
 public final class JobRunRow {
   @Getter @NonNull private final UUID uuid;
+  @Getter @NonNull private final Instant createdAt;
   @Getter @NonNull private final UUID jobVersionUuid;
   @Getter @NonNull private final UUID jobRunArgsUuid;
   @Getter @NonNull private final String currentState;

--- a/src/main/java/marquez/db/models/JobRunStateRow.java
+++ b/src/main/java/marquez/db/models/JobRunStateRow.java
@@ -3,19 +3,13 @@ package marquez.db.models;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
+import lombok.Data;
 
-@RequiredArgsConstructor
-@EqualsAndHashCode
-@ToString
+@Data
 @Builder
 public final class JobRunStateRow {
-  @Getter @NonNull private final UUID uuid;
-  @Getter @NonNull private final UUID jobRunUuid;
-  @Getter @NonNull private final String state;
-  private final Instant transitionedAt;
+  @NonNull private final UUID uuid;
+  @NonNull private final Instant transitionedAt;
+  @NonNull private final UUID jobRunUuid;
+  @NonNull private final String state;
 }

--- a/src/main/java/marquez/db/models/JobRunStateRow.java
+++ b/src/main/java/marquez/db/models/JobRunStateRow.java
@@ -1,0 +1,21 @@
+package marquez.db.models;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+@Builder
+public final class JobRunStateRow {
+  @Getter @NonNull private final UUID uuid;
+  @Getter @NonNull private final UUID jobRunUuid;
+  @Getter @NonNull private final String state;
+  private final Instant transitionedAt;
+}

--- a/src/main/java/marquez/db/models/JobRunStateRow.java
+++ b/src/main/java/marquez/db/models/JobRunStateRow.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NonNull;
 
 @Data
 @Builder

--- a/src/main/java/marquez/db/models/JobRunStateRow.java
+++ b/src/main/java/marquez/db/models/JobRunStateRow.java
@@ -12,5 +12,5 @@ public final class JobRunStateRow {
   @NonNull private final UUID uuid;
   @NonNull private final Instant transitionedAt;
   @NonNull private final UUID jobRunUuid;
-  @NonNull private final String state;
+  @NonNull private final String runState;
 }

--- a/src/main/java/marquez/db/models/JobVersionRow.java
+++ b/src/main/java/marquez/db/models/JobVersionRow.java
@@ -1,0 +1,40 @@
+package marquez.db.models;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.Optional;
+import java.util.List;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+@Builder
+public final class JobVersionRow {
+  @Getter @NonNull private final UUID uuid;
+  @Getter @NonNull private final List<String> inputDatasetUrns;
+  @Getter @NonNull private final List<String> outputDatasetUrns;
+  @Getter @NonNull private final UUID jobUuid;
+  @Getter @NonNull private final UUID version;
+  @Getter @NonNull private final String location;
+  private final Instant createdAt;
+  private final Instant updatedAt;
+  private final UUID latestJobRunUuid;
+
+  public Optional<Instant> getCreatedAt() {
+    return Optional.ofNullable(createdAt);
+  }
+
+  public Optional<Instant> getUpdatedAt() {
+    return Optional.ofNullable(updatedAt);
+  }
+
+  public Optional<UUID> getLatestJobRunUuid() {
+    return Optional.ofNullable(latestJobRunUuid);
+  }
+}

--- a/src/main/java/marquez/db/models/JobVersionRow.java
+++ b/src/main/java/marquez/db/models/JobVersionRow.java
@@ -18,9 +18,9 @@ import lombok.ToString;
 public final class JobVersionRow {
   @Getter @NonNull private final UUID uuid;
   @Getter @NonNull private final Instant createdAt;
+  @Getter @NonNull private final UUID jobUuid;
   @Getter @NonNull private final List<String> inputDatasetUrns;
   @Getter @NonNull private final List<String> outputDatasetUrns;
-  @Getter @NonNull private final UUID jobUuid;
   @Getter @NonNull private final UUID version;
   @Getter @NonNull private final String location;
   private final Instant updatedAt;

--- a/src/main/java/marquez/db/models/JobVersionRow.java
+++ b/src/main/java/marquez/db/models/JobVersionRow.java
@@ -1,9 +1,9 @@
 package marquez.db.models;
 
 import java.time.Instant;
-import java.util.UUID;
-import java.util.Optional;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -17,18 +17,14 @@ import lombok.ToString;
 @Builder
 public final class JobVersionRow {
   @Getter @NonNull private final UUID uuid;
+  @Getter @NonNull private final Instant createdAt;
   @Getter @NonNull private final List<String> inputDatasetUrns;
   @Getter @NonNull private final List<String> outputDatasetUrns;
   @Getter @NonNull private final UUID jobUuid;
   @Getter @NonNull private final UUID version;
   @Getter @NonNull private final String location;
-  private final Instant createdAt;
   private final Instant updatedAt;
   private final UUID latestJobRunUuid;
-
-  public Optional<Instant> getCreatedAt() {
-    return Optional.ofNullable(createdAt);
-  }
 
   public Optional<Instant> getUpdatedAt() {
     return Optional.ofNullable(updatedAt);

--- a/src/test/java/marquez/db/models/JobRowTest.java
+++ b/src/test/java/marquez/db/models/JobRowTest.java
@@ -60,10 +60,10 @@ public class JobRowTest {
   }
 
   @Test(expected = NullPointerException.class)
-  public void testNewJobRow_nullRowUuid() {
-    final UUID nullRowUuid = null;
+  public void testNewJobRow_nullUuid() {
+    final UUID nullUuid = null;
     JobRow.builder()
-        .uuid(nullRowUuid)
+        .uuid(nullUuid)
         .createdAt(CREATED_AT)
         .updatedAt(UPDATED_AT)
         .namespaceUuid(NAMESPACE_UUID)

--- a/src/test/java/marquez/db/models/JobRowTest.java
+++ b/src/test/java/marquez/db/models/JobRowTest.java
@@ -1,0 +1,61 @@
+package marquez.db.models;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.Test;
+
+public class JobRowTest {
+  private static final UUID ROW_UUID = UUID.randomUUID();
+  private static final Instant CREATED_AT = Instant.now();
+  private static final Instant UPDATED_AT = Instant.now();
+  private static final UUID NAMESPACE_UUID = UUID.randomUUID();
+  private static final String NAME = "test job";
+  private static final String DESCRIPTION = "test description";
+  private static final UUID CURRENT_VERSION_UUID = UUID.randomUUID();
+
+  @Test
+  public void testNewJobRow() {
+    final Optional<String> nonEmptyDescription = Optional.of(DESCRIPTION);
+    final JobRow jobRow =
+        JobRow.builder()
+            .uuid(ROW_UUID)
+            .createdAt(CREATED_AT)
+            .updatedAt(UPDATED_AT)
+            .namespaceUuid(NAMESPACE_UUID)
+            .name(NAME)
+            .description(DESCRIPTION)
+            .currentVersionUuid(CURRENT_VERSION_UUID)
+            .build();
+    assertEquals(ROW_UUID, jobRow.getUuid());
+    assertEquals(CREATED_AT, jobRow.getCreatedAt());
+    assertEquals(UPDATED_AT, jobRow.getUpdatedAt());
+    assertEquals(NAMESPACE_UUID, jobRow.getNamespaceUuid());
+    assertEquals(NAME, jobRow.getName());
+    assertEquals(nonEmptyDescription, jobRow.getDescription());
+    assertEquals(CURRENT_VERSION_UUID, jobRow.getCurrentVersionUuid());
+  }
+
+  @Test
+  public void testNewJobRowNoDescription() {
+    final Optional<String> noDescription = Optional.empty();
+    final JobRow jobRow =
+        JobRow.builder()
+            .uuid(ROW_UUID)
+            .createdAt(CREATED_AT)
+            .updatedAt(UPDATED_AT)
+            .namespaceUuid(NAMESPACE_UUID)
+            .name(NAME)
+            .currentVersionUuid(CURRENT_VERSION_UUID)
+            .build();
+    assertEquals(ROW_UUID, jobRow.getUuid());
+    assertEquals(CREATED_AT, jobRow.getCreatedAt());
+    assertEquals(UPDATED_AT, jobRow.getUpdatedAt());
+    assertEquals(NAMESPACE_UUID, jobRow.getNamespaceUuid());
+    assertEquals(NAME, jobRow.getName());
+    assertEquals(noDescription, jobRow.getDescription());
+    assertEquals(CURRENT_VERSION_UUID, jobRow.getCurrentVersionUuid());
+  }
+}

--- a/src/test/java/marquez/db/models/JobRowTest.java
+++ b/src/test/java/marquez/db/models/JobRowTest.java
@@ -13,12 +13,12 @@ public class JobRowTest {
   private static final Instant UPDATED_AT = Instant.now();
   private static final UUID NAMESPACE_UUID = UUID.randomUUID();
   private static final String NAME = "test job";
-  private static final String DESCRIPTION = "test description";
   private static final UUID CURRENT_VERSION_UUID = UUID.randomUUID();
 
   @Test
   public void testNewJobRow() {
-    final Optional<String> nonEmptyDescription = Optional.of(DESCRIPTION);
+    final String description = "test description";
+    final Optional<String> expectedDescription = Optional.of(description);
     final JobRow jobRow =
         JobRow.builder()
             .uuid(ROW_UUID)
@@ -26,7 +26,7 @@ public class JobRowTest {
             .updatedAt(UPDATED_AT)
             .namespaceUuid(NAMESPACE_UUID)
             .name(NAME)
-            .description(DESCRIPTION)
+            .description(description)
             .currentVersionUuid(CURRENT_VERSION_UUID)
             .build();
     assertEquals(ROW_UUID, jobRow.getUuid());
@@ -34,7 +34,7 @@ public class JobRowTest {
     assertEquals(UPDATED_AT, jobRow.getUpdatedAt());
     assertEquals(NAMESPACE_UUID, jobRow.getNamespaceUuid());
     assertEquals(NAME, jobRow.getName());
-    assertEquals(nonEmptyDescription, jobRow.getDescription());
+    assertEquals(expectedDescription, jobRow.getDescription());
     assertEquals(CURRENT_VERSION_UUID, jobRow.getCurrentVersionUuid());
   }
 
@@ -68,7 +68,6 @@ public class JobRowTest {
         .updatedAt(UPDATED_AT)
         .namespaceUuid(NAMESPACE_UUID)
         .name(NAME)
-        .description(DESCRIPTION)
         .currentVersionUuid(CURRENT_VERSION_UUID)
         .build();
   }
@@ -82,7 +81,6 @@ public class JobRowTest {
         .updatedAt(UPDATED_AT)
         .namespaceUuid(NAMESPACE_UUID)
         .name(NAME)
-        .description(DESCRIPTION)
         .currentVersionUuid(CURRENT_VERSION_UUID)
         .build();
   }
@@ -96,7 +94,6 @@ public class JobRowTest {
         .updatedAt(nullUpdatedAt)
         .namespaceUuid(NAMESPACE_UUID)
         .name(NAME)
-        .description(DESCRIPTION)
         .currentVersionUuid(CURRENT_VERSION_UUID)
         .build();
   }
@@ -110,7 +107,6 @@ public class JobRowTest {
         .updatedAt(UPDATED_AT)
         .namespaceUuid(nullNamespaceUuid)
         .name(NAME)
-        .description(DESCRIPTION)
         .currentVersionUuid(CURRENT_VERSION_UUID)
         .build();
   }
@@ -124,7 +120,6 @@ public class JobRowTest {
         .updatedAt(UPDATED_AT)
         .namespaceUuid(NAMESPACE_UUID)
         .name(nullName)
-        .description(DESCRIPTION)
         .currentVersionUuid(CURRENT_VERSION_UUID)
         .build();
   }
@@ -138,7 +133,6 @@ public class JobRowTest {
         .updatedAt(UPDATED_AT)
         .namespaceUuid(NAMESPACE_UUID)
         .name(NAME)
-        .description(DESCRIPTION)
         .currentVersionUuid(nullCurrentVersionUuid)
         .build();
   }

--- a/src/test/java/marquez/db/models/JobRowTest.java
+++ b/src/test/java/marquez/db/models/JobRowTest.java
@@ -39,7 +39,7 @@ public class JobRowTest {
   }
 
   @Test
-  public void testNewJobRowNoDescription() {
+  public void testNewJobRow_noDescription() {
     final Optional<String> noDescription = Optional.empty();
     final JobRow jobRow =
         JobRow.builder()
@@ -57,5 +57,89 @@ public class JobRowTest {
     assertEquals(NAME, jobRow.getName());
     assertEquals(noDescription, jobRow.getDescription());
     assertEquals(CURRENT_VERSION_UUID, jobRow.getCurrentVersionUuid());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullRowUuid() {
+    final UUID nullRowUuid = null;
+    JobRow.builder()
+        .uuid(nullRowUuid)
+        .createdAt(CREATED_AT)
+        .updatedAt(UPDATED_AT)
+        .namespaceUuid(NAMESPACE_UUID)
+        .name(NAME)
+        .description(DESCRIPTION)
+        .currentVersionUuid(CURRENT_VERSION_UUID)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullCreatedAt() {
+    final Instant nullCreatedAt = null;
+    JobRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(nullCreatedAt)
+        .updatedAt(UPDATED_AT)
+        .namespaceUuid(NAMESPACE_UUID)
+        .name(NAME)
+        .description(DESCRIPTION)
+        .currentVersionUuid(CURRENT_VERSION_UUID)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullUpdatedAt() {
+    final Instant nullUpdatedAt = null;
+    JobRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .updatedAt(nullUpdatedAt)
+        .namespaceUuid(NAMESPACE_UUID)
+        .name(NAME)
+        .description(DESCRIPTION)
+        .currentVersionUuid(CURRENT_VERSION_UUID)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullNamespaceUuid() {
+    final UUID nullNamespaceUuid = null;
+    JobRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .updatedAt(UPDATED_AT)
+        .namespaceUuid(nullNamespaceUuid)
+        .name(NAME)
+        .description(DESCRIPTION)
+        .currentVersionUuid(CURRENT_VERSION_UUID)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullName() {
+    final String nullName = null;
+    JobRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .updatedAt(UPDATED_AT)
+        .namespaceUuid(NAMESPACE_UUID)
+        .name(nullName)
+        .description(DESCRIPTION)
+        .currentVersionUuid(CURRENT_VERSION_UUID)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullCurrentVersionUuid() {
+    final UUID nullCurrentVersionUuid = null;
+    JobRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .updatedAt(UPDATED_AT)
+        .namespaceUuid(NAMESPACE_UUID)
+        .name(NAME)
+        .description(DESCRIPTION)
+        .currentVersionUuid(nullCurrentVersionUuid)
+        .build();
   }
 }

--- a/src/test/java/marquez/db/models/JobRunArgsRowTest.java
+++ b/src/test/java/marquez/db/models/JobRunArgsRowTest.java
@@ -1,0 +1,92 @@
+package marquez.db.models;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.Test;
+
+public class JobRunArgsRowTest {
+  private static final UUID ROW_UUID = UUID.randomUUID();
+  private static final Instant CREATED_AT = Instant.now();
+  private static final UUID JOB_RUN_UUID = UUID.randomUUID();
+  private static final String RUN_ARGS = "{\"retries\": 1}";
+  private static final Long CHECKSUM = 4546L;
+
+  @Test
+  public void testNewJobRow() {
+    final JobRunArgsRow jobRunArgsRow =
+        JobRunArgsRow.builder()
+            .uuid(ROW_UUID)
+            .createdAt(CREATED_AT)
+            .jobRunUuid(JOB_RUN_UUID)
+            .runArgs(RUN_ARGS)
+            .checksum(CHECKSUM)
+            .build();
+    assertEquals(ROW_UUID, jobRunArgsRow.getUuid());
+    assertEquals(CREATED_AT, jobRunArgsRow.getCreatedAt());
+    assertEquals(JOB_RUN_UUID, jobRunArgsRow.getJobRunUuid());
+    assertEquals(RUN_ARGS, jobRunArgsRow.getRunArgs());
+    assertEquals(CHECKSUM, jobRunArgsRow.getChecksum());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullUuid() {
+    final UUID nullUuid = null;
+    JobRunArgsRow.builder()
+        .uuid(nullUuid)
+        .createdAt(CREATED_AT)
+        .jobRunUuid(JOB_RUN_UUID)
+        .runArgs(RUN_ARGS)
+        .checksum(CHECKSUM)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullCreatedAt() {
+    final Instant nullCreatedAt = null;
+    JobRunArgsRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(nullCreatedAt)
+        .jobRunUuid(JOB_RUN_UUID)
+        .runArgs(RUN_ARGS)
+        .checksum(CHECKSUM)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullJobRunUuid() {
+    final UUID nullJobRunUuid = null;
+    JobRunArgsRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .jobRunUuid(nullJobRunUuid)
+        .runArgs(RUN_ARGS)
+        .checksum(CHECKSUM)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullRunArgs() {
+    final String nullRunArgs = null;
+    JobRunArgsRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .jobRunUuid(JOB_RUN_UUID)
+        .runArgs(nullRunArgs)
+        .checksum(CHECKSUM)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullChecksum() {
+    final Long nullChecksum = null;
+    JobRunArgsRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .jobRunUuid(JOB_RUN_UUID)
+        .runArgs(RUN_ARGS)
+        .checksum(nullChecksum)
+        .build();
+  }
+}

--- a/src/test/java/marquez/db/models/JobRunRowTest.java
+++ b/src/test/java/marquez/db/models/JobRunRowTest.java
@@ -1,0 +1,124 @@
+package marquez.db.models;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Test;
+
+public class JobRunRowTest {
+  private static final UUID ROW_UUID = UUID.randomUUID();
+  private static final Instant CREATED_AT = Instant.now();
+  private static final Instant UPDATED_AT = Instant.now();
+  private static final UUID JOB_VERSION_UUID = UUID.randomUUID();
+  private static final String CURRENT_RUN_STATE = "NEW";
+  private static final List<UUID> INPUT_DATASET_VERSION_UUIDS = Arrays.asList(UUID.randomUUID());
+  private static final List<UUID> OUTPUT_DATASET_VERSION_UUIDS = Arrays.asList(UUID.randomUUID());
+
+  @Test
+  public void testNewJobRunRow() {
+    final JobRunRow jobRunRow =
+        JobRunRow.builder()
+            .uuid(ROW_UUID)
+            .createdAt(CREATED_AT)
+            .updatedAt(UPDATED_AT)
+            .jobVersionUuid(JOB_VERSION_UUID)
+            .currentRunState(CURRENT_RUN_STATE)
+            .inputDatasetVersionUuids(INPUT_DATASET_VERSION_UUIDS)
+            .outputDatasetVersionUuids(OUTPUT_DATASET_VERSION_UUIDS)
+            .build();
+    assertEquals(ROW_UUID, jobRunRow.getUuid());
+    assertEquals(CREATED_AT, jobRunRow.getCreatedAt());
+    assertEquals(UPDATED_AT, jobRunRow.getUpdatedAt());
+    assertEquals(JOB_VERSION_UUID, jobRunRow.getJobVersionUuid());
+    assertEquals(CURRENT_RUN_STATE, jobRunRow.getCurrentRunState());
+    assertEquals(INPUT_DATASET_VERSION_UUIDS, jobRunRow.getInputDatasetVersionUuids());
+    assertEquals(OUTPUT_DATASET_VERSION_UUIDS, jobRunRow.getOutputDatasetVersionUuids());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullUuid() {
+    final UUID nullUuid = null;
+    JobRunRow.builder()
+        .uuid(nullUuid)
+        .createdAt(CREATED_AT)
+        .updatedAt(UPDATED_AT)
+        .jobVersionUuid(JOB_VERSION_UUID)
+        .currentRunState(CURRENT_RUN_STATE)
+        .inputDatasetVersionUuids(INPUT_DATASET_VERSION_UUIDS)
+        .outputDatasetVersionUuids(OUTPUT_DATASET_VERSION_UUIDS)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullCreatedAt() {
+    final Instant nullCreatedAt = null;
+    JobRunRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(nullCreatedAt)
+        .updatedAt(UPDATED_AT)
+        .jobVersionUuid(JOB_VERSION_UUID)
+        .currentRunState(CURRENT_RUN_STATE)
+        .inputDatasetVersionUuids(INPUT_DATASET_VERSION_UUIDS)
+        .outputDatasetVersionUuids(OUTPUT_DATASET_VERSION_UUIDS)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullUpdatedAt() {
+    final Instant nullUpdatedAt = null;
+    JobRunRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .updatedAt(nullUpdatedAt)
+        .jobVersionUuid(JOB_VERSION_UUID)
+        .currentRunState(CURRENT_RUN_STATE)
+        .inputDatasetVersionUuids(INPUT_DATASET_VERSION_UUIDS)
+        .outputDatasetVersionUuids(OUTPUT_DATASET_VERSION_UUIDS)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullJobVersionUuid() {
+    final UUID nullJobVersionUuid = null;
+    JobRunRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .updatedAt(UPDATED_AT)
+        .jobVersionUuid(nullJobVersionUuid)
+        .currentRunState(CURRENT_RUN_STATE)
+        .inputDatasetVersionUuids(INPUT_DATASET_VERSION_UUIDS)
+        .outputDatasetVersionUuids(OUTPUT_DATASET_VERSION_UUIDS)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullInputDatasetVersionUuids() {
+    final List<UUID> nullInputDatasetVersionUuids = null;
+    JobRunRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .updatedAt(UPDATED_AT)
+        .jobVersionUuid(JOB_VERSION_UUID)
+        .currentRunState(CURRENT_RUN_STATE)
+        .inputDatasetVersionUuids(nullInputDatasetVersionUuids)
+        .outputDatasetVersionUuids(OUTPUT_DATASET_VERSION_UUIDS)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullOutputDatasetVersionUuids() {
+    final List<UUID> nullOutputDatasetVersionUuids = null;
+    JobRunRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .updatedAt(UPDATED_AT)
+        .jobVersionUuid(JOB_VERSION_UUID)
+        .currentRunState(CURRENT_RUN_STATE)
+        .inputDatasetVersionUuids(INPUT_DATASET_VERSION_UUIDS)
+        .outputDatasetVersionUuids(nullOutputDatasetVersionUuids)
+        .build();
+  }
+}

--- a/src/test/java/marquez/db/models/JobRunRowTest.java
+++ b/src/test/java/marquez/db/models/JobRunRowTest.java
@@ -95,6 +95,20 @@ public class JobRunRowTest {
   }
 
   @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullCurrentRunState() {
+    final String nullCurrentRunState = null;
+    JobRunRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .updatedAt(UPDATED_AT)
+        .jobVersionUuid(JOB_VERSION_UUID)
+        .currentRunState(nullCurrentRunState)
+        .inputDatasetVersionUuids(INPUT_DATASET_VERSION_UUIDS)
+        .outputDatasetVersionUuids(OUTPUT_DATASET_VERSION_UUIDS)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
   public void testNewJobRow_nullInputDatasetVersionUuids() {
     final List<UUID> nullInputDatasetVersionUuids = null;
     JobRunRow.builder()

--- a/src/test/java/marquez/db/models/JobRunRowTest.java
+++ b/src/test/java/marquez/db/models/JobRunRowTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.Test;
 
@@ -19,6 +20,8 @@ public class JobRunRowTest {
 
   @Test
   public void testNewJobRunRow() {
+    final Optional<Instant> noNominalStartTime = Optional.empty();
+    final Optional<Instant> noNominalEndTime = Optional.empty();
     final JobRunRow jobRunRow =
         JobRunRow.builder()
             .uuid(ROW_UUID)
@@ -33,6 +36,37 @@ public class JobRunRowTest {
     assertEquals(CREATED_AT, jobRunRow.getCreatedAt());
     assertEquals(UPDATED_AT, jobRunRow.getUpdatedAt());
     assertEquals(JOB_VERSION_UUID, jobRunRow.getJobVersionUuid());
+    assertEquals(noNominalStartTime, jobRunRow.getNominalStartTime());
+    assertEquals(noNominalEndTime, jobRunRow.getNominalEndTime());
+    assertEquals(CURRENT_RUN_STATE, jobRunRow.getCurrentRunState());
+    assertEquals(INPUT_DATASET_VERSION_UUIDS, jobRunRow.getInputDatasetVersionUuids());
+    assertEquals(OUTPUT_DATASET_VERSION_UUIDS, jobRunRow.getOutputDatasetVersionUuids());
+  }
+
+  @Test
+  public void testNewJobRunRow_nominalStartAndEndTime() {
+    final Instant nominalStartTime = Instant.parse("2018-10-04T15:01:00.00Z");
+    final Instant nominalEndTime = Instant.parse("2018-10-04T15:02:00.00Z");
+    final Optional<Instant> expectedNominalStartTime = Optional.of(nominalStartTime);
+    final Optional<Instant> expectedNominalEndTime = Optional.of(nominalEndTime);
+    final JobRunRow jobRunRow =
+        JobRunRow.builder()
+            .uuid(ROW_UUID)
+            .createdAt(CREATED_AT)
+            .updatedAt(UPDATED_AT)
+            .jobVersionUuid(JOB_VERSION_UUID)
+            .nominalStartTime(nominalStartTime)
+            .nominalEndTime(nominalEndTime)
+            .currentRunState(CURRENT_RUN_STATE)
+            .inputDatasetVersionUuids(INPUT_DATASET_VERSION_UUIDS)
+            .outputDatasetVersionUuids(OUTPUT_DATASET_VERSION_UUIDS)
+            .build();
+    assertEquals(ROW_UUID, jobRunRow.getUuid());
+    assertEquals(CREATED_AT, jobRunRow.getCreatedAt());
+    assertEquals(UPDATED_AT, jobRunRow.getUpdatedAt());
+    assertEquals(JOB_VERSION_UUID, jobRunRow.getJobVersionUuid());
+    assertEquals(expectedNominalStartTime, jobRunRow.getNominalStartTime());
+    assertEquals(expectedNominalEndTime, jobRunRow.getNominalEndTime());
     assertEquals(CURRENT_RUN_STATE, jobRunRow.getCurrentRunState());
     assertEquals(INPUT_DATASET_VERSION_UUIDS, jobRunRow.getInputDatasetVersionUuids());
     assertEquals(OUTPUT_DATASET_VERSION_UUIDS, jobRunRow.getOutputDatasetVersionUuids());

--- a/src/test/java/marquez/db/models/JobRunRowTest.java
+++ b/src/test/java/marquez/db/models/JobRunRowTest.java
@@ -20,31 +20,6 @@ public class JobRunRowTest {
 
   @Test
   public void testNewJobRunRow() {
-    final Optional<Instant> noNominalStartTime = Optional.empty();
-    final Optional<Instant> noNominalEndTime = Optional.empty();
-    final JobRunRow jobRunRow =
-        JobRunRow.builder()
-            .uuid(ROW_UUID)
-            .createdAt(CREATED_AT)
-            .updatedAt(UPDATED_AT)
-            .jobVersionUuid(JOB_VERSION_UUID)
-            .currentRunState(CURRENT_RUN_STATE)
-            .inputDatasetVersionUuids(INPUT_DATASET_VERSION_UUIDS)
-            .outputDatasetVersionUuids(OUTPUT_DATASET_VERSION_UUIDS)
-            .build();
-    assertEquals(ROW_UUID, jobRunRow.getUuid());
-    assertEquals(CREATED_AT, jobRunRow.getCreatedAt());
-    assertEquals(UPDATED_AT, jobRunRow.getUpdatedAt());
-    assertEquals(JOB_VERSION_UUID, jobRunRow.getJobVersionUuid());
-    assertEquals(noNominalStartTime, jobRunRow.getNominalStartTime());
-    assertEquals(noNominalEndTime, jobRunRow.getNominalEndTime());
-    assertEquals(CURRENT_RUN_STATE, jobRunRow.getCurrentRunState());
-    assertEquals(INPUT_DATASET_VERSION_UUIDS, jobRunRow.getInputDatasetVersionUuids());
-    assertEquals(OUTPUT_DATASET_VERSION_UUIDS, jobRunRow.getOutputDatasetVersionUuids());
-  }
-
-  @Test
-  public void testNewJobRunRow_nominalStartAndEndTime() {
     final Instant nominalStartTime = Instant.parse("2018-10-04T15:01:00.00Z");
     final Instant nominalEndTime = Instant.parse("2018-10-04T15:02:00.00Z");
     final Optional<Instant> expectedNominalStartTime = Optional.of(nominalStartTime);
@@ -67,6 +42,31 @@ public class JobRunRowTest {
     assertEquals(JOB_VERSION_UUID, jobRunRow.getJobVersionUuid());
     assertEquals(expectedNominalStartTime, jobRunRow.getNominalStartTime());
     assertEquals(expectedNominalEndTime, jobRunRow.getNominalEndTime());
+    assertEquals(CURRENT_RUN_STATE, jobRunRow.getCurrentRunState());
+    assertEquals(INPUT_DATASET_VERSION_UUIDS, jobRunRow.getInputDatasetVersionUuids());
+    assertEquals(OUTPUT_DATASET_VERSION_UUIDS, jobRunRow.getOutputDatasetVersionUuids());
+  }
+
+  @Test
+  public void testNewJobRunRow_noNominalStartAndEndTime() {
+    final Optional<Instant> noNominalStartTime = Optional.empty();
+    final Optional<Instant> noNominalEndTime = Optional.empty();
+    final JobRunRow jobRunRow =
+        JobRunRow.builder()
+            .uuid(ROW_UUID)
+            .createdAt(CREATED_AT)
+            .updatedAt(UPDATED_AT)
+            .jobVersionUuid(JOB_VERSION_UUID)
+            .currentRunState(CURRENT_RUN_STATE)
+            .inputDatasetVersionUuids(INPUT_DATASET_VERSION_UUIDS)
+            .outputDatasetVersionUuids(OUTPUT_DATASET_VERSION_UUIDS)
+            .build();
+    assertEquals(ROW_UUID, jobRunRow.getUuid());
+    assertEquals(CREATED_AT, jobRunRow.getCreatedAt());
+    assertEquals(UPDATED_AT, jobRunRow.getUpdatedAt());
+    assertEquals(JOB_VERSION_UUID, jobRunRow.getJobVersionUuid());
+    assertEquals(noNominalStartTime, jobRunRow.getNominalStartTime());
+    assertEquals(noNominalEndTime, jobRunRow.getNominalEndTime());
     assertEquals(CURRENT_RUN_STATE, jobRunRow.getCurrentRunState());
     assertEquals(INPUT_DATASET_VERSION_UUIDS, jobRunRow.getInputDatasetVersionUuids());
     assertEquals(OUTPUT_DATASET_VERSION_UUIDS, jobRunRow.getOutputDatasetVersionUuids());

--- a/src/test/java/marquez/db/models/JobRunStateRowTest.java
+++ b/src/test/java/marquez/db/models/JobRunStateRowTest.java
@@ -1,0 +1,73 @@
+package marquez.db.models;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.Test;
+
+public class JobRunStateRowTest {
+  private static final UUID ROW_UUID = UUID.randomUUID();
+  private static final Instant TRANSITIONED_AT = Instant.now();
+  private static final UUID JOB_RUN_UUID = UUID.randomUUID();
+  private static final String RUN_STATE = "NEW";
+
+  @Test
+  public void testNewJobRunStateRow() {
+    final JobRunStateRow jobRunStateRow =
+        JobRunStateRow.builder()
+            .uuid(ROW_UUID)
+            .transitionedAt(TRANSITIONED_AT)
+            .jobRunUuid(JOB_RUN_UUID)
+            .runState(RUN_STATE)
+            .build();
+    assertEquals(ROW_UUID, jobRunStateRow.getUuid());
+    assertEquals(TRANSITIONED_AT, jobRunStateRow.getTransitionedAt());
+    assertEquals(JOB_RUN_UUID, jobRunStateRow.getJobRunUuid());
+    assertEquals(RUN_STATE, jobRunStateRow.getRunState());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullUuid() {
+    final UUID nullUuid = null;
+    JobRunStateRow.builder()
+        .uuid(nullUuid)
+        .transitionedAt(TRANSITIONED_AT)
+        .jobRunUuid(JOB_RUN_UUID)
+        .runState(RUN_STATE)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullTransitionedAt() {
+    final Instant nullTransitionedAt = null;
+    JobRunStateRow.builder()
+        .uuid(ROW_UUID)
+        .transitionedAt(nullTransitionedAt)
+        .jobRunUuid(JOB_RUN_UUID)
+        .runState(RUN_STATE)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullJobRunUuid() {
+    final UUID nullJobRunUuid = null;
+    JobRunStateRow.builder()
+        .uuid(ROW_UUID)
+        .transitionedAt(TRANSITIONED_AT)
+        .jobRunUuid(nullJobRunUuid)
+        .runState(RUN_STATE)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobRow_nullRunState() {
+    final String nullRunState = null;
+    JobRunStateRow.builder()
+        .uuid(ROW_UUID)
+        .transitionedAt(TRANSITIONED_AT)
+        .jobRunUuid(JOB_RUN_UUID)
+        .runState(nullRunState)
+        .build();
+  }
+}

--- a/src/test/java/marquez/db/models/JobVersionRowTest.java
+++ b/src/test/java/marquez/db/models/JobVersionRowTest.java
@@ -21,7 +21,7 @@ public class JobVersionRowTest {
 
   @Test
   public void testNewJobVersionRow() {
-    final Optional<Instant> notUpdated = Optional.empty();
+    final Optional<Instant> noUpdatedAt = Optional.empty();
     final Optional<UUID> noLatestJobRunUuid = Optional.empty();
     final JobVersionRow jobVersionRow =
         JobVersionRow.builder()
@@ -35,7 +35,7 @@ public class JobVersionRowTest {
             .build();
     assertEquals(ROW_UUID, jobVersionRow.getUuid());
     assertEquals(CREATED_AT, jobVersionRow.getCreatedAt());
-    assertEquals(notUpdated, jobVersionRow.getUpdatedAt());
+    assertEquals(noUpdatedAt, jobVersionRow.getUpdatedAt());
     assertEquals(JOB_UUID, jobVersionRow.getJobUuid());
     assertEquals(INPUT_DATASET_URNS, jobVersionRow.getInputDatasetUrns());
     assertEquals(OUTPUT_DATASET_URNS, jobVersionRow.getOutputDatasetUrns());
@@ -71,5 +71,103 @@ public class JobVersionRowTest {
     assertEquals(VERSION, jobVersionRow.getVersion());
     assertEquals(LOCATION, jobVersionRow.getLocation());
     assertEquals(expectedLatestJobRunUuid, jobVersionRow.getLatestJobRunUuid());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobVersionRow_nullUuid() {
+    final UUID nullUuid = null;
+    JobVersionRow.builder()
+        .uuid(nullUuid)
+        .createdAt(CREATED_AT)
+        .jobUuid(JOB_UUID)
+        .inputDatasetUrns(INPUT_DATASET_URNS)
+        .outputDatasetUrns(OUTPUT_DATASET_URNS)
+        .version(VERSION)
+        .location(LOCATION)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobVersionRow_nullCreatedAt() {
+    final Instant nullCreatedAt = null;
+    JobVersionRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(nullCreatedAt)
+        .jobUuid(JOB_UUID)
+        .inputDatasetUrns(INPUT_DATASET_URNS)
+        .outputDatasetUrns(OUTPUT_DATASET_URNS)
+        .version(VERSION)
+        .location(LOCATION)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobVersionRow_nullJobUuid() {
+    final UUID nullJobUuid = null;
+    JobVersionRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .jobUuid(nullJobUuid)
+        .inputDatasetUrns(INPUT_DATASET_URNS)
+        .outputDatasetUrns(OUTPUT_DATASET_URNS)
+        .version(VERSION)
+        .location(LOCATION)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobVersionRow_nullInputDatasetUrns() {
+    final List<String> nullInputDatasetUrns = null;
+    JobVersionRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .jobUuid(JOB_UUID)
+        .inputDatasetUrns(nullInputDatasetUrns)
+        .outputDatasetUrns(OUTPUT_DATASET_URNS)
+        .version(VERSION)
+        .location(LOCATION)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobVersionRow_nullOutDatasetUrns() {
+    final List<String> nullOutDatasetUrns = null;
+    JobVersionRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .jobUuid(JOB_UUID)
+        .inputDatasetUrns(INPUT_DATASET_URNS)
+        .outputDatasetUrns(nullOutDatasetUrns)
+        .version(VERSION)
+        .location(LOCATION)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobVersionRow_nullVersion() {
+    final UUID nullVersion = null;
+    JobVersionRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .jobUuid(JOB_UUID)
+        .inputDatasetUrns(INPUT_DATASET_URNS)
+        .outputDatasetUrns(OUTPUT_DATASET_URNS)
+        .version(nullVersion)
+        .location(LOCATION)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewJobVersionRow_nullLocation() {
+    final String nullLocation = null;
+    JobVersionRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .jobUuid(JOB_UUID)
+        .inputDatasetUrns(INPUT_DATASET_URNS)
+        .outputDatasetUrns(OUTPUT_DATASET_URNS)
+        .version(VERSION)
+        .location(nullLocation)
+        .build();
   }
 }

--- a/src/test/java/marquez/db/models/JobVersionRowTest.java
+++ b/src/test/java/marquez/db/models/JobVersionRowTest.java
@@ -1,0 +1,75 @@
+package marquez.db.models;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.Test;
+
+public class JobVersionRowTest {
+  private static final UUID ROW_UUID = UUID.randomUUID();
+  private static final Instant CREATED_AT = Instant.now();
+  private static final UUID JOB_UUID = UUID.randomUUID();
+  private static final List<String> INPUT_DATASET_URNS = Arrays.asList("urn:a:b.c");
+  private static final List<String> OUTPUT_DATASET_URNS = Arrays.asList("urn:d:e.f");
+  private static final UUID VERSION = UUID.randomUUID();
+  private static final String LOCATION =
+      "https://github.com/test/job/commit/1867de4c29e55d3667d6505426ec325767d998c9";
+
+  @Test
+  public void testNewJobVersionRow() {
+    final Optional<Instant> notUpdated = Optional.empty();
+    final Optional<UUID> noLatestJobRunUuid = Optional.empty();
+    final JobVersionRow jobVersionRow =
+        JobVersionRow.builder()
+            .uuid(ROW_UUID)
+            .createdAt(CREATED_AT)
+            .jobUuid(JOB_UUID)
+            .inputDatasetUrns(INPUT_DATASET_URNS)
+            .outputDatasetUrns(OUTPUT_DATASET_URNS)
+            .version(VERSION)
+            .location(LOCATION)
+            .build();
+    assertEquals(ROW_UUID, jobVersionRow.getUuid());
+    assertEquals(CREATED_AT, jobVersionRow.getCreatedAt());
+    assertEquals(notUpdated, jobVersionRow.getUpdatedAt());
+    assertEquals(JOB_UUID, jobVersionRow.getJobUuid());
+    assertEquals(INPUT_DATASET_URNS, jobVersionRow.getInputDatasetUrns());
+    assertEquals(OUTPUT_DATASET_URNS, jobVersionRow.getOutputDatasetUrns());
+    assertEquals(VERSION, jobVersionRow.getVersion());
+    assertEquals(LOCATION, jobVersionRow.getLocation());
+    assertEquals(noLatestJobRunUuid, jobVersionRow.getLatestJobRunUuid());
+  }
+
+  @Test
+  public void testNewJobVersionRow_latestJobRunUuid() {
+    final Instant updatedAt = Instant.now();
+    final UUID latestJobRunUuid = UUID.randomUUID();
+    final Optional<Instant> expectedUpdatedAt = Optional.of(updatedAt);
+    final Optional<UUID> expectedLatestJobRunUuid = Optional.of(latestJobRunUuid);
+    final JobVersionRow jobVersionRow =
+        JobVersionRow.builder()
+            .uuid(ROW_UUID)
+            .createdAt(CREATED_AT)
+            .updatedAt(updatedAt)
+            .jobUuid(JOB_UUID)
+            .inputDatasetUrns(INPUT_DATASET_URNS)
+            .outputDatasetUrns(OUTPUT_DATASET_URNS)
+            .version(VERSION)
+            .location(LOCATION)
+            .latestJobRunUuid(latestJobRunUuid)
+            .build();
+    assertEquals(ROW_UUID, jobVersionRow.getUuid());
+    assertEquals(CREATED_AT, jobVersionRow.getCreatedAt());
+    assertEquals(expectedUpdatedAt, jobVersionRow.getUpdatedAt());
+    assertEquals(JOB_UUID, jobVersionRow.getJobUuid());
+    assertEquals(INPUT_DATASET_URNS, jobVersionRow.getInputDatasetUrns());
+    assertEquals(OUTPUT_DATASET_URNS, jobVersionRow.getOutputDatasetUrns());
+    assertEquals(VERSION, jobVersionRow.getVersion());
+    assertEquals(LOCATION, jobVersionRow.getLocation());
+    assertEquals(expectedLatestJobRunUuid, jobVersionRow.getLatestJobRunUuid());
+  }
+}

--- a/src/test/java/marquez/db/models/JobVersionRowTest.java
+++ b/src/test/java/marquez/db/models/JobVersionRowTest.java
@@ -21,31 +21,6 @@ public class JobVersionRowTest {
 
   @Test
   public void testNewJobVersionRow() {
-    final Optional<Instant> noUpdatedAt = Optional.empty();
-    final Optional<UUID> noLatestJobRunUuid = Optional.empty();
-    final JobVersionRow jobVersionRow =
-        JobVersionRow.builder()
-            .uuid(ROW_UUID)
-            .createdAt(CREATED_AT)
-            .jobUuid(JOB_UUID)
-            .inputDatasetUrns(INPUT_DATASET_URNS)
-            .outputDatasetUrns(OUTPUT_DATASET_URNS)
-            .version(VERSION)
-            .location(LOCATION)
-            .build();
-    assertEquals(ROW_UUID, jobVersionRow.getUuid());
-    assertEquals(CREATED_AT, jobVersionRow.getCreatedAt());
-    assertEquals(noUpdatedAt, jobVersionRow.getUpdatedAt());
-    assertEquals(JOB_UUID, jobVersionRow.getJobUuid());
-    assertEquals(INPUT_DATASET_URNS, jobVersionRow.getInputDatasetUrns());
-    assertEquals(OUTPUT_DATASET_URNS, jobVersionRow.getOutputDatasetUrns());
-    assertEquals(VERSION, jobVersionRow.getVersion());
-    assertEquals(LOCATION, jobVersionRow.getLocation());
-    assertEquals(noLatestJobRunUuid, jobVersionRow.getLatestJobRunUuid());
-  }
-
-  @Test
-  public void testNewJobVersionRow_latestJobRunUuid() {
     final Instant updatedAt = Instant.now();
     final UUID latestJobRunUuid = UUID.randomUUID();
     final Optional<Instant> expectedUpdatedAt = Optional.of(updatedAt);
@@ -71,6 +46,31 @@ public class JobVersionRowTest {
     assertEquals(VERSION, jobVersionRow.getVersion());
     assertEquals(LOCATION, jobVersionRow.getLocation());
     assertEquals(expectedLatestJobRunUuid, jobVersionRow.getLatestJobRunUuid());
+  }
+
+  @Test
+  public void testNewJobVersionRow_noLatestJobRunUuid() {
+    final Optional<Instant> noUpdatedAt = Optional.empty();
+    final Optional<UUID> noLatestJobRunUuid = Optional.empty();
+    final JobVersionRow jobVersionRow =
+        JobVersionRow.builder()
+            .uuid(ROW_UUID)
+            .createdAt(CREATED_AT)
+            .jobUuid(JOB_UUID)
+            .inputDatasetUrns(INPUT_DATASET_URNS)
+            .outputDatasetUrns(OUTPUT_DATASET_URNS)
+            .version(VERSION)
+            .location(LOCATION)
+            .build();
+    assertEquals(ROW_UUID, jobVersionRow.getUuid());
+    assertEquals(CREATED_AT, jobVersionRow.getCreatedAt());
+    assertEquals(noUpdatedAt, jobVersionRow.getUpdatedAt());
+    assertEquals(JOB_UUID, jobVersionRow.getJobUuid());
+    assertEquals(INPUT_DATASET_URNS, jobVersionRow.getInputDatasetUrns());
+    assertEquals(OUTPUT_DATASET_URNS, jobVersionRow.getOutputDatasetUrns());
+    assertEquals(VERSION, jobVersionRow.getVersion());
+    assertEquals(LOCATION, jobVersionRow.getLocation());
+    assertEquals(noLatestJobRunUuid, jobVersionRow.getLatestJobRunUuid());
   }
 
   @Test(expected = NullPointerException.class)


### PR DESCRIPTION
This PR adds all db models for accessing a row in the following tables:

* `jobs`
* `job_versions`
* `job_runs`
* `job_run_args`
* `job_run_states`

**NOTE:** This PR is depended on issue #224 in order to allow for proper test coverage