### PR TITLE
Lookup cache deps by branch only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ defaults: &defaults
 cache: &cache
   keys:
     - v1-deps-{{ .Branch }}-{{ .Revision }}
-    - v1-deps-
+    - v1-deps-{{ .Branch }}
 
 jobs:
   build:


### PR DESCRIPTION
This PR removes the cache key `v1-deps-` in favor of `v1-deps-{{ .Branch }}`. That is, `v1-deps-` finds the most recently generated cache used from *any* branch. So, let's be specific and cache/restore deps by branch only.

see: https://circleci.com/docs/2.0/caching/#restoring-cache