### PR TITLE
Drop 'v' prefix from docker img tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,6 @@ workflows:
             - test
           filters:
             tags:
-              only: /^v[0-9]+(\.[0-9]+){2}$/
+              only: /^[0-9]+(\.[0-9]+){2}$/
             branches:
               ignore: /.*/

--- a/docker/build-and-push.sh
+++ b/docker/build-and-push.sh
@@ -6,7 +6,7 @@ set -eu
 
 source common.sh
 
-readonly SEMVER_REGEX="^v[0-9]+(\.[0-9]+){2}$" # vX.Y.Z
+readonly SEMVER_REGEX="^[0-9]+(\.[0-9]+){2}$" # X.Y.Z
 readonly ORG="marquezproject"
 readonly REPO="marquez"
 readonly NAME="${ORG}/${REPO}"


### PR DESCRIPTION
This PR is a continuation of #240 removing the `v` prefix from our tagged releases (see https://semver.org)