### PR TITLE
Bump spotless plugin to 3.20.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id 'jacoco'
   id 'java'
   id 'com.adarshr.test-logger' version '1.6.0'
-  id 'com.diffplug.gradle.spotless' version '3.18.0'
+  id 'com.diffplug.gradle.spotless' version '3.20.0'
   id 'com.github.jk1.dependency-license-report' version '1.3'
   id 'com.github.johnrengelman.shadow' version '4.0.4'
   id 'net.researchgate.release' version '2.6.0'


### PR DESCRIPTION
This PR bump the spotless plugin to `3.20.0`

see: https://github.com/diffplug/spotless/blob/master/plugin-gradle/CHANGES.md