### PR TITLE
Add namespace and owner row classes

### DIFF
--- a/src/main/java/marquez/db/mappers/NamespaceOwnershipRowMapper.java
+++ b/src/main/java/marquez/db/mappers/NamespaceOwnershipRowMapper.java
@@ -1,0 +1,23 @@
+package marquez.db.mappers;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+import lombok.NonNull;
+import marquez.db.models.NamespaceOwnershipRow;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public final class NamespaceOwnershipRowMapper implements RowMapper<NamespaceOwnershipRow> {
+  @Override
+  public NamespaceOwnershipRow map(@NonNull ResultSet results, @NonNull StatementContext context)
+      throws SQLException {
+    return NamespaceOwnershipRow.builder()
+        .uuid(UUID.fromString(results.getString("uuid")))
+        .startedAt(results.getDate("started_at").toInstant())
+        .endedAt(results.getDate("ended_at").toInstant())
+        .namespaceUuid(UUID.fromString(results.getString("namespace_uuid")))
+        .ownerUuid(UUID.fromString(results.getString("owner_uuid")))
+        .build();
+  }
+}

--- a/src/main/java/marquez/db/mappers/NamespaceRowMapper.java
+++ b/src/main/java/marquez/db/mappers/NamespaceRowMapper.java
@@ -1,0 +1,24 @@
+package marquez.db.mappers;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+import lombok.NonNull;
+import marquez.db.models.NamespaceRow;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public final class NamespaceRowMapper implements RowMapper<NamespaceRow> {
+  @Override
+  public NamespaceRow map(@NonNull ResultSet results, @NonNull StatementContext context)
+      throws SQLException {
+    return NamespaceRow.builder()
+        .uuid(UUID.fromString(results.getString("uuid")))
+        .createdAt(results.getDate("created_at").toInstant())
+        .updatedAt(results.getDate("updated_at").toInstant())
+        .namespace(results.getString("namespace"))
+        .description(results.getString("description"))
+        .currentOwnership(results.getString("current_ownership"))
+        .build();
+  }
+}

--- a/src/main/java/marquez/db/mappers/OwnerRowMapper.java
+++ b/src/main/java/marquez/db/mappers/OwnerRowMapper.java
@@ -1,0 +1,21 @@
+package marquez.db.mappers;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+import lombok.NonNull;
+import marquez.db.models.OwnerRow;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public final class OwnerRowMapper implements RowMapper<OwnerRow> {
+  @Override
+  public OwnerRow map(@NonNull ResultSet results, @NonNull StatementContext context)
+      throws SQLException {
+    return OwnerRow.builder()
+        .uuid(UUID.fromString(results.getString("uuid")))
+        .createdAt(results.getDate("created_at").toInstant())
+        .owner(results.getString("owner"))
+        .build();
+  }
+}

--- a/src/main/java/marquez/db/models/NamespaceOwnershipRow.java
+++ b/src/main/java/marquez/db/models/NamespaceOwnershipRow.java
@@ -1,4 +1,4 @@
-package marquez.db.model;
+package marquez.db.models;
 
 import java.time.Instant;
 import java.util.Optional;

--- a/src/main/java/marquez/db/models/NamespaceOwnershipRow.java
+++ b/src/main/java/marquez/db/models/NamespaceOwnershipRow.java
@@ -1,0 +1,27 @@
+package marquez.db.model;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+@Builder
+public final class NamespaceOwnershipRow {
+  @Getter @NonNull private final UUID uuid;
+  @Getter @NonNull private final Instant startedAt;
+  @Getter @NonNull private final UUID namespaceUuid;
+  @Getter @NonNull private final UUID ownerUuid;
+  private final Instant endedAt;
+
+  public Optional<Instant> getEndedAt() {
+    return Optional.ofNullable(endedAt);
+  }
+}

--- a/src/main/java/marquez/db/models/NamespaceRow.java
+++ b/src/main/java/marquez/db/models/NamespaceRow.java
@@ -17,9 +17,14 @@ import lombok.ToString;
 public final class NamespaceRow {
   @Getter @NonNull private final UUID uuid;
   @Getter @NonNull private final Instant createdAt;
-  @Getter @NonNull private final String currentOwnership;
   @Getter @NonNull private final String namespace;
+  @Getter @NonNull private final String currentOwnership;
+  private final Instant updatedAt;
   private final String description;
+
+  public Optional<Instant> getUpdatedAt() {
+    return Optional.ofNullable(updatedAt);
+  }
 
   public Optional<String> getDescription() {
     return Optional.ofNullable(description);

--- a/src/main/java/marquez/db/models/NamespaceRow.java
+++ b/src/main/java/marquez/db/models/NamespaceRow.java
@@ -1,0 +1,27 @@
+package marquez.db.models;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+@Builder
+public final class NamespaceRow {
+  @Getter @NonNull private final UUID uuid;
+  @Getter @NonNull private final Instant createdAt;
+  @Getter @NonNull private final String currentOwnership;
+  @Getter @NonNull private final String namespace;
+  private final String description;
+
+  public Optional<String> getDescription() {
+    return Optional.ofNullable(description);
+  }
+}

--- a/src/main/java/marquez/db/models/OwnerRow.java
+++ b/src/main/java/marquez/db/models/OwnerRow.java
@@ -1,0 +1,15 @@
+package marquez.db.models;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+
+@Data
+@Builder
+public final class OwnerRow {
+  @NonNull private final UUID uuid;
+  @NonNull private final Instant createdAt;
+  @NonNull private final String owner;
+}


### PR DESCRIPTION
This PR adds all db models for accessing a row in the following tables:

* `namespaces`
* `namespace_ownerships`
* `owners`

**NOTE:** This PR is depended on issue #224 in order to allow for proper test coverage