### PR TITLE
Add namespace ownership rows 

### DIFF
--- a/src/main/java/marquez/db/models/NamespaceOwnershipRow.java
+++ b/src/main/java/marquez/db/models/NamespaceOwnershipRow.java
@@ -1,0 +1,27 @@
+package marquez.db.models;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+@Builder
+public final class NamespaceOwnershipRow {
+  @Getter @NonNull private final UUID uuid;
+  @Getter @NonNull private final Instant startedAt;
+  @Getter @NonNull private final UUID namespaceUuid;
+  @Getter @NonNull private final UUID ownerUuid;
+  private final Instant endedAt;
+
+  public Optional<Instant> getEndedAt() {
+    return Optional.ofNullable(endedAt);
+  }
+}

--- a/src/main/java/marquez/db/models/NamespaceRow.java
+++ b/src/main/java/marquez/db/models/NamespaceRow.java
@@ -1,0 +1,28 @@
+package marquez.db.models;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@EqualsAndHashCode
+@ToString
+@Builder
+public final class NamespaceRow {
+  @Getter @NonNull private final UUID uuid;
+  @Getter @NonNull private final Instant createdAt;
+  @Getter @NonNull private final Instant updatedAt;
+  @Getter @NonNull private final String name;
+  @Getter @NonNull private final String currentOwnerName;
+  private final String description;
+
+  public Optional<String> getDescription() {
+    return Optional.ofNullable(description);
+  }
+}

--- a/src/main/java/marquez/db/models/OwnerRow.java
+++ b/src/main/java/marquez/db/models/OwnerRow.java
@@ -1,0 +1,15 @@
+package marquez.db.models;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+
+@Data
+@Builder
+public final class OwnerRow {
+  @NonNull private final UUID uuid;
+  @NonNull private final Instant createdAt;
+  @NonNull private final String name;
+}

