### PR TITLE
Rename RunArgsDao to JobRunArgsDao

### DIFF
--- a/src/main/java/marquez/MarquezApp.java
+++ b/src/main/java/marquez/MarquezApp.java
@@ -19,10 +19,10 @@ import marquez.api.resources.PingResource;
 import marquez.core.mappers.ResourceExceptionMapper;
 import marquez.db.DatasetDao;
 import marquez.db.JobDao;
+import marquez.db.JobRunArgsDao;
 import marquez.db.JobRunDao;
 import marquez.db.JobVersionDao;
 import marquez.db.NamespaceDao;
-import marquez.db.RunArgsDao;
 import marquez.service.DatasetService;
 import marquez.service.JobService;
 import marquez.service.NamespaceService;
@@ -105,22 +105,20 @@ public class MarquezApp extends Application<MarquezConfig> {
             .installPlugin(new PostgresPlugin());
 
     final NamespaceDao namespaceDao = jdbi.onDemand(NamespaceDao.class);
+    final JobDao jobDao = jdbi.onDemand(JobDao.class);
+    final JobVersionDao jobVersionDao = jdbi.onDemand(JobVersionDao.class);
+    final JobRunDao jobRunDao = jdbi.onDemand(JobRunDao.class);
+    final JobRunArgsDao jobRunArgsDao = jdbi.onDemand(JobRunArgsDao.class);
     final DatasetDao datasetDao = jdbi.onDemand(DatasetDao.class);
 
     final NamespaceService namespaceService = new NamespaceService(namespaceDao);
+    final JobService jobService = new JobService(jobDao, jobVersionDao, jobRunDao, jobRunArgsDao);
 
     env.jersey().register(new PingResource());
     env.jersey().register(new HealthResource());
     env.jersey().register(new NamespaceResource(namespaceService));
-    env.jersey().register(new DatasetResource(namespaceService, new DatasetService(datasetDao)));
-
-    final JobDao jobDao = jdbi.onDemand(JobDao.class);
-    final JobVersionDao jobVersionDao = jdbi.onDemand(JobVersionDao.class);
-    final JobRunDao jobRunDao = jdbi.onDemand(JobRunDao.class);
-    final RunArgsDao runArgsDao = jdbi.onDemand(RunArgsDao.class);
-
-    final JobService jobService = new JobService(jobDao, jobVersionDao, jobRunDao, runArgsDao);
     env.jersey().register(new JobResource(namespaceService, jobService));
+    env.jersey().register(new DatasetResource(namespaceService, new DatasetService(datasetDao)));
 
     env.jersey().register(new ResourceExceptionMapper());
   }

--- a/src/main/java/marquez/db/JobRunArgsDao.java
+++ b/src/main/java/marquez/db/JobRunArgsDao.java
@@ -1,15 +1,15 @@
 package marquez.db;
 
 import marquez.core.models.RunArgs;
