### PR TITLE
Add -parameters compiler flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
 compileJava {
   options.incremental = true
+  options.compilerArgs << '-parameters'
 }
 
 compileTestJava {


### PR DESCRIPTION
This PR sets the compiler flag `-parameters`, no longer needing to annotate fields with `@JsonProperty` or `@Bind`.

### Related Issues

* Remove `@JsonProperty` #343 
* Remove `@Bind` #344

### Resources

* https://github.com/FasterXML/jackson-modules-java8/tree/master/parameter-names
* http://jdbi.org/#_compiling_with_parameter_names
* https://julien.ponge.org/blog/java8-parameter-names-and-jdk-dogfooding/