### PR TITLE
Bump jdbi3 to 3.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,8 @@ dependencies {
   compile 'io.dropwizard:dropwizard-core:1.3.7'
   compile 'io.dropwizard:dropwizard-jdbi3:1.3.7'
   compile 'io.dropwizard.metrics:metrics-jdbi3:4.1.0-rc3'
-  compile 'org.jdbi:jdbi3-postgres:3.5.1'
-  compile 'org.jdbi:jdbi3-sqlobject:3.5.1'
+  compile 'org.jdbi:jdbi3-postgres:3.6.0'
+  compile 'org.jdbi:jdbi3-sqlobject:3.6.0'
   compile 'org.postgresql:postgresql:42.2.5'
   compileOnly 'org.projectlombok:lombok:1.18.4'
 


### PR DESCRIPTION
This PR bumps jdbi3 to 3.6.0 (see [release notes](https://github.com/jdbi/jdbi/blob/master/RELEASE_NOTES.md))