### PR TITLE
Bump mockito-core to 2.25.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   testCompile 'junit:junit:4.12'
   testCompile 'io.dropwizard:dropwizard-testing:1.3.9'
   testCompile 'org.jdbi:jdbi3-testing:3.3.0'
-  testCompile 'org.mockito:mockito-core:2.23.4'
+  testCompile 'org.mockito:mockito-core:2.25.1'
 }
 
 compileJava {


### PR DESCRIPTION
This PR bumps mockito-core to `2.25.1`

see: https://github.com/mockito/mockito/releases/tag/v2.25.1