### PR TITLE
Update NamespaceService and NamespaceDao interface

### DIFF
--- a/src/main/java/marquez/api/resources/DatasetResource.java
+++ b/src/main/java/marquez/api/resources/DatasetResource.java
@@ -63,7 +63,7 @@ public final class DatasetResource {
       @QueryParam("limit") @DefaultValue("100") Integer limit,
       @QueryParam("offset") @DefaultValue("0") Integer offset)
       throws MarquezServiceException, WebApplicationException {
-    if (!namespaceService.exists(namespaceName.getValue())) {
+    if (!namespaceService.exists(namespaceName)) {
       throw new WebApplicationException(
           String.format("The namespace %s does not exist.", namespaceName.getValue()), NOT_FOUND);
     }

--- a/src/main/java/marquez/api/resources/JobResource.java
+++ b/src/main/java/marquez/api/resources/JobResource.java
@@ -73,7 +73,7 @@ public final class JobResource {
       @PathParam("job") JobName jobName,
       @Valid final JobRequest request)
       throws MarquezServiceException {
-    if (!namespaceService.exists(namespaceName.getValue())) {
+    if (!namespaceService.exists(namespaceName)) {
       return Response.status(Response.Status.NOT_FOUND).build();
     }
     final Job jobToCreate =
@@ -85,7 +85,7 @@ public final class JobResource {
                 request.getOutputDatasetUrns(),
                 request.getLocation(),
                 request.getDescription().orElse(null)));
-    jobToCreate.setNamespaceGuid(namespaceService.get(namespaceName.getValue()).get().getGuid());
+    jobToCreate.setNamespaceGuid(namespaceService.get(namespaceName).get().getGuid());
     final Job createdJob = jobService.createJob(namespaceName.getValue(), jobToCreate);
     return Response.status(Response.Status.CREATED)
         .entity(coreJobToApiJobMapper.map(createdJob))
@@ -99,7 +99,7 @@ public final class JobResource {
   public Response getJob(
       @PathParam("namespace") NamespaceName namespaceName, @PathParam("job") final JobName jobName)
       throws MarquezServiceException {
-    if (!namespaceService.exists(namespaceName.getValue())) {
+    if (!namespaceService.exists(namespaceName)) {
       return Response.status(Response.Status.NOT_FOUND).entity("Namespace not found").build();
     }
     final Optional<Job> returnedJob =
@@ -116,7 +116,7 @@ public final class JobResource {
   @Path("/namespaces/{namespace}/jobs")
   public Response listJobs(@PathParam("namespace") NamespaceName namespaceName)
       throws MarquezServiceException {
-    if (!namespaceService.exists(namespaceName.getValue())) {
+    if (!namespaceService.exists(namespaceName)) {
       return Response.status(Response.Status.NOT_FOUND).build();
     }
     final List<Job> jobList = jobService.getAllJobsInNamespace(namespaceName.getValue());
@@ -133,7 +133,7 @@ public final class JobResource {
       @PathParam("job") JobName jobName,
       @Valid final JobRunRequest request)
       throws MarquezServiceException {
-    if (!namespaceService.exists(namespaceName.getValue())) {
+    if (!namespaceService.exists(namespaceName)) {
       return Response.status(Response.Status.NOT_FOUND).build();
     }
     if (!jobService.getJob(namespaceName.getValue(), jobName.getValue()).isPresent()) {

--- a/src/main/java/marquez/api/resources/NamespaceResource.java
+++ b/src/main/java/marquez/api/resources/NamespaceResource.java
@@ -73,7 +73,7 @@ public final class NamespaceResource {
   public Response get(@PathParam("namespace") NamespaceName namespaceName)
       throws MarquezServiceException {
     final Optional<NamespaceResponse> namespaceResponse =
-        namespaceService.get(namespaceName.getValue()).map(NamespaceResponseMapper::map);
+        namespaceService.get(namespaceName).map(NamespaceResponseMapper::map);
     if (namespaceResponse.isPresent()) {
       return Response.ok(namespaceResponse.get()).build();
     } else {
@@ -85,8 +85,8 @@ public final class NamespaceResource {
   @Produces(APPLICATION_JSON)
   @Timed
   @Path("/namespaces")
-  public Response listNamespaces() throws MarquezServiceException {
-    final List<Namespace> namespaces = namespaceService.listNamespaces();
+  public Response list() throws MarquezServiceException {
+    final List<Namespace> namespaces = namespaceService.getAll();
     final List<NamespaceResponse> namespaceResponses =
         coreNamespaceToApiNamespaceMapper.map(namespaces);
     return Response.ok(new NamespacesResponse(namespaceResponses)).build();

--- a/src/main/java/marquez/db/NamespaceDao.java
+++ b/src/main/java/marquez/db/NamespaceDao.java
@@ -32,7 +32,7 @@ public interface NamespaceDao {
           + "ON CONFLICT DO NOTHING")
   void insert(@BindBean Namespace namespace);
 
-  @SqlQuery("SELECT COUNT(*) > 0 FROM namespaces WHERE name = :value")
+  @SqlQuery("SELECT EXISTS (SELECT 1 FROM namespaces WHERE name = :value)")
   boolean exists(@BindBean NamespaceName namespaceName);
 
   @SqlQuery("SELECT * FROM namespaces WHERE name = :value")

--- a/src/main/java/marquez/db/NamespaceDao.java
+++ b/src/main/java/marquez/db/NamespaceDao.java
@@ -15,6 +15,8 @@
 package marquez.db;
 
 import java.util.List;
+import java.util.Optional;
+import marquez.common.models.NamespaceName;
 import marquez.db.mappers.NamespaceRowMapper;
 import marquez.service.models.Namespace;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
@@ -30,12 +32,12 @@ public interface NamespaceDao {
           + "ON CONFLICT DO NOTHING")
   void insert(@BindBean Namespace namespace);
 
-  @SqlQuery("SELECT * FROM namespaces WHERE name = :name")
-  Namespace find(String name);
+  @SqlQuery("SELECT COUNT(*) > 0 FROM namespaces WHERE name = :value")
+  boolean exists(@BindBean NamespaceName namespaceName);
+
+  @SqlQuery("SELECT * FROM namespaces WHERE name = :value")
+  Optional<Namespace> findBy(@BindBean NamespaceName namespaceName);
 
   @SqlQuery("SELECT * FROM namespaces")
   List<Namespace> findAll();
-
-  @SqlQuery("SELECT COUNT(*) > 0 FROM namespaces WHERE name = :name")
-  boolean exists(String name);
 }

--- a/src/test/java/marquez/api/JobResourceTest.java
+++ b/src/test/java/marquez/api/JobResourceTest.java
@@ -41,6 +41,7 @@ import marquez.api.models.JobRunRequest;
 import marquez.api.models.JobRunResponse;
 import marquez.api.models.JobsResponse;
 import marquez.api.resources.JobResource;
+import marquez.common.models.NamespaceName;
 import marquez.service.JobService;
 import marquez.service.NamespaceService;
 import marquez.service.exceptions.MarquezServiceException;
@@ -56,7 +57,7 @@ public class JobResourceTest {
   private static final NamespaceService MOCK_NAMESPACE_SERVICE = mock(NamespaceService.class);
   private static final JobResource JOB_RESOURCE =
       new JobResource(MOCK_NAMESPACE_SERVICE, MOCK_JOB_SERVICE);
-  private static final String NAMESPACE_NAME = "someNamespace";
+  private static final NamespaceName NAMESPACE_NAME = NamespaceName.fromString("test");
   private static final Entity<?> EMPTY_PUT_BODY = Entity.json("");
 
   final int UNPROCESSABLE_ENTRY_STATUS_CODE = 422;
@@ -147,7 +148,7 @@ public class JobResourceTest {
 
     when(MOCK_JOB_SERVICE.getJob(any(), any())).thenReturn(Optional.empty());
 
-    String path = format("/api/v1/namespaces/%s/jobs/%s", NAMESPACE_NAME, "nosuchjob");
+    String path = format("/api/v1/namespaces/%s/jobs/%s", NAMESPACE_NAME.getValue(), "nosuchjob");
     Response res = resources.client().target(path).request(MediaType.APPLICATION_JSON).get();
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), res.getStatus());
   }
@@ -165,7 +166,7 @@ public class JobResourceTest {
     when(MOCK_NAMESPACE_SERVICE.exists(NAMESPACE_NAME)).thenReturn(false);
     when(MOCK_NAMESPACE_SERVICE.get(any())).thenReturn(Optional.empty());
 
-    String path = format("/api/v1/namespaces/%s/jobs/", NAMESPACE_NAME);
+    String path = format("/api/v1/namespaces/%s/jobs", NAMESPACE_NAME.getValue());
     Response res = resources.client().target(path).request(MediaType.APPLICATION_JSON).get();
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), res.getStatus());
   }
@@ -173,10 +174,10 @@ public class JobResourceTest {
   @Test
   public void testGetAllJobsInNamespaceErrorHandling() throws MarquezServiceException {
     when(MOCK_NAMESPACE_SERVICE.exists(NAMESPACE_NAME)).thenReturn(true);
-    when(MOCK_JOB_SERVICE.getAllJobsInNamespace(NAMESPACE_NAME))
+    when(MOCK_JOB_SERVICE.getAllJobsInNamespace(NAMESPACE_NAME.getValue()))
         .thenThrow(new MarquezServiceException());
 
-    String path = format("/api/v1/namespaces/%s/jobs/", NAMESPACE_NAME);
+    String path = format("/api/v1/namespaces/%s/jobs", NAMESPACE_NAME.getValue());
     Response res = resources.client().target(path).request(MediaType.APPLICATION_JSON).get();
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), res.getStatus());
   }
@@ -188,9 +189,9 @@ public class JobResourceTest {
     List<marquez.service.models.Job> jobsList = Arrays.asList(job1, job2);
 
     when(MOCK_NAMESPACE_SERVICE.exists(NAMESPACE_NAME)).thenReturn(true);
-    when(MOCK_JOB_SERVICE.getAllJobsInNamespace(NAMESPACE_NAME)).thenReturn(jobsList);
+    when(MOCK_JOB_SERVICE.getAllJobsInNamespace(NAMESPACE_NAME.getValue())).thenReturn(jobsList);
 
-    String path = format("/api/v1/namespaces/%s/jobs/", NAMESPACE_NAME);
+    String path = format("/api/v1/namespaces/%s/jobs", NAMESPACE_NAME.getValue());
     Response res = resources.client().target(path).request(MediaType.APPLICATION_JSON).get();
     assertEquals(Response.Status.OK.getStatusCode(), res.getStatus());
     List<JobResponse> returnedJobs = res.readEntity(JobsResponse.class).getJobs();
@@ -323,12 +324,12 @@ public class JobResourceTest {
   }
 
   private Response getJobRun(String jobRunId) {
-    String path = format("/api/v1/jobs/runs/%s", NAMESPACE_NAME, jobRunId);
+    String path = format("/api/v1/jobs/runs/%s", NAMESPACE_NAME.getValue(), jobRunId);
     return resources.client().target(path).request(MediaType.APPLICATION_JSON).get();
   }
 
   private Response getJob(String jobName) {
-    String path = format("/api/v1/namespaces/%s/jobs/%s", NAMESPACE_NAME, jobName);
+    String path = format("/api/v1/namespaces/%s/jobs/%s", NAMESPACE_NAME.getValue(), jobName);
     return resources.client().target(path).request(MediaType.APPLICATION_JSON).get();
   }
 
@@ -339,7 +340,7 @@ public class JobResourceTest {
             job.getOutputDatasetUrns(),
             job.getLocation(),
             job.getDescription());
-    String path = format("/api/v1/namespaces/%s/jobs/%s", NAMESPACE_NAME, job.getName());
+    String path = format("/api/v1/namespaces/%s/jobs/%s", NAMESPACE_NAME.getValue(), job.getName());
     return resources
         .client()
         .target(path)
@@ -351,7 +352,8 @@ public class JobResourceTest {
     JobRunRequest jobRequest =
         new JobRunRequest(
             jobRun.getNominalStartTime(), jobRun.getNominalEndTime(), jobRun.getRunArgs());
-    String path = format("/api/v1/namespaces/%s/jobs/%s/runs", NAMESPACE_NAME, "somejob");
+    String path =
+        format("/api/v1/namespaces/%s/jobs/%s/runs", NAMESPACE_NAME.getValue(), "somejob");
     return resources
         .client()
         .target(path)

--- a/src/test/java/marquez/api/resources/DatasetResourceTest.java
+++ b/src/test/java/marquez/api/resources/DatasetResourceTest.java
@@ -64,7 +64,7 @@ public class DatasetResourceTest {
 
   @Test
   public void testListDatasets200() throws MarquezServiceException {
-    when(mockNamespaceService.exists(NAMESPACE_NAME.getValue())).thenReturn(true);
+    when(mockNamespaceService.exists(NAMESPACE_NAME)).thenReturn(true);
 
     final Dataset dataset = new Dataset(DATASET_URN, CREATED_AT, NO_DESCRIPTION);
     final List<Dataset> datasets = Arrays.asList(dataset);
@@ -84,7 +84,7 @@ public class DatasetResourceTest {
 
   @Test(expected = WebApplicationException.class)
   public void testListDatasetsNamespaceDoesNotExist() throws MarquezServiceException {
-    when(mockNamespaceService.exists(NAMESPACE_NAME.getValue())).thenReturn(false);
+    when(mockNamespaceService.exists(NAMESPACE_NAME)).thenReturn(false);
 
     datasetResource.list(NAMESPACE_NAME, LIMIT, OFFSET);
   }

--- a/src/test/java/marquez/api/resources/NamespaceResourceTest.java
+++ b/src/test/java/marquez/api/resources/NamespaceResourceTest.java
@@ -81,7 +81,7 @@ public class NamespaceResourceTest extends NamespaceBaseTest {
     NamespaceService namespaceService = mock(NamespaceService.class);
     NamespaceResource namespaceResource = new NamespaceResource(namespaceService);
 
-    when(namespaceService.get(NAMESPACE_NAME)).thenReturn(returnedOptionalNamespace);
+    when(namespaceService.get(namespaceName)).thenReturn(returnedOptionalNamespace);
     Response res = namespaceResource.get(namespaceName);
     NamespaceResponse responseBody = (NamespaceResponse) res.getEntity();
 
@@ -106,9 +106,9 @@ public class NamespaceResourceTest extends NamespaceBaseTest {
     final List<Namespace> existingCoreModelNamespaces = Collections.singletonList(TEST_NAMESPACE);
     NamespaceService namespaceService = mock(NamespaceService.class);
     NamespaceResource namespaceResource = new NamespaceResource(namespaceService);
-    when(namespaceService.listNamespaces()).thenReturn(existingCoreModelNamespaces);
+    when(namespaceService.getAll()).thenReturn(existingCoreModelNamespaces);
 
-    Response res = namespaceResource.listNamespaces();
+    Response res = namespaceResource.list();
     NamespacesResponse responseBody = (NamespacesResponse) res.getEntity();
 
     NamespaceResponse expectedApiNamespace = namespaceMapper.map(TEST_NAMESPACE);
@@ -122,8 +122,8 @@ public class NamespaceResourceTest extends NamespaceBaseTest {
     NamespaceService namespaceService = mock(NamespaceService.class);
     NamespaceResource namespaceResource = new NamespaceResource(namespaceService);
 
-    when(namespaceService.listNamespaces()).thenReturn(existingNamespaces);
-    Response res = namespaceResource.listNamespaces();
+    when(namespaceService.getAll()).thenReturn(existingNamespaces);
+    Response res = namespaceResource.list();
 
     NamespacesResponse responseBody = (NamespacesResponse) res.getEntity();
     NamespaceResponse nsResponseFromList = responseBody.getNamespaces().get(0);
@@ -148,9 +148,9 @@ public class NamespaceResourceTest extends NamespaceBaseTest {
             "a second ns for testing");
     existingCoreModelNamespaces.add(TEST_NAMESPACE);
     existingCoreModelNamespaces.add(secondNamespace);
-    when(namespaceService.listNamespaces()).thenReturn(existingCoreModelNamespaces);
+    when(namespaceService.getAll()).thenReturn(existingCoreModelNamespaces);
 
-    Response res = namespaceResource.listNamespaces();
+    Response res = namespaceResource.list();
     NamespacesResponse responseBody = (NamespacesResponse) res.getEntity();
     NamespaceResponse nsResponse = namespaceMapper.map(TEST_NAMESPACE);
     NamespaceResponse secondNsResponse = namespaceMapper.map(secondNamespace);
@@ -160,7 +160,7 @@ public class NamespaceResourceTest extends NamespaceBaseTest {
 
   @Test
   public void testListNamespacesErrorHandling() throws MarquezServiceException {
-    doThrow(new MarquezServiceException()).when(NAMESPACE_SERVICE).listNamespaces();
+    doThrow(new MarquezServiceException()).when(NAMESPACE_SERVICE).getAll();
 
     assertEquals(
         Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),

--- a/src/test/java/marquez/db/NamespaceDaoTest.java
+++ b/src/test/java/marquez/db/NamespaceDaoTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import marquez.common.models.NamespaceName;
 import marquez.db.fixtures.AppWithPostgresRule;
 import marquez.service.models.Generator;
 import marquez.service.models.Namespace;
@@ -61,15 +62,18 @@ public class NamespaceDaoTest {
                   namespace.getDescription(),
                   namespace.getOwnerName());
             });
-    assertFieldsMatchExceptTS(namespace, namespaceDao.find(namespace.getName()));
-    assertEquals(null, namespaceDao.find("nonexistent_namespace"));
+    assertFieldsMatchExceptTS(
+        namespace, namespaceDao.findBy(NamespaceName.fromString(namespace.getName())).get());
+    assertEquals(
+        null, namespaceDao.findBy(NamespaceName.fromString("nonexistent_namespace")).orElse(null));
   }
 
   @Test
   public void testInsert() {
     Namespace newNs = Generator.genNamespace();
     namespaceDao.insert(newNs);
-    assertFieldsMatchExceptTS(newNs, namespaceDao.find(newNs.getName()));
+    assertFieldsMatchExceptTS(
+        newNs, namespaceDao.findBy(NamespaceName.fromString(newNs.getName())).get());
   }
 
   @Test
@@ -89,10 +93,12 @@ public class NamespaceDaoTest {
 
   @Test
   public void testExists() {
-    Namespace nonexistentNs = Generator.genNamespace();
-    assertFalse(namespaceDao.exists(nonexistentNs.getName()));
-    Namespace existingNs = Generator.genNamespace();
-    namespaceDao.insert(existingNs);
-    assertTrue(namespaceDao.exists(existingNs.getName()));
+    final Namespace newNamespace = Generator.genNamespace();
+    final NamespaceName found = NamespaceName.fromString(newNamespace.getName());
+    namespaceDao.insert(newNamespace);
+    assertTrue(namespaceDao.exists(found));
+
+    final NamespaceName notFound = NamespaceName.fromString("test");
+    assertFalse(namespaceDao.exists(notFound));
   }
 }


### PR DESCRIPTION
This PR introduces the following changes:

- Use `NamespaceName` type as param in `NamespaceService`
- Use `NamespaceName` type as param in `NamespaceDao`
- Rename `NamespaceResource.listNamespaces()` **=>** `NamespaceResource.list()`
- Rename `NamespaceService.listNamespaces()` **=>** `NamespaceService.getAll()`
- Rename `NamespaceDao.find()` **=>** `NamespaceDao.findBy()`
- Add `NamespaceDao.exists()`