### PR TITLE
Bump lombok to 1.18.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   compile 'org.jdbi:jdbi3-sqlobject:3.6.0'
   compile 'org.postgresql:postgresql:42.2.5'
   compileOnly 'org.projectlombok:lombok:1.18.6'
+  annotationProcessor 'org.projectlombok:lombok:1.18.6'
 
   testCompile 'junit:junit:4.12'
   testCompile 'io.dropwizard:dropwizard-testing:1.3.9'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
   compile 'org.jdbi:jdbi3-postgres:3.6.0'
   compile 'org.jdbi:jdbi3-sqlobject:3.6.0'
   compile 'org.postgresql:postgresql:42.2.5'
-  compileOnly 'org.projectlombok:lombok:1.18.4'
+  compileOnly 'org.projectlombok:lombok:1.18.6'
 
   testCompile 'junit:junit:4.12'
   testCompile 'io.dropwizard:dropwizard-testing:1.3.9'


### PR DESCRIPTION
This PR bumps lombok to 1.18.6 

see: https://github.com/rzwitserloot/lombok/blob/master/doc/changelog.markdown

This PR also introduces the use of `annotationProcessor`:
> Declaring annotation processors on a separate configuration improves performance by preserving incremental compilation for tasks that don't require annotation processors.

see: https://blog.gradle.org/incremental-compiler-avoidance#about-annotation-processors