### PR TITLE
Update data source row mapper test

### DIFF
--- a/src/test/java/marquez/service/mappers/DataSourceRowMapperTest.java
+++ b/src/test/java/marquez/service/mappers/DataSourceRowMapperTest.java
@@ -13,7 +13,10 @@ import marquez.common.models.Description;
 import marquez.db.models.DataSourceRow;
 import marquez.service.models.DbTableVersion;
 import org.junit.Test;
+import marquez.UnitTests;
+import org.junit.experimental.categories.Category;
 
+@Category(UnitTests.class)
 public class DataSourceRowMapperTest {
   private static final DataSource DATA_SOURCE = DataSource.fromString("postgresql");
   private static final ConnectionUrl CONNECTION_URL =

--- a/src/test/java/marquez/service/mappers/DataSourceRowMapperTest.java
+++ b/src/test/java/marquez/service/mappers/DataSourceRowMapperTest.java
@@ -1,17 +1,14 @@
 package marquez.service.mappers;
 
-import static marquez.common.models.Description.NO_DESCRIPTION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.Optional;
 import marquez.UnitTests;
 import marquez.common.models.ConnectionUrl;
 import marquez.common.models.DataSource;
 import marquez.common.models.DbName;
 import marquez.common.models.DbSchemaName;
 import marquez.common.models.DbTableName;
-import marquez.common.models.Description;
 import marquez.db.models.DataSourceRow;
 import marquez.service.models.DbTableVersion;
 import org.junit.Test;
@@ -26,19 +23,20 @@ public class DataSourceRowMapperTest {
           String.format("jdbc:%s://localhost:5432/%s", DATA_SOURCE.getValue(), DB_NAME.getValue()));
   private static final DbSchemaName DB_SCHEMA_NAME = DbSchemaName.fromString("test_schema");
   private static final DbTableName DB_TABLE_NAME = DbTableName.fromString("test_table");
-  private static final Description DESCRIPTION = Description.fromString("test description");
 
   @Test
   public void testMap() {
-    final Optional<Description> expectedDescription = Optional.of(DESCRIPTION);
     final DbTableVersion dbTableVersion =
-        new DbTableVersion(CONNECTION_URL, DB_SCHEMA_NAME, DB_TABLE_NAME, DESCRIPTION);
+        DbTableVersion.builder()
+            .connectionUrl(CONNECTION_URL)
+            .dbSchemaName(DB_SCHEMA_NAME)
+            .dbTableName(DB_TABLE_NAME)
+            .build();
     final DataSourceRow dataSourceRow = DataSourceRowMapper.map(dbTableVersion);
     assertNotNull(dataSourceRow);
     assertNotNull(dataSourceRow.getUuid());
     assertEquals(DATA_SOURCE.getValue(), dataSourceRow.getName());
     assertEquals(CONNECTION_URL.getRawValue(), dataSourceRow.getConnectionUrl());
-    assertEquals(expectedDescription, dbTableVersion.getDescription());
   }
 
   @Test(expected = NullPointerException.class)

--- a/src/test/java/marquez/service/mappers/DataSourceRowMapperTest.java
+++ b/src/test/java/marquez/service/mappers/DataSourceRowMapperTest.java
@@ -5,31 +5,32 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.Optional;
+import marquez.UnitTests;
 import marquez.common.models.ConnectionUrl;
 import marquez.common.models.DataSource;
+import marquez.common.models.DbName;
 import marquez.common.models.DbSchemaName;
 import marquez.common.models.DbTableName;
 import marquez.common.models.Description;
 import marquez.db.models.DataSourceRow;
 import marquez.service.models.DbTableVersion;
 import org.junit.Test;
-import marquez.UnitTests;
 import org.junit.experimental.categories.Category;
 
 @Category(UnitTests.class)
 public class DataSourceRowMapperTest {
   private static final DataSource DATA_SOURCE = DataSource.fromString("postgresql");
+  private static final DbName DB_NAME = DbName.fromString("test_db");
   private static final ConnectionUrl CONNECTION_URL =
       ConnectionUrl.fromString(
-          String.format("jdbc:%s://localhost:5432/novelists", DATA_SOURCE.getValue()));
-  private static final DbSchemaName DB_SCHEMA_NAME = DbSchemaName.fromString("marquez");
-  private static final DbTableName DB_TABLE_NAME = DbTableName.fromString("quotes");
-  private static final Description DESCRIPTION =
-      Description.fromString("It's enough for me to be sure that you and I exist as this moment.");
+          String.format("jdbc:%s://localhost:5432/%s", DATA_SOURCE.getValue(), DB_NAME.getValue()));
+  private static final DbSchemaName DB_SCHEMA_NAME = DbSchemaName.fromString("test_schema");
+  private static final DbTableName DB_TABLE_NAME = DbTableName.fromString("test_table");
+  private static final Description DESCRIPTION = Description.fromString("test description");
 
   @Test
-  public void testMapDbTableVersion() {
-    final Optional<Description> nonEmptyDescription = Optional.of(DESCRIPTION);
+  public void testMap() {
+    final Optional<Description> expectedDescription = Optional.of(DESCRIPTION);
     final DbTableVersion dbTableVersion =
         new DbTableVersion(CONNECTION_URL, DB_SCHEMA_NAME, DB_TABLE_NAME, DESCRIPTION);
     final DataSourceRow dataSourceRow = DataSourceRowMapper.map(dbTableVersion);
@@ -37,24 +38,11 @@ public class DataSourceRowMapperTest {
     assertNotNull(dataSourceRow.getUuid());
     assertEquals(DATA_SOURCE.getValue(), dataSourceRow.getName());
     assertEquals(CONNECTION_URL.getRawValue(), dataSourceRow.getConnectionUrl());
-    assertEquals(nonEmptyDescription, dbTableVersion.getDescription());
-  }
-
-  @Test
-  public void testMapDbTableVersionNoDescription() {
-    final Optional<Description> noDescription = Optional.of(NO_DESCRIPTION);
-    final DbTableVersion dbTableVersion =
-        new DbTableVersion(CONNECTION_URL, DB_SCHEMA_NAME, DB_TABLE_NAME, NO_DESCRIPTION);
-    final DataSourceRow dataSourceRow = DataSourceRowMapper.map(dbTableVersion);
-    assertNotNull(dataSourceRow);
-    assertNotNull(dataSourceRow.getUuid());
-    assertEquals(DATA_SOURCE.getValue(), dataSourceRow.getName());
-    assertEquals(CONNECTION_URL.getRawValue(), dataSourceRow.getConnectionUrl());
-    assertEquals(noDescription, dbTableVersion.getDescription());
+    assertEquals(expectedDescription, dbTableVersion.getDescription());
   }
 
   @Test(expected = NullPointerException.class)
-  public void testMapNullDbTableVersion() {
+  public void testMap_throwsException_onNullDbTableVersion() {
     final DbTableVersion nullDbTableVersion = null;
     DataSourceRowMapper.map(nullDbTableVersion);
   }


### PR DESCRIPTION
This PR makes the following updates to [`DataSourceRowMapperTest`](https://github.com/MarquezProject/marquez/blob/master/src/test/java/marquez/service/mappers/DataSourceRowMapperTest.java):

- Add `UnitTests` category
- Add clearer test descriptions