### PR TITLE
Bump shadow plugin to 4.0.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'com.adarshr.test-logger' version '1.6.0'
   id 'com.diffplug.gradle.spotless' version '3.16.0'
   id 'com.github.jk1.dependency-license-report' version '1.2'
-  id 'com.github.johnrengelman.shadow' version '4.0.3'
+  id 'com.github.johnrengelman.shadow' version '4.0.4'
   id 'net.researchgate.release' version '2.6.0'
 }
 


### PR DESCRIPTION
This PR bump the shadow plugin to `4.0.4`. see [release](https://github.com/johnrengelman/shadow/releases/tag/4.0.4)