### PR TITLE
Renamed the function in JobRunResponseTest and JobTest

### DIFF
--- a/src/test/java/marquez/api/JobRunResponseTest.java
+++ b/src/test/java/marquez/api/JobRunResponseTest.java
@@ -91,7 +91,7 @@ public class JobRunResponseTest {
   }
 
   @Test
-  public void testJobRunInequalityOnNonIDField() {
+  public void testJobRunInequalityOnNonIdField() {
     JobRunResponse jr2 =
         new JobRunResponse(
             JOB_RUN_UUID,

--- a/src/test/java/marquez/api/JobTest.java
+++ b/src/test/java/marquez/api/JobTest.java
@@ -54,7 +54,7 @@ public class JobTest {
   }
 
   @Test
-  public void testJobInequalityOnNonIDField() {
+  public void testJobInequalityOnNonIdField() {
     Job j2 =
         new Job(
             JOB_NAME,


### PR DESCRIPTION
Fixed the abbreviation in JobTest and JobRunResponseTest in api models by renaming the function names