-import marquez.db.mappers.RunArgsRowMapper;
+import marquez.db.mappers.JobRunArgsRowMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
-@RegisterRowMapper(RunArgsRowMapper.class)
-public interface RunArgsDao {
+@RegisterRowMapper(JobRunArgsRowMapper.class)
+public interface JobRunArgsDao {
   @SqlUpdate("INSERT INTO job_run_args(hex_digest, args_json) VALUES (:hexDigest, :json)")
   void insert(@BindBean RunArgs runArgs);
 

--- a/src/main/java/marquez/db/JobRunDao.java
+++ b/src/main/java/marquez/db/JobRunDao.java
@@ -18,7 +18,7 @@ public interface JobRunDao {
   JobRunStateDao createJobRunStateDao();
 
   @CreateSqlObject
-  RunArgsDao createRunArgsDao();
+  JobRunArgsDao createJobRunArgsDao();
 
   @SqlUpdate(
       "INSERT INTO job_runs (guid, job_version_guid, current_state, "
@@ -35,7 +35,7 @@ public interface JobRunDao {
 
   @Transaction
   default void insertJobRunAndArgs(JobRun jobRun, RunArgs runArgs) {
-    createRunArgsDao().insert(runArgs);
+    createJobRunArgsDao().insert(runArgs);
     insert(jobRun);
   }
 

--- a/src/main/java/marquez/db/mappers/JobRunArgsRowMapper.java
+++ b/src/main/java/marquez/db/mappers/JobRunArgsRowMapper.java
@@ -6,7 +6,7 @@ import marquez.core.models.RunArgs;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
-public class RunArgsRowMapper implements RowMapper<RunArgs> {
+public class JobRunArgsRowMapper implements RowMapper<RunArgs> {
   @Override
   public RunArgs map(ResultSet rs, StatementContext ctx) throws SQLException {
     return new RunArgs(

--- a/src/main/java/marquez/service/JobService.java
+++ b/src/main/java/marquez/service/JobService.java
@@ -15,9 +15,9 @@ import marquez.core.models.JobRunState;
 import marquez.core.models.JobVersion;
 import marquez.core.models.RunArgs;
 import marquez.db.JobDao;
+import marquez.db.JobRunArgsDao;
 import marquez.db.JobRunDao;
 import marquez.db.JobVersionDao;
-import marquez.db.RunArgsDao;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 
 @Slf4j
@@ -25,14 +25,17 @@ public class JobService {
   private final JobDao jobDao;
   private final JobVersionDao jobVersionDao;
   private final JobRunDao jobRunDao;
-  private final RunArgsDao runArgsDao;
+  private final JobRunArgsDao jobRunArgsDao;
 
   public JobService(
-      JobDao jobDao, JobVersionDao jobVersionDao, JobRunDao jobRunDao, RunArgsDao runArgsDao) {
+      JobDao jobDao,
+      JobVersionDao jobVersionDao,
+      JobRunDao jobRunDao,
+      JobRunArgsDao jobRunArgsDao) {
     this.jobDao = jobDao;
     this.jobVersionDao = jobVersionDao;
     this.jobRunDao = jobRunDao;
-    this.runArgsDao = runArgsDao;
+    this.jobRunArgsDao = jobRunArgsDao;
   }
 
   public Optional<Job> getJob(String namespace, String jobName) throws UnexpectedException {
@@ -178,7 +181,7 @@ public class JobService {
               nominalStartTime,
               nominalEndTime,
               null);
-      if (runArgsJson == null || runArgsDao.digestExists(runArgsDigest)) {
+      if (runArgsJson == null || jobRunArgsDao.digestExists(runArgsDigest)) {
         jobRunDao.insert(jobRun);
       } else {
         jobRunDao.insertJobRunAndArgs(jobRun, runArgs);

--- a/src/test/java/marquez/api/JobIntegrationTest.java
+++ b/src/test/java/marquez/api/JobIntegrationTest.java
@@ -26,10 +26,10 @@ import marquez.core.models.JobRun;
 import marquez.core.models.JobRunState;
 import marquez.core.models.Namespace;
 import marquez.db.JobDao;
+import marquez.db.JobRunArgsDao;
 import marquez.db.JobRunDao;
 import marquez.db.JobVersionDao;
 import marquez.db.NamespaceDao;
-import marquez.db.RunArgsDao;
 import marquez.service.JobService;
 import marquez.service.NamespaceService;
 import org.junit.After;
@@ -54,11 +54,11 @@ public class JobIntegrationTest extends JobRunBaseTest {
   protected static final JobDao jobDao = APP.onDemand(JobDao.class);
   protected static final JobVersionDao jobVersionDao = APP.onDemand(JobVersionDao.class);
   protected static final JobRunDao jobRunDao = APP.onDemand(JobRunDao.class);
-  protected static final RunArgsDao runArgsDao = APP.onDemand(RunArgsDao.class);
+  protected static final JobRunArgsDao jobRunArgsDao = APP.onDemand(JobRunArgsDao.class);
 
   protected static final NamespaceService namespaceService = new NamespaceService(namespaceDao);
   protected static final JobService jobService =
-      new JobService(jobDao, jobVersionDao, jobRunDao, runArgsDao);
+      new JobService(jobDao, jobVersionDao, jobRunDao, jobRunArgsDao);
 
   @BeforeClass
   public static void setup() throws UnexpectedException {

--- a/src/test/java/marquez/db/JobRunArgsDaoTest.java
+++ b/src/test/java/marquez/db/JobRunArgsDaoTest.java
@@ -10,11 +10,11 @@ import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-public class RunArgsDaoTest {
+public class JobRunArgsDaoTest {
 
   @ClassRule public static final AppWithPostgresRule APP = new AppWithPostgresRule();
 
-  final RunArgsDao runArgsDao = APP.onDemand(RunArgsDao.class);
+  final JobRunArgsDao jobRunArgsDao = APP.onDemand(JobRunArgsDao.class);
   final String hexDigest = "07d4ee12aac795ec60a549dce809c8105c541f0c4f3e7715686953f1702940e0";
   final String argsJson = "{'foo': 1}";
   final RunArgs runArgs = new RunArgs(hexDigest, argsJson, null);
@@ -38,23 +38,23 @@ public class RunArgsDaoTest {
                   hexDigest,
                   argsJson);
             });
-    RunArgs runArgsFound = runArgsDao.findByDigest(hexDigest);
+    RunArgs runArgsFound = jobRunArgsDao.findByDigest(hexDigest);
     assertEquals(runArgs.getHexDigest(), runArgsFound.getHexDigest());
     assertEquals(runArgs.getJson(), runArgsFound.getJson());
   }
 
   @Test
   public void testInsert() {
-    runArgsDao.insert(runArgs);
-    RunArgs runArgsFound = runArgsDao.findByDigest(hexDigest);
+    jobRunArgsDao.insert(runArgs);
+    RunArgs runArgsFound = jobRunArgsDao.findByDigest(hexDigest);
     assertEquals(runArgs.getHexDigest(), runArgsFound.getHexDigest());
     assertEquals(runArgs.getJson(), runArgsFound.getJson());
   }
 
   @Test
   public void testDigestExists() {
-    runArgsDao.insert(runArgs);
-    assertTrue(runArgsDao.digestExists(hexDigest));
-    assertFalse(runArgsDao.digestExists("non-existent"));
+    jobRunArgsDao.insert(runArgs);
+    assertTrue(jobRunArgsDao.digestExists(hexDigest));
+    assertFalse(jobRunArgsDao.digestExists("non-existent"));
   }
 }

--- a/src/test/java/marquez/db/JobRunDaoTest.java
+++ b/src/test/java/marquez/db/JobRunDaoTest.java
@@ -36,11 +36,11 @@ public class JobRunDaoTest extends JobRunBaseTest {
   protected static final JobVersionDao jobVersionDao = APP.onDemand(JobVersionDao.class);
   protected static final JobRunDao jobRunDao = APP.onDemand(JobRunDao.class);
   protected static final JobRunStateDao jobRunStateDao = APP.onDemand(JobRunStateDao.class);
-  protected static final RunArgsDao runArgsDao = APP.onDemand(RunArgsDao.class);
+  protected static final JobRunArgsDao jobRunArgsDao = APP.onDemand(JobRunArgsDao.class);
 
   protected static final NamespaceService namespaceService = new NamespaceService(namespaceDao);
   protected static final JobService jobService =
-      new JobService(jobDao, jobVersionDao, jobRunDao, runArgsDao);
+      new JobService(jobDao, jobVersionDao, jobRunDao, jobRunArgsDao);
 
   @BeforeClass
   public static void setUpRowMapper() {

--- a/src/test/java/marquez/service/JobServiceIntegrationTest.java
+++ b/src/test/java/marquez/service/JobServiceIntegrationTest.java
@@ -16,9 +16,9 @@ import marquez.core.models.JobRun;
 import marquez.core.models.JobRunState;
 import marquez.core.models.JobVersion;
 import marquez.db.JobDao;
+import marquez.db.JobRunArgsDao;
 import marquez.db.JobRunDao;
 import marquez.db.JobVersionDao;
-import marquez.db.RunArgsDao;
 import marquez.db.fixtures.AppWithPostgresRule;
 import org.junit.After;
 import org.junit.Before;
@@ -30,11 +30,11 @@ public class JobServiceIntegrationTest {
   final JobDao jobDao = APP.onDemand(JobDao.class);
   final JobVersionDao jobVersionDao = APP.onDemand(JobVersionDao.class);
   final JobRunDao jobRunDao = APP.onDemand(JobRunDao.class);
-  final RunArgsDao runArgsDao = APP.onDemand(RunArgsDao.class);
+  final JobRunArgsDao jobRunArgsDao = APP.onDemand(JobRunArgsDao.class);
   final UUID namespaceID = UUID.randomUUID();
   final String namespaceName = "job_service_test_ns";
   final String jobOwner = "Amaranta";
-  JobService jobService = new JobService(jobDao, jobVersionDao, jobRunDao, runArgsDao);
+  JobService jobService = new JobService(jobDao, jobVersionDao, jobRunDao, jobRunArgsDao);
 
   @Before
   public void setup() {
@@ -134,7 +134,7 @@ public class JobServiceIntegrationTest {
         JobRunState.State.toInt(JobRunState.State.NEW),
         jobRunFound.get().getCurrentState().intValue());
     String argsHexDigest = jobRun.getRunArgsHexDigest();
-    assertEquals(runArgsJson, runArgsDao.findByDigest(argsHexDigest).getJson());
+    assertEquals(runArgsJson, jobRunArgsDao.findByDigest(argsHexDigest).getJson());
     jobService.updateJobRunState(jobRun.getGuid(), JobRunState.State.RUNNING);
   }
 

--- a/src/test/java/marquez/service/JobServiceTest.java
+++ b/src/test/java/marquez/service/JobServiceTest.java
@@ -24,9 +24,9 @@ import marquez.core.models.JobRun;
 import marquez.core.models.JobRunState;
 import marquez.core.models.JobVersion;
 import marquez.db.JobDao;
+import marquez.db.JobRunArgsDao;
 import marquez.db.JobRunDao;
 import marquez.db.JobVersionDao;
-import marquez.db.RunArgsDao;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.After;
 import org.junit.Assert;
@@ -39,14 +39,14 @@ public class JobServiceTest {
   private static final JobDao jobDao = mock(JobDao.class);
   private static final JobVersionDao jobVersionDao = mock(JobVersionDao.class);
   private static final JobRunDao jobRunDao = mock(JobRunDao.class);
-  private static final RunArgsDao runArgsDao = mock(RunArgsDao.class);
+  private static final JobRunArgsDao jobRunArgsDao = mock(JobRunArgsDao.class);
   private static final UUID namespaceID = UUID.randomUUID();
 
   JobService jobService;
 
   @Before
   public void setUp() {
-    jobService = new JobService(jobDao, jobVersionDao, jobRunDao, runArgsDao);
+    jobService = new JobService(jobDao, jobVersionDao, jobRunDao, jobRunArgsDao);
   }
 
   @After
@@ -54,7 +54,7 @@ public class JobServiceTest {
     reset(jobDao);
     reset(jobVersionDao);
     reset(jobRunDao);
-    reset(runArgsDao);
+    reset(jobRunArgsDao);
   }
 
   private void assertJobFieldsMatch(Job job1, Job job2) {


### PR DESCRIPTION
This PR renames `RunArgsDao` to `JobRunArgsDao` therefore matching the table under the same name in our schema: `job_run_args`