### PR TITLE
Adjust to use class-level setup instead of method-level setup

### DIFF
--- a/src/test/java/marquez/db/DatasetDaoTest.java
+++ b/src/test/java/marquez/db/DatasetDaoTest.java
@@ -11,6 +11,7 @@ import marquez.service.models.Generator;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.testing.JdbiRule;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -20,7 +21,7 @@ import org.slf4j.LoggerFactory;
 public class DatasetDaoTest {
   static final Logger logger = LoggerFactory.getLogger(DatasetDaoTest.class);
   private static DatasetDao datasetDAO;
-  private static marquez.service.models.Namespace namespace = Generator.genNamespace();
+  private static marquez.service.models.Namespace namespace;
   private static NamespaceDao namespaceDAO;
 
   @ClassRule
@@ -30,8 +31,13 @@ public class DatasetDaoTest {
   @BeforeClass
   public static void setup() {
     Jdbi jdbi = dbRule.getJdbi();
-    datasetDAO = jdbi.onDemand(DatasetDao.class);
     namespaceDAO = jdbi.onDemand(NamespaceDao.class);
+    datasetDAO = jdbi.onDemand(DatasetDao.class);
+  }
+
+  @Before
+  public void setupTest() {
+    namespace = Generator.genNamespace();
     namespaceDAO.insert(namespace);
   }
 
@@ -45,12 +51,23 @@ public class DatasetDaoTest {
   }
 
   @Test
-  public void testFindAll() throws Exception {
+  public void testFindAll() {
     assertEquals(
         0, datasetDAO.findAll(NamespaceName.fromString(namespace.getName()), 10, 0).size());
     insertRandomDataset();
     insertRandomDataset();
     assertEquals(
         2, datasetDAO.findAll(NamespaceName.fromString(namespace.getName()), 10, 0).size());
+  }
+
+  @Test
+  public void testFindAllWithLimit() {
+    final int limit = 1;
+    assertEquals(
+        0, datasetDAO.findAll(NamespaceName.fromString(namespace.getName()), limit, 0).size());
+    insertRandomDataset();
+    insertRandomDataset();
+    assertEquals(
+        limit, datasetDAO.findAll(NamespaceName.fromString(namespace.getName()), limit, 0).size());
   }
 }

--- a/src/test/java/marquez/db/DatasetDaoTest.java
+++ b/src/test/java/marquez/db/DatasetDaoTest.java
@@ -11,24 +11,24 @@ import marquez.service.models.Generator;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.testing.JdbiRule;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DatasetDaoTest {
   static final Logger logger = LoggerFactory.getLogger(DatasetDaoTest.class);
-  private DatasetDao datasetDAO;
-  private marquez.service.models.Namespace namespace = Generator.genNamespace();
-  private NamespaceDao namespaceDAO;
+  private static DatasetDao datasetDAO;
+  private static marquez.service.models.Namespace namespace = Generator.genNamespace();
+  private static NamespaceDao namespaceDAO;
 
-  @Rule
-  public final JdbiRule dbRule =
+  @ClassRule
+  public static final JdbiRule dbRule =
       JdbiRule.embeddedPostgres().withPlugin(new SqlObjectPlugin()).migrateWithFlyway();
 
-  @Before
-  public void setup() {
+  @BeforeClass
+  public static void setup() {
     Jdbi jdbi = dbRule.getJdbi();
     datasetDAO = jdbi.onDemand(DatasetDao.class);
     namespaceDAO = jdbi.onDemand(NamespaceDao.class);


### PR DESCRIPTION
Brought this up during the review of this file, but since this is a 1-method test class (for now), it won't make a meaningful difference. Still, this is a good practice to follow and wanted to bring attention to it.