### PR TITLE
Update data source row class

### DIFF
--- a/src/main/java/marquez/db/models/DataSourceRow.java
+++ b/src/main/java/marquez/db/models/DataSourceRow.java
@@ -7,28 +7,18 @@ import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
+@RequiredArgsConstructor
 @EqualsAndHashCode
 @ToString
 @Builder
 public final class DataSourceRow {
-  @Getter private final UUID uuid;
-  @Getter private final String name;
-  @Getter private final String connectionUrl;
-  private final Instant createdAt;
-
-  public DataSourceRow(
-      @NonNull final UUID uuid,
-      @NonNull final String name,
-      @NonNull final String connectionUrl,
-      @Nullable final Instant createdAt) {
-    this.uuid = uuid;
-    this.name = name;
-    this.connectionUrl = connectionUrl;
-    this.createdAt = createdAt;
-  }
+  @Getter @NonNull private final UUID uuid;
+  @Getter @NonNull private final String name;
+  @Getter @NonNull private final String connectionUrl;
+  @Nullable private final Instant createdAt;
 
   public Optional<Instant> getCreatedAt() {
     return Optional.ofNullable(createdAt);

--- a/src/main/java/marquez/db/models/DataSourceRow.java
+++ b/src/main/java/marquez/db/models/DataSourceRow.java
@@ -7,6 +7,7 @@ import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 

--- a/src/main/java/marquez/db/models/DataSourceRow.java
+++ b/src/main/java/marquez/db/models/DataSourceRow.java
@@ -1,21 +1,36 @@
 package marquez.db.models;
 
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
-@RequiredArgsConstructor
 @EqualsAndHashCode
 @ToString
 @Builder
 public final class DataSourceRow {
-  @Getter @NonNull private final UUID uuid;
-  @Getter @NonNull private final String name;
-  @Getter @NonNull private final String connectionUrl;
-  @Getter private final Instant createdAt;
+  @Getter private final UUID uuid;
+  @Getter private final String name;
+  @Getter private final String connectionUrl;
+  private final Instant createdAt;
+
+  public DataSourceRow(
+      @NonNull final UUID uuid,
+      @NonNull final String name,
+      @NonNull final String connectionUrl,
+      @Nullable final Instant createdAt) {
+    this.uuid = uuid;
+    this.name = name;
+    this.connectionUrl = connectionUrl;
+    this.createdAt = createdAt;
+  }
+
+  public Optional<Instant> getCreatedAt() {
+    return Optional.ofNullable(createdAt);
+  }
 }

--- a/src/test/java/marquez/db/mappers/DataSourceRowMapperTest.java
+++ b/src/test/java/marquez/db/mappers/DataSourceRowMapperTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -26,18 +27,18 @@ public class DataSourceRowMapperTest {
 
   @Test
   public void testMap() throws SQLException {
+    final Optional<Instant> expectedCreatedAt = Optional.of(CREATED_AT);
     final ResultSet results = mock(ResultSet.class);
     when(results.getObject(Columns.ROW_UUID, UUID.class)).thenReturn(ROW_UUID);
     when(results.getTimestamp(Columns.CREATED_AT)).thenReturn(Timestamp.from(CREATED_AT));
     when(results.getString(Columns.NAME)).thenReturn(NAME);
     when(results.getString(Columns.CONNECTION_URL)).thenReturn(CONNECTION_URL);
-
     final StatementContext context = mock(StatementContext.class);
 
     final DataSourceRowMapper dataSourceRowMapper = new DataSourceRowMapper();
     final DataSourceRow dataSourceRow = dataSourceRowMapper.map(results, context);
     assertEquals(ROW_UUID, dataSourceRow.getUuid());
-    assertEquals(CREATED_AT, dataSourceRow.getCreatedAt());
+    assertEquals(expectedCreatedAt, dataSourceRow.getCreatedAt());
     assertEquals(NAME, dataSourceRow.getName());
     assertEquals(CONNECTION_URL, dataSourceRow.getConnectionUrl());
   }

--- a/src/test/java/marquez/db/mappers/DataSourceRowMapperTest.java
+++ b/src/test/java/marquez/db/mappers/DataSourceRowMapperTest.java
@@ -4,11 +4,11 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Optional;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 import marquez.UnitTests;
 import marquez.db.Columns;

--- a/src/test/java/marquez/db/models/DataSourceRowTest.java
+++ b/src/test/java/marquez/db/models/DataSourceRowTest.java
@@ -1,0 +1,64 @@
+package marquez.db.models;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import marquez.UnitTests;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(UnitTests.class)
+public class DataSourceRowTest {
+  private static final UUID ROW_UUID = UUID.randomUUID();
+  private static final Instant CREATED_AT = Instant.now();
+  private static final String NAME = "postgresql";
+  private static final String CONNECTION_URL =
+      String.format("jdbc:%s://localhost:5432/test_db", NAME);
+
+  @Test
+  public void testNewDataSourceRow() {
+    final Optional<Instant> expectedCreatedAt = Optional.of(CREATED_AT);
+    final DataSourceRow dataSourceRow =
+        DataSourceRow.builder()
+            .uuid(ROW_UUID)
+            .createdAt(CREATED_AT)
+            .name(NAME)
+            .connectionUrl(CONNECTION_URL)
+            .build();
+    assertEquals(ROW_UUID, dataSourceRow.getUuid());
+    assertEquals(expectedCreatedAt, dataSourceRow.getCreatedAt());
+    assertEquals(NAME, dataSourceRow.getName());
+    assertEquals(CONNECTION_URL, dataSourceRow.getConnectionUrl());
+  }
+
+  @Test
+  public void testNewDataSourceRow_noCreatedAt() {
+    final Optional<Instant> noCreatedAt = Optional.empty();
+    final DataSourceRow dataSourceRow =
+        DataSourceRow.builder().uuid(ROW_UUID).name(NAME).connectionUrl(CONNECTION_URL).build();
+    assertEquals(ROW_UUID, dataSourceRow.getUuid());
+    assertEquals(noCreatedAt, dataSourceRow.getCreatedAt());
+    assertEquals(NAME, dataSourceRow.getName());
+    assertEquals(CONNECTION_URL, dataSourceRow.getConnectionUrl());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewDataSourceRow_throwsException_onNullUuid() {
+    final UUID nullUuid = null;
+    DataSourceRow.builder().uuid(nullUuid).name(NAME).connectionUrl(CONNECTION_URL).build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewDataSourceRow_throwsException_onNullName() {
+    final String nullName = null;
+    DataSourceRow.builder().uuid(ROW_UUID).name(nullName).connectionUrl(CONNECTION_URL).build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNewDataSourceRow_throwsException_onNullConnectionUrl() {
+    final String nullConnectionUrl = null;
+    DataSourceRow.builder().uuid(ROW_UUID).name(NAME).connectionUrl(nullConnectionUrl).build();
+  }
+}


### PR DESCRIPTION
This PR explicitly marks `DataSourceRow.createdAt` as  nullable with `@Nullable`. The getter has  also been updated to return an optional. This change also required adding unit tests (yeah!).