### PR TITLE
Update job request

### DIFF
--- a/src/main/java/marquez/api/models/JobRequest.java
+++ b/src/main/java/marquez/api/models/JobRequest.java
@@ -1,29 +1,25 @@
 package marquez.api.models;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
+@AllArgsConstructor(onConstructor = @__(@JsonCreator))
+@EqualsAndHashCode
+@ToString
 public final class JobRequest {
+  @Getter @NotNull private List<String> inputDatasetUrns;
+  @Getter @NotNull private List<String> outputDatasetUrns;
+  @Getter @NotNull private String location;
+  @Nullable private String description;
 
-  @JsonProperty("location")
-  @NotNull
-  private String location;
-
-  @JsonProperty("description")
-  private String description;
-
-  @JsonProperty("inputDatasetUrns")
-  @NotNull
-  public List<String> inputDataSetUrns;
-
-  @JsonProperty("outputDatasetUrns")
-  @NotNull
-  public List<String> outputDatasetUrns;
+  public Optional<String> getDescription() {
+    return Optional.ofNullable(description);
+  }
 }

--- a/src/main/java/marquez/api/models/JobRequest.java
+++ b/src/main/java/marquez/api/models/JobRequest.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public final class CreateJobRequest {
+public final class JobRequest {
 
   @JsonProperty("location")
   @NotNull

--- a/src/main/java/marquez/api/resources/JobResource.java
+++ b/src/main/java/marquez/api/resources/JobResource.java
@@ -36,7 +36,7 @@ import marquez.api.exceptions.ResourceException;
 import marquez.api.mappers.ApiJobToCoreJobMapper;
 import marquez.api.mappers.CoreJobRunToApiJobRunResponseMapper;
 import marquez.api.mappers.CoreJobToApiJobMapper;
-import marquez.api.models.CreateJobRequest;
+import marquez.api.models.JobRequest;
 import marquez.api.models.CreateJobRunRequest;
 import marquez.api.models.JobsResponse;
 import marquez.service.JobService;
@@ -70,7 +70,7 @@ public final class JobResource {
   public Response create(
       @PathParam("namespace") final String namespace,
       @PathParam("job") final String job,
-      @Valid final CreateJobRequest request)
+      @Valid final JobRequest request)
       throws ResourceException {
     try {
       if (!namespaceService.exists(namespace)) {

--- a/src/main/java/marquez/api/resources/JobResource.java
+++ b/src/main/java/marquez/api/resources/JobResource.java
@@ -36,8 +36,8 @@ import marquez.api.exceptions.ResourceException;
 import marquez.api.mappers.ApiJobToCoreJobMapper;
 import marquez.api.mappers.CoreJobRunToApiJobRunResponseMapper;
 import marquez.api.mappers.CoreJobToApiJobMapper;
-import marquez.api.models.JobRequest;
 import marquez.api.models.CreateJobRunRequest;
+import marquez.api.models.JobRequest;
 import marquez.api.models.JobsResponse;
 import marquez.service.JobService;
 import marquez.service.NamespaceService;
@@ -81,10 +81,10 @@ public final class JobResource {
               new marquez.api.models.Job(
                   job,
                   null,
-                  request.getInputDataSetUrns(),
+                  request.getInputDatasetUrns(),
                   request.getOutputDatasetUrns(),
                   request.getLocation(),
-                  request.getDescription()));
+                  request.getDescription().orElse(null)));
       jobToCreate.setNamespaceGuid(namespaceService.get(namespace).get().getGuid());
       final Job createdJob = jobService.createJob(namespace, jobToCreate);
       return Response.status(Response.Status.CREATED)

--- a/src/test/java/marquez/api/JobIntegrationTest.java
+++ b/src/test/java/marquez/api/JobIntegrationTest.java
@@ -30,9 +30,9 @@ import java.util.UUID;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import marquez.api.models.JobRequest;
 import marquez.api.models.CreateJobRunRequest;
 import marquez.api.models.Job;
+import marquez.api.models.JobRequest;
 import marquez.api.models.JobRunResponse;
 import marquez.db.JobDao;
 import marquez.db.JobRunArgsDao;
@@ -257,10 +257,10 @@ public class JobIntegrationTest extends JobRunBaseTest {
   private Response createJobOnNamespace(String namespace, Job job) {
     JobRequest createJobRequest =
         new JobRequest(
-            job.getLocation(),
-            job.getDescription(),
             job.getInputDataSetUrns(),
-            job.getOutputDataSetUrns());
+            job.getOutputDataSetUrns(),
+            job.getLocation(),
+            job.getDescription());
 
     String path = format("/api/v1/namespaces/%s/jobs/%s", namespace, job.getName());
     return APP.client()

--- a/src/test/java/marquez/api/JobIntegrationTest.java
+++ b/src/test/java/marquez/api/JobIntegrationTest.java
@@ -255,7 +255,7 @@ public class JobIntegrationTest extends JobRunBaseTest {
   }
 
   private Response createJobOnNamespace(String namespace, Job job) {
-    JobRequest createJobRequest =
+    JobRequest jobRequest =
         new JobRequest(
             job.getInputDataSetUrns(),
             job.getOutputDataSetUrns(),
@@ -267,7 +267,7 @@ public class JobIntegrationTest extends JobRunBaseTest {
         .target(URI.create("http://localhost:" + APP.getLocalPort()))
         .path(path)
         .request(MediaType.APPLICATION_JSON)
-        .put(Entity.json(createJobRequest));
+        .put(Entity.json(jobRequest));
   }
 
   static Job generateApiJob() {

--- a/src/test/java/marquez/api/JobIntegrationTest.java
+++ b/src/test/java/marquez/api/JobIntegrationTest.java
@@ -30,7 +30,7 @@ import java.util.UUID;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import marquez.api.models.CreateJobRequest;
+import marquez.api.models.JobRequest;
 import marquez.api.models.CreateJobRunRequest;
 import marquez.api.models.Job;
 import marquez.api.models.JobRunResponse;
@@ -255,8 +255,8 @@ public class JobIntegrationTest extends JobRunBaseTest {
   }
 
   private Response createJobOnNamespace(String namespace, Job job) {
-    CreateJobRequest createJobRequest =
-        new CreateJobRequest(
+    JobRequest createJobRequest =
+        new JobRequest(
             job.getLocation(),
             job.getDescription(),
             job.getInputDataSetUrns(),

--- a/src/test/java/marquez/api/JobResourceTest.java
+++ b/src/test/java/marquez/api/JobResourceTest.java
@@ -35,9 +35,9 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import marquez.api.exceptions.ResourceExceptionMapper;
-import marquez.api.models.JobRequest;
 import marquez.api.models.CreateJobRunRequest;
 import marquez.api.models.Job;
+import marquez.api.models.JobRequest;
 import marquez.api.models.JobRunResponse;
 import marquez.api.models.JobsResponse;
 import marquez.api.resources.JobResource;
@@ -335,10 +335,10 @@ public class JobResourceTest {
   private Response insertJob(Job job) {
     JobRequest createJobRequest =
         new JobRequest(
-            job.getLocation(),
-            job.getDescription(),
             job.getInputDataSetUrns(),
-            job.getOutputDataSetUrns());
+            job.getOutputDataSetUrns(),
+            job.getLocation(),
+            job.getDescription());
     String path = format("/api/v1/namespaces/%s/jobs/%s", NAMESPACE_NAME, job.getName());
     return resources
         .client()

--- a/src/test/java/marquez/api/JobResourceTest.java
+++ b/src/test/java/marquez/api/JobResourceTest.java
@@ -333,7 +333,7 @@ public class JobResourceTest {
   }
 
   private Response insertJob(Job job) {
-    JobRequest createJobRequest =
+    JobRequest jobRequest =
         new JobRequest(
             job.getInputDataSetUrns(),
             job.getOutputDataSetUrns(),
@@ -344,11 +344,11 @@ public class JobResourceTest {
         .client()
         .target(path)
         .request(MediaType.APPLICATION_JSON)
-        .put(entity(createJobRequest, javax.ws.rs.core.MediaType.APPLICATION_JSON));
+        .put(entity(jobRequest, javax.ws.rs.core.MediaType.APPLICATION_JSON));
   }
 
   private Response insertJobRun(JobRunResponse jobRun) {
-    CreateJobRunRequest createJobRequest =
+    CreateJobRunRequest jobRequest =
         new CreateJobRunRequest(
             jobRun.getNominalStartTime(), jobRun.getNominalEndTime(), jobRun.getRunArgs());
     String path = format("/api/v1/namespaces/%s/jobs/%s/runs", NAMESPACE_NAME, "somejob");
@@ -356,7 +356,7 @@ public class JobResourceTest {
         .client()
         .target(path)
         .request(MediaType.APPLICATION_JSON)
-        .post(entity(createJobRequest, javax.ws.rs.core.MediaType.APPLICATION_JSON));
+        .post(entity(jobRequest, javax.ws.rs.core.MediaType.APPLICATION_JSON));
   }
 
   private Response markJobRunAsRunning(UUID jobRunId) {

--- a/src/test/java/marquez/api/JobResourceTest.java
+++ b/src/test/java/marquez/api/JobResourceTest.java
@@ -35,7 +35,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import marquez.api.exceptions.ResourceExceptionMapper;
-import marquez.api.models.CreateJobRequest;
+import marquez.api.models.JobRequest;
 import marquez.api.models.CreateJobRunRequest;
 import marquez.api.models.Job;
 import marquez.api.models.JobRunResponse;
@@ -333,8 +333,8 @@ public class JobResourceTest {
   }
 
   private Response insertJob(Job job) {
-    CreateJobRequest createJobRequest =
-        new CreateJobRequest(
+    JobRequest createJobRequest =
+        new JobRequest(
             job.getLocation(),
             job.getDescription(),
             job.getInputDataSetUrns(),


### PR DESCRIPTION
This PR makes the following changes to `CreateJobRequest`:

- Renamed to `JobRequest`
- Explicitly use `@Getter`, `@EqualsAndHashCode` and `@ToString`
- Annotate `JobRequest. description` with `@Nullable`
- Annotate construct with `@JsonCreator` to allow for jackson deserialization
- Add `JobRequest.getDescription()` returning an optional string

**Related issue:** #193