### PR TITLE
Bump dependency-license-report plugin to 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
   id 'java'
   id 'com.adarshr.test-logger' version '1.6.0'
   id 'com.diffplug.gradle.spotless' version '3.16.0'
-  id 'com.github.jk1.dependency-license-report' version '1.2'
+  id 'com.github.jk1.dependency-license-report' version '1.3'
   id 'com.github.johnrengelman.shadow' version '4.0.3'
   id 'net.researchgate.release' version '2.6.0'
 }


### PR DESCRIPTION
This PR bump the dependency-license-report plugin to 1.3. see [diff](https://github.com/jk1/Gradle-License-Report/compare/v1.3...master)