### PR TITLE
Fixes #353 Removed Create* prefix from request payloads

### DIFF
--- a/src/main/java/marquez/api/mappers/NamespaceApiMapper.java
+++ b/src/main/java/marquez/api/mappers/NamespaceApiMapper.java
@@ -16,7 +16,7 @@ package marquez.api.mappers;
 
 import static java.util.Objects.requireNonNull;
 
-import marquez.api.models.CreateNamespaceRequest;
+import marquez.api.models.NamespaceRequest;
 import marquez.api.models.NamespaceResponse;
 import marquez.service.models.Namespace;
 
@@ -27,7 +27,7 @@ public class NamespaceApiMapper extends Mapper<NamespaceResponse, Namespace> {
         null, namespace.getName().toLowerCase(), namespace.getOwner(), namespace.getDescription());
   }
 
-  public Namespace of(String namespaceName, CreateNamespaceRequest request) {
+  public Namespace of(String namespaceName, NamespaceRequest request) {
     return map(
         new NamespaceResponse(namespaceName, null, request.getOwner(), request.getDescription()));
   }

--- a/src/main/java/marquez/api/models/JobRunRequest.java
+++ b/src/main/java/marquez/api/models/JobRunRequest.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public final class CreateJobRunRequest {
+public final class JobRunRequest {
 
   @JsonProperty("nominalStartTime")
   private String nominalStartTime;

--- a/src/main/java/marquez/api/models/NamespaceRequest.java
+++ b/src/main/java/marquez/api/models/NamespaceRequest.java
@@ -22,7 +22,7 @@ import org.hibernate.validator.constraints.NotBlank;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public final class CreateNamespaceRequest {
+public final class NamespaceRequest {
   @NotBlank private String owner;
   private String description;
 }

--- a/src/main/java/marquez/api/resources/JobResource.java
+++ b/src/main/java/marquez/api/resources/JobResource.java
@@ -36,8 +36,8 @@ import marquez.api.exceptions.ResourceException;
 import marquez.api.mappers.ApiJobToCoreJobMapper;
 import marquez.api.mappers.CoreJobRunToApiJobRunResponseMapper;
 import marquez.api.mappers.CoreJobToApiJobMapper;
-import marquez.api.models.CreateJobRunRequest;
 import marquez.api.models.JobRequest;
+import marquez.api.models.JobRunRequest;
 import marquez.api.models.JobsResponse;
 import marquez.service.JobService;
 import marquez.service.NamespaceService;
@@ -144,7 +144,7 @@ public final class JobResource {
   public Response create(
       @PathParam("namespace") final String namespace,
       @PathParam("job") final String job,
-      @Valid final CreateJobRunRequest request)
+      @Valid final JobRunRequest request)
       throws ResourceException {
     try {
       if (!namespaceService.exists(namespace)) {

--- a/src/main/java/marquez/api/resources/NamespaceResource.java
+++ b/src/main/java/marquez/api/resources/NamespaceResource.java
@@ -33,7 +33,7 @@ import marquez.api.exceptions.ResourceException;
 import marquez.api.mappers.CoreNamespaceToApiNamespaceMapper;
 import marquez.api.mappers.NamespaceApiMapper;
 import marquez.api.mappers.NamespaceResponseMapper;
-import marquez.api.models.CreateNamespaceRequest;
+import marquez.api.models.NamespaceRequest;
 import marquez.api.models.NamespaceResponse;
 import marquez.api.models.NamespacesResponse;
 import marquez.service.NamespaceService;
@@ -59,8 +59,7 @@ public final class NamespaceResource {
   @Timed
   @Path("/namespaces/{namespace}")
   public Response create(
-      @PathParam("namespace") @NotBlank String namespaceString,
-      @Valid CreateNamespaceRequest request)
+      @PathParam("namespace") @NotBlank String namespaceString, @Valid NamespaceRequest request)
       throws ResourceException {
     try {
       final Namespace namespace =

--- a/src/test/java/marquez/api/JobIntegrationTest.java
+++ b/src/test/java/marquez/api/JobIntegrationTest.java
@@ -30,9 +30,9 @@ import java.util.UUID;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import marquez.api.models.CreateJobRunRequest;
 import marquez.api.models.Job;
 import marquez.api.models.JobRequest;
+import marquez.api.models.JobRunRequest;
 import marquez.api.models.JobRunResponse;
 import marquez.db.JobDao;
 import marquez.db.JobRunArgsDao;
@@ -124,7 +124,7 @@ public class JobIntegrationTest extends JobRunBaseTest {
   @Test
   public void testJobRunCreationEndToEnd() throws JsonProcessingException {
     Entity createJobRunRequestEntity =
-        Entity.json(MAPPER.writeValueAsString(new CreateJobRunRequest(null, null, JOB_RUN_ARGS)));
+        Entity.json(MAPPER.writeValueAsString(new JobRunRequest(null, null, JOB_RUN_ARGS)));
     final Response res =
         APP.client()
             .target(URI.create("http://localhost:" + APP.getLocalPort()))

--- a/src/test/java/marquez/api/JobResourceTest.java
+++ b/src/test/java/marquez/api/JobResourceTest.java
@@ -35,9 +35,9 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import marquez.api.exceptions.ResourceExceptionMapper;
-import marquez.api.models.CreateJobRunRequest;
 import marquez.api.models.Job;
 import marquez.api.models.JobRequest;
+import marquez.api.models.JobRunRequest;
 import marquez.api.models.JobRunResponse;
 import marquez.api.models.JobsResponse;
 import marquez.api.resources.JobResource;
@@ -348,8 +348,8 @@ public class JobResourceTest {
   }
 
   private Response insertJobRun(JobRunResponse jobRun) {
-    CreateJobRunRequest jobRequest =
-        new CreateJobRunRequest(
+    JobRunRequest jobRequest =
+        new JobRunRequest(
             jobRun.getNominalStartTime(), jobRun.getNominalEndTime(), jobRun.getRunArgs());
     String path = format("/api/v1/namespaces/%s/jobs/%s/runs", NAMESPACE_NAME, "somejob");
     return resources

--- a/src/test/java/marquez/api/NamespaceIntegrationTest.java
+++ b/src/test/java/marquez/api/NamespaceIntegrationTest.java
@@ -22,7 +22,7 @@ import java.sql.Timestamp;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import marquez.api.models.CreateNamespaceRequest;
+import marquez.api.models.NamespaceRequest;
 import marquez.api.models.NamespaceResponse;
 import marquez.api.models.NamespacesResponse;
 import marquez.api.resources.NamespaceBaseTest;
@@ -78,7 +78,7 @@ public class NamespaceIntegrationTest extends NamespaceBaseTest {
             .target(URI.create("http://localhost:" + APP.getLocalPort()))
             .path("/api/v1/namespaces/" + "abc123")
             .request(MediaType.APPLICATION_JSON)
-            .put(Entity.json(new CreateNamespaceRequest(null, "someDesc")));
+            .put(Entity.json(new NamespaceRequest(null, "someDesc")));
     assertEquals(HTTP_UNPROCESSABLE_ENTITY, res.getStatus());
   }
 

--- a/src/test/java/marquez/api/resources/NamespaceBaseTest.java
+++ b/src/test/java/marquez/api/resources/NamespaceBaseTest.java
@@ -18,7 +18,7 @@ import static java.time.Instant.now;
 
 import java.sql.Timestamp;
 import java.util.UUID;
-import marquez.api.models.CreateNamespaceRequest;
+import marquez.api.models.NamespaceRequest;
 import marquez.service.models.Namespace;
 import org.junit.BeforeClass;
 
@@ -32,12 +32,12 @@ public class NamespaceBaseTest {
   public static final Namespace TEST_NAMESPACE =
       new Namespace(NAMESPACE_UUID, START_TIME, NAMESPACE_NAME, OWNER, DESCRIPTION);
 
-  public static CreateNamespaceRequest createNamespaceRequest;
+  public static NamespaceRequest createNamespaceRequest;
 
   public final int HTTP_UNPROCESSABLE_ENTITY = 422;
 
   @BeforeClass
   public static void setup() {
-    createNamespaceRequest = new CreateNamespaceRequest(OWNER, DESCRIPTION);
+    createNamespaceRequest = new NamespaceRequest(OWNER, DESCRIPTION);
   }
 }


### PR DESCRIPTION
Renamed:
1. 'CreateJobRunRequest' class to 'JobRunRequest'
2. 'CreateNamespaceReques' class to 'NamespaceRequest'

Modified all occurrences of the above classes to use new names.