--- a/src/test/java/marquez/db/models/NamespaceOwnershipRowTest.java
+++ b/src/test/java/marquez/db/models/NamespaceOwnershipRowTest.java
@@ -1,0 +1,95 @@
+package marquez.db.models;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.Test;
+
+public class NamespaceOwnershipRowTest {
+  private static final UUID ROW_UUID = UUID.randomUUID();
+  private static final Instant STARTED_AT = Instant.now();
+  private static final UUID NAMESPACE_UUID = UUID.randomUUID();
+  private static final UUID OWNER_UUID = UUID.randomUUID();
+
+  @Test
+  public void testNewNamespaceOwnershipRow() {
+    final Instant endedAt = Instant.now();
+    final Optional<Instant> expectedEndedAt = Optional.of(endedAt);
+    final NamespaceOwnershipRow namespaceOwnershipRow =
+        NamespaceOwnershipRow.builder()
+            .uuid(ROW_UUID)
+            .startedAt(STARTED_AT)
+            .endedAt(endedAt)
+            .namespaceUuid(NAMESPACE_UUID)
+            .ownerUuid(OWNER_UUID)
+            .build();
+    assertEquals(ROW_UUID, namespaceOwnershipRow.getUuid());
+    assertEquals(STARTED_AT, namespaceOwnershipRow.getStartedAt());
+    assertEquals(expectedEndedAt, namespaceOwnershipRow.getEndedAt());
+    assertEquals(NAMESPACE_UUID, namespaceOwnershipRow.getNamespaceUuid());
+    assertEquals(OWNER_UUID, namespaceOwnershipRow.getOwnerUuid());
+  }
+
+  @Test
+  public void testNewNamespaceOwnershipRow_noEndedAt() {
+    final Optional<Instant> noEndedAt = Optional.empty();
+    final NamespaceOwnershipRow namespaceOwnershipRow =
+        NamespaceOwnershipRow.builder()
+            .uuid(ROW_UUID)
+            .startedAt(STARTED_AT)
+            .namespaceUuid(NAMESPACE_UUID)
+            .ownerUuid(OWNER_UUID)
+            .build();
+    assertEquals(ROW_UUID, namespaceOwnershipRow.getUuid());
+    assertEquals(STARTED_AT, namespaceOwnershipRow.getStartedAt());
+    assertEquals(noEndedAt, namespaceOwnershipRow.getEndedAt());
+    assertEquals(NAMESPACE_UUID, namespaceOwnershipRow.getNamespaceUuid());
+    assertEquals(OWNER_UUID, namespaceOwnershipRow.getOwnerUuid());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewNamespaceOwnershipRow_nullUuid() {
+    final UUID nullUuid = null;
+    NamespaceOwnershipRow.builder()
+        .uuid(nullUuid)
+        .startedAt(STARTED_AT)
+        .namespaceUuid(NAMESPACE_UUID)
+        .ownerUuid(OWNER_UUID)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewNamespaceOwnershipRow_nullStartedAt() {
+    final Instant nullStartedAt = null;
+    NamespaceOwnershipRow.builder()
+        .uuid(ROW_UUID)
+        .startedAt(nullStartedAt)
+        .namespaceUuid(NAMESPACE_UUID)
+        .ownerUuid(OWNER_UUID)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewNamespaceOwnershipRow_nullNamespaceUuid() {
+    final UUID nullNamespaceUuid = null;
+    NamespaceOwnershipRow.builder()
+        .uuid(ROW_UUID)
+        .startedAt(STARTED_AT)
+        .namespaceUuid(nullNamespaceUuid)
+        .ownerUuid(OWNER_UUID)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewNamespaceOwnershipRow_nullOwnerUuid() {
+    final UUID nullOwnerUuid = null;
+    NamespaceOwnershipRow.builder()
+        .uuid(ROW_UUID)
+        .startedAt(STARTED_AT)
+        .namespaceUuid(NAMESPACE_UUID)
+        .ownerUuid(nullOwnerUuid)
+        .build();
+  }
+}

--- a/src/test/java/marquez/db/models/NamespaceRowTest.java
+++ b/src/test/java/marquez/db/models/NamespaceRowTest.java
@@ -1,0 +1,116 @@
+package marquez.db.models;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.Test;
+
+public class NamespaceRowTest {
+  private static final UUID ROW_UUID = UUID.randomUUID();
+  private static final Instant CREATED_AT = Instant.now();
+  private static final Instant UPDATED_AT = Instant.now();
+  private static final String NAME = "test_namespace";
+  private static final String CURRENT_OWNER_NAME = "test owner";
+
+  @Test
+  public void testNewNamespaceOwnershipRow() {
+    final String description = "test description";
+    final Optional<String> expectedDescription = Optional.of(description);
+    final NamespaceRow namespaceRow =
+        NamespaceRow.builder()
+            .uuid(ROW_UUID)
+            .createdAt(CREATED_AT)
+            .updatedAt(UPDATED_AT)
+            .name(NAME)
+            .description(description)
+            .currentOwnerName(CURRENT_OWNER_NAME)
+            .build();
+    assertEquals(ROW_UUID, namespaceRow.getUuid());
+    assertEquals(CREATED_AT, namespaceRow.getCreatedAt());
+    assertEquals(UPDATED_AT, namespaceRow.getUpdatedAt());
+    assertEquals(NAME, namespaceRow.getName());
+    assertEquals(expectedDescription, namespaceRow.getDescription());
+    assertEquals(CURRENT_OWNER_NAME, namespaceRow.getCurrentOwnerName());
+  }
+
+  @Test
+  public void testNewNamespaceOwnershipRow_noDescription() {
+    final Optional<String> noDescription = Optional.empty();
+    final NamespaceRow namespaceRow =
+        NamespaceRow.builder()
+            .uuid(ROW_UUID)
+            .createdAt(CREATED_AT)
+            .updatedAt(UPDATED_AT)
+            .name(NAME)
+            .currentOwnerName(CURRENT_OWNER_NAME)
+            .build();
+    assertEquals(ROW_UUID, namespaceRow.getUuid());
+    assertEquals(CREATED_AT, namespaceRow.getCreatedAt());
+    assertEquals(UPDATED_AT, namespaceRow.getUpdatedAt());
+    assertEquals(NAME, namespaceRow.getName());
+    assertEquals(noDescription, namespaceRow.getDescription());
+    assertEquals(CURRENT_OWNER_NAME, namespaceRow.getCurrentOwnerName());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewNamespaceOwnershipRow_nullUuid() {
+    final UUID nullUuid = null;
+    NamespaceRow.builder()
+        .uuid(nullUuid)
+        .createdAt(CREATED_AT)
+        .updatedAt(UPDATED_AT)
+        .name(NAME)
+        .currentOwnerName(CURRENT_OWNER_NAME)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewNamespaceOwnershipRow_nullCreatedAt() {
+    final Instant nullCreatedAt = null;
+    NamespaceRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(nullCreatedAt)
+        .updatedAt(UPDATED_AT)
+        .name(NAME)
+        .currentOwnerName(CURRENT_OWNER_NAME)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewNamespaceOwnershipRow_nullUpdatedAt() {
+    final Instant nullUpdatedAt = null;
+    NamespaceRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .updatedAt(nullUpdatedAt)
+        .name(NAME)
+        .currentOwnerName(CURRENT_OWNER_NAME)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewNamespaceOwnershipRow_nullName() {
+    final String nullName = null;
+    NamespaceRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .updatedAt(UPDATED_AT)
+        .name(nullName)
+        .currentOwnerName(CURRENT_OWNER_NAME)
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewNamespaceOwnershipRow_nullCurrentOwnerName() {
+    final String nullCurrentOwnerName = null;
+    NamespaceRow.builder()
+        .uuid(ROW_UUID)
+        .createdAt(CREATED_AT)
+        .updatedAt(UPDATED_AT)
+        .name(NAME)
+        .currentOwnerName(nullCurrentOwnerName)
+        .build();
+  }
+}

--- a/src/test/java/marquez/db/models/OwnerRowTest.java
+++ b/src/test/java/marquez/db/models/OwnerRowTest.java
@@ -1,0 +1,40 @@
+package marquez.db.models;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.Test;
+
+public class OwnerRowTest {
+  private static final UUID ROW_UUID = UUID.randomUUID();
+  private static final Instant CREATED_AT = Instant.now();
+  private static final String NAME = "test owner";
+
+  @Test
+  public void testNewOwnerRow() {
+    final OwnerRow ownerRow =
+        OwnerRow.builder().uuid(ROW_UUID).createdAt(CREATED_AT).name(NAME).build();
+    assertEquals(ROW_UUID, ownerRow.getUuid());
+    assertEquals(CREATED_AT, ownerRow.getCreatedAt());
+    assertEquals(NAME, ownerRow.getName());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewOwnerRow_nullUuid() {
+    final UUID nullUuid = null;
+    OwnerRow.builder().uuid(nullUuid).createdAt(CREATED_AT).name(NAME).build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewOwnerRow_nullCreatedAt() {
+    final Instant nullCreatedAt = null;
+    OwnerRow.builder().uuid(ROW_UUID).createdAt(nullCreatedAt).name(NAME).build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewOwnerRow_nullName() {
+    final String nullName = null;
+    OwnerRow.builder().uuid(ROW_UUID).createdAt(CREATED_AT).name(nullName).build();
+  }
+}


### PR DESCRIPTION
This PR adds all db models for accessing a row in the following tables:

* `namespaces`
* `namespace_ownerships`
* `owners`