### PR TITLE
Bump dropwizard to 1.3.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ repositories {
 
 dependencies {
   compile 'io.dropwizard.modules:dropwizard-flyway:1.3.0-4'
-  compile 'io.dropwizard:dropwizard-core:1.3.8'
-  compile 'io.dropwizard:dropwizard-jdbi3:1.3.8'
+  compile 'io.dropwizard:dropwizard-core:1.3.9'
+  compile 'io.dropwizard:dropwizard-jdbi3:1.3.9'
   compile 'io.dropwizard.metrics:metrics-jdbi3:4.1.0-rc3'
   compile 'org.jdbi:jdbi3-postgres:3.6.0'
   compile 'org.jdbi:jdbi3-sqlobject:3.6.0'
@@ -27,7 +27,7 @@ dependencies {
   compileOnly 'org.projectlombok:lombok:1.18.4'
 
   testCompile 'junit:junit:4.12'
-  testCompile 'io.dropwizard:dropwizard-testing:1.3.8'
+  testCompile 'io.dropwizard:dropwizard-testing:1.3.9'
   testCompile 'org.jdbi:jdbi3-testing:3.3.0'
   testCompile 'org.mockito:mockito-core:2.23.4'
 }


### PR DESCRIPTION
This PR bumps dropwizard to 1.3.9

see: https://github.com/dropwizard/dropwizard/releases/tag/v1.3.9