### PR TITLE
Refactor datasource models and mappers

### DIFF
--- a/src/main/java/marquez/api/models/DatasourceResponse.java
+++ b/src/main/java/marquez/api/models/DatasourceResponse.java
@@ -14,19 +14,29 @@
 
 package marquez.api.models;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import lombok.AllArgsConstructor;
+import static marquez.common.Preconditions.checkNotBlank;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
 
-@AllArgsConstructor(onConstructor = @__(@JsonCreator))
 @EqualsAndHashCode
 @ToString
-public class DatasourceResponse {
-  @Getter @NonNull private final String name;
-  @Getter @NonNull private final String createdAt;
-  @Getter @NonNull private final String urn;
-  @Getter @NonNull private final String connectionUrl;
+public final class DatasourceResponse {
+  @Getter private final String name;
+  @Getter private final String createdAt;
+  @Getter private final String urn;
+  @Getter private final String connectionUrl;
+
+  public DatasourceResponse(
+      @NonNull final String name,
+      @NonNull final String createdAt,
+      @NonNull final String urn,
+      @NonNull final String connectionUrl) {
+    this.name = checkNotBlank(name);
+    this.createdAt = checkNotBlank(createdAt);
+    this.urn = checkNotBlank(urn);
+    this.connectionUrl = checkNotBlank(connectionUrl);
+  }
 }

--- a/src/main/java/marquez/api/models/DatasourcesResponse.java
+++ b/src/main/java/marquez/api/models/DatasourcesResponse.java
@@ -15,10 +15,10 @@
 package marquez.api.models;
 
 import java.util.List;
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
-@Data
-public class DatasourcesResponse {
+@Value
+public final class DatasourcesResponse {
   @NonNull private final List<DatasourceResponse> datasources;
 }

--- a/src/main/java/marquez/api/models/DatasourcesResponse.java
+++ b/src/main/java/marquez/api/models/DatasourcesResponse.java
@@ -14,16 +14,11 @@
 
 package marquez.api.models;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.Data;
+import lombok.NonNull;
 
-@AllArgsConstructor(onConstructor = @__(@JsonCreator))
-@EqualsAndHashCode
-@ToString
+@Data
 public class DatasourcesResponse {
-  @Getter private final List<DatasourceResponse> datasources;
+  @NonNull private final List<DatasourceResponse> datasources;
 }

--- a/src/main/java/marquez/db/mappers/DatasourceRowMapper.java
+++ b/src/main/java/marquez/db/mappers/DatasourceRowMapper.java
@@ -14,9 +14,12 @@
 
 package marquez.db.mappers;
 
+import static marquez.db.Columns.stringOrThrow;
+import static marquez.db.Columns.timestampOrThrow;
+import static marquez.db.Columns.uuidOrThrow;
+
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.UUID;
 import lombok.NonNull;
 import marquez.db.Columns;
 import marquez.db.models.DatasourceRow;
@@ -28,11 +31,11 @@ public final class DatasourceRowMapper implements RowMapper<DatasourceRow> {
   public DatasourceRow map(@NonNull ResultSet results, @NonNull StatementContext context)
       throws SQLException {
     return DatasourceRow.builder()
-        .uuid(results.getObject(Columns.ROW_UUID, UUID.class))
-        .urn(results.getString(Columns.URN))
-        .createdAt(results.getTimestamp(Columns.CREATED_AT).toInstant())
-        .name(results.getString(Columns.NAME))
-        .connectionUrl(results.getString(Columns.CONNECTION_URL))
+        .uuid(uuidOrThrow(results, Columns.ROW_UUID))
+        .createdAt(timestampOrThrow(results, Columns.CREATED_AT))
+        .name(stringOrThrow(results, Columns.NAME))
+        .urn(stringOrThrow(results, Columns.URN))
+        .connectionUrl(stringOrThrow(results, Columns.CONNECTION_URL))
         .build();
   }
 }

--- a/src/main/java/marquez/db/models/DatasourceRow.java
+++ b/src/main/java/marquez/db/models/DatasourceRow.java
@@ -15,28 +15,16 @@
 package marquez.db.models;
 
 import java.time.Instant;
-import java.util.Optional;
 import java.util.UUID;
-import javax.annotation.Nullable;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
+import lombok.Data;
 
-@RequiredArgsConstructor
-@EqualsAndHashCode
-@ToString
+@Data
 @Builder
 public final class DatasourceRow {
-  @Getter @NonNull private final UUID uuid;
-  @Getter @NonNull private final String urn;
-  @Getter @NonNull private final String name;
-  @Getter @NonNull private final String connectionUrl;
-  @Nullable private final Instant createdAt;
-
-  public Optional<Instant> getCreatedAt() {
-    return Optional.ofNullable(createdAt);
-  }
+  private UUID uuid;
+  private Instant createdAt;
+  private String name;
+  private String urn;
+  private String connectionUrl;
 }

--- a/src/main/java/marquez/service/mappers/DatasourceMapper.java
+++ b/src/main/java/marquez/service/mappers/DatasourceMapper.java
@@ -14,9 +14,9 @@
 
 package marquez.service.mappers;
 
+import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
 
-import java.util.Collections;
 import java.util.List;
 import lombok.NonNull;
 import marquez.common.models.ConnectionUrl;
@@ -25,22 +25,19 @@ import marquez.common.models.DatasourceUrn;
 import marquez.db.models.DatasourceRow;
 import marquez.service.models.Datasource;
 
-public class DatasourceMapper {
+public final class DatasourceMapper {
   private DatasourceMapper() {}
 
-  public static Datasource map(@NonNull DatasourceRow datasourceRow) {
-    final DatasourceName datasourceName = DatasourceName.fromString(datasourceRow.getName());
-    final ConnectionUrl connectionUrl = ConnectionUrl.fromString(datasourceRow.getConnectionUrl());
-    final DatasourceUrn datasourceUrn = DatasourceUrn.from(connectionUrl, datasourceName);
-    return new Datasource(
-        datasourceName,
-        datasourceRow.getCreatedAt().get(),
-        datasourceUrn,
-        ConnectionUrl.fromString(datasourceRow.getConnectionUrl()));
+  public static Datasource map(@NonNull DatasourceRow row) {
+    return Datasource.builder()
+        .name(DatasourceName.fromString(row.getName()))
+        .createdAt(row.getCreatedAt())
+        .urn(DatasourceUrn.fromString(row.getUrn()))
+        .connectionUrl(ConnectionUrl.fromString(row.getConnectionUrl()))
+        .build();
   }
 
-  public static List<Datasource> map(@NonNull List<DatasourceRow> datasourceRows) {
-    return Collections.unmodifiableList(
-        datasourceRows.stream().map(datasourceRow -> map(datasourceRow)).collect(toList()));
+  public static List<Datasource> map(@NonNull List<DatasourceRow> rows) {
+    return unmodifiableList(rows.stream().map(row -> map(row)).collect(toList()));
   }
 }

--- a/src/main/java/marquez/service/models/Datasource.java
+++ b/src/main/java/marquez/service/models/Datasource.java
@@ -15,21 +15,17 @@
 package marquez.service.models;
 
 import java.time.Instant;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
+import lombok.Builder;
+import lombok.Data;
 import marquez.common.models.ConnectionUrl;
 import marquez.common.models.DatasourceName;
 import marquez.common.models.DatasourceUrn;
 
-@RequiredArgsConstructor
-@EqualsAndHashCode
-@ToString
-public class Datasource {
-  @Getter @NonNull private final DatasourceName name;
-  @Getter @NonNull private final Instant createdAt;
-  @Getter @NonNull private final DatasourceUrn urn;
-  @Getter @NonNull private final ConnectionUrl connectionUrl;
+@Data
+@Builder
+public final class Datasource {
+  private DatasourceName name;
+  private Instant createdAt;
+  private DatasourceUrn urn;
+  private ConnectionUrl connectionUrl;
 }

--- a/src/test/java/marquez/api/mappers/DatasourceResponseMapperTest.java
+++ b/src/test/java/marquez/api/mappers/DatasourceResponseMapperTest.java
@@ -57,8 +57,8 @@ public class DatasourceResponseMapperTest {
 
   @Test
   public void testMap_throwsException_onNullDatasources() {
-    final List<Datasource> datasources = null;
-    assertThatNullPointerException().isThrownBy(() -> DatasourceResponseMapper.map(datasources));
+    final List<Datasource> nullDatasources = null;
+    assertThatNullPointerException().isThrownBy(() -> DatasourceResponseMapper.map(nullDatasources));
   }
 
   @Test
@@ -81,8 +81,8 @@ public class DatasourceResponseMapperTest {
 
   @Test
   public void testToDatasourcesResponse_throwsException_onNullDatasources() {
-    final List<Datasource> datasources = null;
+    final List<Datasource> nullDatasources = null;
     assertThatNullPointerException()
-        .isThrownBy(() -> DatasourceResponseMapper.toDatasourcesResponse(datasources));
+        .isThrownBy(() -> DatasourceResponseMapper.toDatasourcesResponse(nullDatasources));
   }
 }

--- a/src/test/java/marquez/api/mappers/DatasourceResponseMapperTest.java
+++ b/src/test/java/marquez/api/mappers/DatasourceResponseMapperTest.java
@@ -14,96 +14,75 @@
 
 package marquez.api.mappers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static marquez.service.models.ServiceModelGenerator.newDatasource;
+import static marquez.service.models.ServiceModelGenerator.newDatasources;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
-import java.time.Instant;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import marquez.UnitTests;
 import marquez.api.models.DatasourceResponse;
-import marquez.common.models.ConnectionUrl;
-import marquez.common.models.DatasourceName;
-import marquez.common.models.DatasourceUrn;
+import marquez.api.models.DatasourcesResponse;
 import marquez.service.models.Datasource;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(UnitTests.class)
 public class DatasourceResponseMapperTest {
-  private static final DatasourceName NAME = DatasourceName.fromString("datasource_name");
-  private static final Instant CREATED_AT = Instant.now();
-
-  private static final ConnectionUrl CONNECTION_URL =
-      ConnectionUrl.fromString("jdbc:postgresql://localhost:5431/novelists_");
-
-  private static final DatasourceUrn DATASOURCE_URN = DatasourceUrn.from(CONNECTION_URL, NAME);
-  private static final Datasource DATASOURCE =
-      new Datasource(NAME, CREATED_AT, DATASOURCE_URN, CONNECTION_URL);
-
   @Test
-  public void testMapDatasource() {
-
-    final DatasourceResponse datasourceResponse = DatasourceResponseMapper.map(DATASOURCE);
-    assertNotNull(datasourceResponse);
-    assertEquals(NAME.getValue(), datasourceResponse.getName());
-    assertEquals(CREATED_AT.toString(), datasourceResponse.getCreatedAt());
-    assertEquals(DATASOURCE_URN.getValue(), datasourceResponse.getUrn());
-    assertEquals(CONNECTION_URL.getRawValue(), datasourceResponse.getConnectionUrl());
+  public void testMap_datasource() {
+    final Datasource datasource = newDatasource();
+    final DatasourceResponse response = DatasourceResponseMapper.map(datasource);
+    assertThat(response).isNotNull();
+    assertThat(datasource.getName().getValue()).isEqualTo(response.getName());
+    assertThat(datasource.getCreatedAt().toString()).isEqualTo(response.getCreatedAt());
+    assertThat(datasource.getUrn().getValue()).isEqualTo(response.getUrn());
+    assertThat(datasource.getConnectionUrl().getRawValue()).isEqualTo(response.getConnectionUrl());
   }
 
-  @Test(expected = NullPointerException.class)
-  public void testMapNullDatasource() {
+  @Test
+  public void testMap_throwsException_onNullDatasource() {
     final Datasource nulldatasource = null;
-    DatasourceResponseMapper.map(nulldatasource);
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testDatasourceResponseNameMissing() {
-    final DatasourceName nullDatasourceName = null;
-
-    final Datasource nullNameDatasource = mock(Datasource.class);
-    when(nullNameDatasource.getConnectionUrl()).thenReturn(CONNECTION_URL);
-    when(nullNameDatasource.getUrn()).thenReturn(DATASOURCE_URN);
-    when(nullNameDatasource.getCreatedAt()).thenReturn(CREATED_AT);
-
-    when(nullNameDatasource.getName()).thenReturn(nullDatasourceName);
-
-    DatasourceResponseMapper.map(nullNameDatasource);
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testDatasourceResponseUrnMissing() {
-    final DatasourceUrn nullDatasourceUrn = null;
-
-    final Datasource nullNameDatasource = mock(Datasource.class);
-    when(nullNameDatasource.getName()).thenReturn(NAME);
-    when(nullNameDatasource.getConnectionUrl()).thenReturn(CONNECTION_URL);
-    when(nullNameDatasource.getCreatedAt()).thenReturn(CREATED_AT);
-
-    when(nullNameDatasource.getUrn()).thenReturn(nullDatasourceUrn);
-
-    DatasourceResponseMapper.map(nullNameDatasource);
+    assertThatNullPointerException().isThrownBy(() -> DatasourceResponseMapper.map(nulldatasource));
   }
 
   @Test
-  public void testMapDatasourceList() {
-    final List<Datasource> datasources = Arrays.asList(DATASOURCE);
-    final List<DatasourceResponse> datasourceResponses = DatasourceResponseMapper.map(datasources);
-    assertNotNull(datasourceResponses);
-    assertEquals(1, datasourceResponses.size());
+  public void testMap_datasources() {
+    final List<Datasource> datasources = newDatasources(4);
+    final List<DatasourceResponse> responses = DatasourceResponseMapper.map(datasources);
+    assertThat(responses).isNotNull();
+    assertThat(responses).hasSize(4);
   }
 
   @Test
-  public void testMapEmptyDatasourceList() {
-    final List<Datasource> datasources = Arrays.asList();
-    final List<DatasourceResponse> datasourceResponses = DatasourceResponseMapper.map(datasources);
-    assertNotNull(datasourceResponses);
-    assertEquals(0, datasourceResponses.size());
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testMapNullDatasourceList() {
+  public void testMap_throwsException_onNullDatasources() {
     final List<Datasource> datasources = null;
-    DatasourceResponseMapper.map(datasources);
+    assertThatNullPointerException().isThrownBy(() -> DatasourceResponseMapper.map(datasources));
+  }
+
+  @Test
+  public void testToDatasourcesResponse() {
+    final List<Datasource> datasources = newDatasources(4);
+    final DatasourcesResponse response =
+        DatasourceResponseMapper.toDatasourcesResponse(datasources);
+    assertThat(response).isNotNull();
+    assertThat(response.getDatasources()).hasSize(4);
+  }
+
+  @Test
+  public void testToDatasourcesResponse_emptyDatasources() {
+    final List<Datasource> emptyDatasources = Collections.emptyList();
+    final DatasourcesResponse response =
+        DatasourceResponseMapper.toDatasourcesResponse(emptyDatasources);
+    assertThat(response).isNotNull();
+    assertThat(response.getDatasources()).isEmpty();
+  }
+
+  @Test
+  public void testToDatasourcesResponse_throwsException_onNullDatasources() {
+    final List<Datasource> datasources = null;
+    assertThatNullPointerException()
+        .isThrownBy(() -> DatasourceResponseMapper.toDatasourcesResponse(datasources));
   }
 }

--- a/src/test/java/marquez/api/mappers/DatasourceResponseMapperTest.java
+++ b/src/test/java/marquez/api/mappers/DatasourceResponseMapperTest.java
@@ -56,6 +56,14 @@ public class DatasourceResponseMapperTest {
   }
 
   @Test
+  public void testMap_emptyDatasources() {
+    final List<Datasource> emptyDatasources = Collections.emptyList();
+    final List<DatasourceResponse> emptyResponses = DatasourceResponseMapper.map(emptyDatasources);
+    assertThat(emptyResponses).isNotNull();
+    assertThat(emptyResponses).isEmpty();
+  }
+
+  @Test
   public void testMap_throwsException_onNullDatasources() {
     final List<Datasource> nullDatasources = null;
     assertThatNullPointerException()

--- a/src/test/java/marquez/api/mappers/DatasourceResponseMapperTest.java
+++ b/src/test/java/marquez/api/mappers/DatasourceResponseMapperTest.java
@@ -58,7 +58,8 @@ public class DatasourceResponseMapperTest {
   @Test
   public void testMap_throwsException_onNullDatasources() {
     final List<Datasource> nullDatasources = null;
-    assertThatNullPointerException().isThrownBy(() -> DatasourceResponseMapper.map(nullDatasources));
+    assertThatNullPointerException()
+        .isThrownBy(() -> DatasourceResponseMapper.map(nullDatasources));
   }
 
   @Test

--- a/src/test/java/marquez/api/resources/DatasourceResourceTest.java
+++ b/src/test/java/marquez/api/resources/DatasourceResourceTest.java
@@ -145,7 +145,12 @@ public class DatasourceResourceTest {
     final DatasourceUrn datasourceUrn = DatasourceUrn.from(connectionUrl, datasourceName);
 
     final Datasource ds1 =
-        new Datasource(datasourceName, Instant.now(), datasourceUrn, connectionUrl);
+        Datasource.builder()
+            .name(datasourceName)
+            .createdAt(Instant.now())
+            .urn(datasourceUrn)
+            .connectionUrl(connectionUrl)
+            .build();
     when(mockDatasourceService.get(datasourceUrn)).thenReturn(Optional.of(ds1));
 
     final Response datasourceResourceResponse = datasourceResource.get(datasourceUrn);
@@ -181,7 +186,12 @@ public class DatasourceResourceTest {
     final DatasourceUrn datasourceUrn = DatasourceUrn.from(connectionUrl, datasourceName);
 
     final Datasource ds1 =
-        new Datasource(datasourceName, Instant.now(), datasourceUrn, connectionUrl);
+        Datasource.builder()
+            .name(datasourceName)
+            .createdAt(Instant.now())
+            .urn(datasourceUrn)
+            .connectionUrl(connectionUrl)
+            .build();
     when(mockDatasourceService.get(ds1.getUrn())).thenThrow(MarquezServiceException.class);
     datasourceResource.get(ds1.getUrn());
   }

--- a/src/test/java/marquez/common/models/CommonModelGenerator.java
+++ b/src/test/java/marquez/common/models/CommonModelGenerator.java
@@ -58,6 +58,10 @@ public final class CommonModelGenerator {
     return DatasourceUrn.from(type, newDatasourceName());
   }
 
+  public static DatasourceUrn newDatasourceUrnWith(DatasourceType type, DatasourceName name) {
+    return DatasourceUrn.from(type, name);
+  }
+
   public static DatasourceUrn newDatasourceUrnWith(String value) {
     return DatasourceUrn.fromString(value);
   }

--- a/src/test/java/marquez/db/DatasourceDaoTest.java
+++ b/src/test/java/marquez/db/DatasourceDaoTest.java
@@ -62,7 +62,7 @@ public class DatasourceDaoTest {
     final DatasourceRow row = returnedRow.get();
     assertThat(row.getConnectionUrl()).isEqualTo(datasourceRow.getConnectionUrl());
     assertThat(row.getName()).isEqualTo(datasourceRow.getName());
-    assertThat(row.getCreatedAt()).isPresent();
+    assertThat(row.getCreatedAt()).isNotNull();
   }
 
   @Test

--- a/src/test/java/marquez/db/mappers/DatasourceRowMapperTest.java
+++ b/src/test/java/marquez/db/mappers/DatasourceRowMapperTest.java
@@ -73,11 +73,11 @@ public class DatasourceRowMapperTest {
   }
 
   @Test(expected = NullPointerException.class)
-  public void testMap_throwsException_onNullResultSet() throws SQLException {
-    final ResultSet nullResultSet = null;
+  public void testMap_throwsException_onNullResults() throws SQLException {
+    final ResultSet nullResults = null;
     final StatementContext context = mock(StatementContext.class);
     final DatasourceRowMapper rowMapper = new DatasourceRowMapper();
-    rowMapper.map(nullResultSet, context);
+    rowMapper.map(nullResults, context);
   }
 
   @Test(expected = NullPointerException.class)

--- a/src/test/java/marquez/db/mappers/DatasourceRowMapperTest.java
+++ b/src/test/java/marquez/db/mappers/DatasourceRowMapperTest.java
@@ -51,8 +51,8 @@ public class DatasourceRowMapperTest {
     when(results.getObject(Columns.ROW_UUID, UUID.class)).thenReturn(ROW_UUID);
     when(results.getTimestamp(Columns.CREATED_AT)).thenReturn(Timestamp.from(CREATED_AT));
     when(results.getString(Columns.NAME)).thenReturn(NAME.getValue());
-    when(results.getString(Columns.CONNECTION_URL)).thenReturn(CONNECTION_URL.getRawValue());
     when(results.getString(Columns.URN)).thenReturn(URN.getValue());
+    when(results.getString(Columns.CONNECTION_URL)).thenReturn(CONNECTION_URL.getRawValue());
     final StatementContext context = mock(StatementContext.class);
 
     final DatasourceRowMapper rowMapper = new DatasourceRowMapper();
@@ -66,10 +66,10 @@ public class DatasourceRowMapperTest {
 
   @Test(expected = NullPointerException.class)
   public void testMap_throwsException_onNullResultSet() throws SQLException {
-    final ResultSet nullResults = null;
+    final ResultSet nullResultSet = null;
     final StatementContext context = mock(StatementContext.class);
     final DatasourceRowMapper rowMapper = new DatasourceRowMapper();
-    rowMapper.map(nullResults, context);
+    rowMapper.map(nullResultSet, context);
   }
 
   @Test(expected = NullPointerException.class)

--- a/src/test/java/marquez/db/mappers/DatasourceRowMapperTest.java
+++ b/src/test/java/marquez/db/mappers/DatasourceRowMapperTest.java
@@ -47,12 +47,20 @@ public class DatasourceRowMapperTest {
 
   @Test
   public void testMap() throws SQLException {
+    final Object exists = mock(Object.class);
     final ResultSet results = mock(ResultSet.class);
+    when(results.getObject(Columns.ROW_UUID)).thenReturn(exists);
+    when(results.getObject(Columns.CREATED_AT)).thenReturn(exists);
+    when(results.getObject(Columns.NAME)).thenReturn(exists);
+    when(results.getObject(Columns.URN)).thenReturn(exists);
+    when(results.getObject(Columns.CONNECTION_URL)).thenReturn(exists);
+
     when(results.getObject(Columns.ROW_UUID, UUID.class)).thenReturn(ROW_UUID);
     when(results.getTimestamp(Columns.CREATED_AT)).thenReturn(Timestamp.from(CREATED_AT));
     when(results.getString(Columns.NAME)).thenReturn(NAME.getValue());
     when(results.getString(Columns.URN)).thenReturn(URN.getValue());
     when(results.getString(Columns.CONNECTION_URL)).thenReturn(CONNECTION_URL.getRawValue());
+
     final StatementContext context = mock(StatementContext.class);
 
     final DatasourceRowMapper rowMapper = new DatasourceRowMapper();

--- a/src/test/java/marquez/db/models/DatasourceRowTest.java
+++ b/src/test/java/marquez/db/models/DatasourceRowTest.java
@@ -14,10 +14,12 @@
 
 package marquez.db.models;
 
-import static org.junit.Assert.assertEquals;
+import static marquez.common.models.CommonModelGenerator.newConnectionUrl;
+import static marquez.common.models.CommonModelGenerator.newDatasourceName;
+import static marquez.common.models.CommonModelGenerator.newDatasourceUrnWith;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
-import java.util.Optional;
 import java.util.UUID;
 import marquez.UnitTests;
 import marquez.common.models.ConnectionUrl;
@@ -30,62 +32,29 @@ import org.junit.experimental.categories.Category;
 public class DatasourceRowTest {
   private static final UUID ROW_UUID = UUID.randomUUID();
   private static final Instant CREATED_AT = Instant.now();
-  private static final String TYPE = "postgresql";
-  private static final String NAME = "mydatabase123";
-  private static final String CONNECTION_URL =
-      String.format("jdbc:%s://localhost:5432/test_db", TYPE);
-  private static final String DATASOURCE_URN =
-      DatasourceUrn.from(ConnectionUrl.fromString(CONNECTION_URL), DatasourceName.fromString(NAME))
-          .toString();
+  private static final DatasourceName NAME = newDatasourceName();
+  private static final ConnectionUrl CONNECTION_URL = newConnectionUrl();
+  private static final DatasourceUrn URN =
+      newDatasourceUrnWith(CONNECTION_URL.getDatasourceType(), NAME);
 
   @Test
-  public void testNewDatasourceRow() {
-    final Optional<Instant> expectedCreatedAt = Optional.of(CREATED_AT);
-    final DatasourceRow datasourceRow =
+  public void testNewRow() {
+    final DatasourceRow expected =
         DatasourceRow.builder()
             .uuid(ROW_UUID)
             .createdAt(CREATED_AT)
-            .urn(DATASOURCE_URN)
-            .name(NAME)
-            .connectionUrl(CONNECTION_URL)
+            .name(NAME.getValue())
+            .urn(URN.getValue())
+            .connectionUrl(CONNECTION_URL.getRawValue())
             .build();
-    assertEquals(ROW_UUID, datasourceRow.getUuid());
-    assertEquals(expectedCreatedAt, datasourceRow.getCreatedAt());
-    assertEquals(NAME, datasourceRow.getName());
-    assertEquals(CONNECTION_URL, datasourceRow.getConnectionUrl());
-  }
-
-  @Test
-  public void testNewDatasourceRow_noCreatedAt() {
-    final Optional<Instant> noCreatedAt = Optional.empty();
-    final DatasourceRow datasourceRow =
+    final DatasourceRow actual =
         DatasourceRow.builder()
             .uuid(ROW_UUID)
-            .urn(DATASOURCE_URN)
-            .name(NAME)
-            .connectionUrl(CONNECTION_URL)
+            .createdAt(CREATED_AT)
+            .name(NAME.getValue())
+            .urn(URN.getValue())
+            .connectionUrl(CONNECTION_URL.getRawValue())
             .build();
-    assertEquals(ROW_UUID, datasourceRow.getUuid());
-    assertEquals(noCreatedAt, datasourceRow.getCreatedAt());
-    assertEquals(NAME, datasourceRow.getName());
-    assertEquals(CONNECTION_URL, datasourceRow.getConnectionUrl());
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testNewDatasourceRow_throwsException_onNullUuid() {
-    final UUID nullUuid = null;
-    DatasourceRow.builder().uuid(nullUuid).name(NAME).connectionUrl(CONNECTION_URL).build();
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testNewDatasourceRow_throwsException_onNullName() {
-    final String nullName = null;
-    DatasourceRow.builder().uuid(ROW_UUID).name(nullName).connectionUrl(CONNECTION_URL).build();
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testNewDatasourceRow_throwsException_onNullConnectionUrl() {
-    final String nullConnectionUrl = null;
-    DatasourceRow.builder().uuid(ROW_UUID).name(NAME).connectionUrl(nullConnectionUrl).build();
+    assertThat(expected).isEqualTo(actual);
   }
 }

--- a/src/test/java/marquez/db/models/DbModelGenerator.java
+++ b/src/test/java/marquez/db/models/DbModelGenerator.java
@@ -14,6 +14,7 @@
 
 package marquez.db.models;
 
+import static java.util.stream.Collectors.toList;
 import static marquez.common.models.CommonModelGenerator.newConnectionUrl;
 import static marquez.common.models.CommonModelGenerator.newDatasetUrn;
 import static marquez.common.models.CommonModelGenerator.newDatasourceName;
@@ -23,7 +24,9 @@ import static marquez.common.models.CommonModelGenerator.newNamespaceName;
 import static marquez.common.models.CommonModelGenerator.newOwnerName;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 public final class DbModelGenerator {
   private DbModelGenerator() {}
@@ -48,6 +51,10 @@ public final class DbModelGenerator {
     }
 
     return builder.build();
+  }
+
+  public static List<DatasourceRow> newDatasourceRows(int limit) {
+    return Stream.generate(() -> newDatasourceRow()).limit(limit).collect(toList());
   }
 
   public static DatasourceRow newDatasourceRow() {

--- a/src/test/java/marquez/service/mappers/DatasourceMapperTest.java
+++ b/src/test/java/marquez/service/mappers/DatasourceMapperTest.java
@@ -57,9 +57,9 @@ public class DatasourceMapperTest {
   @Test
   public void testMap_emptyRows() {
     final List<DatasourceRow> emptyRows = Collections.emptyList();
-    final List<Datasource> datasources = DatasourceMapper.map(emptyRows);
-    assertThat(datasources).isNotNull();
-    assertThat(datasources).isEmpty();
+    final List<Datasource> emptyDatasources = DatasourceMapper.map(emptyRows);
+    assertThat(emptyDatasources).isNotNull();
+    assertThat(emptyDatasources).isEmpty();
   }
 
   public void testMap_throwsException_onNullRows() {

--- a/src/test/java/marquez/service/mappers/DatasourceMapperTest.java
+++ b/src/test/java/marquez/service/mappers/DatasourceMapperTest.java
@@ -14,73 +14,56 @@
 
 package marquez.service.mappers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static marquez.db.models.DbModelGenerator.newDatasourceRow;
+import static marquez.db.models.DbModelGenerator.newDatasourceRows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
-import java.time.Instant;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
-import marquez.common.models.ConnectionUrl;
-import marquez.common.models.DatasourceName;
-import marquez.common.models.DatasourceUrn;
+import marquez.UnitTests;
 import marquez.db.models.DatasourceRow;
 import marquez.service.models.Datasource;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(UnitTests.class)
 public class DatasourceMapperTest {
-  private static final Instant CREATED_AT = Instant.now();
-
-  private static final String CONNECTION_URL = "jdbc:postgresql://localhost:5431/novelists";
-  private static final String DATASOURCE_NAME = "my_database";
-  private static final String DATASOURCE_URN =
-      DatasourceUrn.from(
-              ConnectionUrl.fromString(CONNECTION_URL).getDatasourceType(),
-              DatasourceName.fromString(DATASOURCE_NAME))
-          .toString();
-
   @Test
-  public void testMapDatasourceRow() {
-    final DatasourceRow datasourceRow =
-        new DatasourceRow(
-            UUID.randomUUID(), DATASOURCE_URN, DATASOURCE_NAME, CONNECTION_URL, CREATED_AT);
-    final Datasource datasource = DatasourceMapper.map(datasourceRow);
-
-    assertNotNull(datasourceRow);
-    assertEquals(CONNECTION_URL, datasource.getConnectionUrl().getRawValue());
-    assertEquals(DATASOURCE_NAME, datasource.getName().getValue());
-    assertEquals(CREATED_AT, datasource.getCreatedAt());
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testMapNullDatasourceRow() {
-    final DatasourceRow nullDatasourceRow = null;
-    DatasourceMapper.map(nullDatasourceRow);
+  public void testMap_row() {
+    final DatasourceRow row = newDatasourceRow();
+    final Datasource datasource = DatasourceMapper.map(row);
+    assertThat(datasource).isNotNull();
+    assertThat(row.getName()).isEqualTo(datasource.getName().getValue());
+    assertThat(row.getCreatedAt()).isEqualTo(datasource.getCreatedAt().toString());
+    assertThat(row.getUrn()).isEqualTo(datasource.getUrn().getValue());
+    assertThat(row.getConnectionUrl()).isEqualTo(datasource.getConnectionUrl().getRawValue());
   }
 
   @Test
-  public void testMapDatasourceRowList() {
-    final List<DatasourceRow> datasourceRows =
-        Arrays.asList(
-            new DatasourceRow(
-                UUID.randomUUID(), DATASOURCE_URN, DATASOURCE_NAME, CONNECTION_URL, CREATED_AT));
-    final List<Datasource> datasources = DatasourceMapper.map(datasourceRows);
-
-    assertNotNull(datasources);
-    assertEquals(1, datasources.size());
+  public void testMap_throwsException_onNullRow() {
+    final DatasourceRow nullRow = null;
+    assertThatNullPointerException().isThrownBy(() -> DatasourceMapper.map(nullRow));
   }
 
   @Test
-  public void testMapEmptyDatasourceRowList() {
-    final List<DatasourceRow> emptyDatasourceRows = Arrays.asList();
-    final List<Datasource> datasources = DatasourceMapper.map(emptyDatasourceRows);
-    assertNotNull(datasources);
-    assertEquals(0, datasources.size());
+  public void testMap_rows() {
+    final List<DatasourceRow> rows = newDatasourceRows(4);
+    final List<Datasource> datasources = DatasourceMapper.map(rows);
+    assertThat(datasources).isNotNull();
+    assertThat(datasources).hasSize(4);
   }
 
-  @Test(expected = NullPointerException.class)
-  public void testMapNullDatasourceRowList() {
-    final List<DatasourceRow> nullDatasourceRows = null;
-    DatasourceMapper.map(nullDatasourceRows);
+  @Test
+  public void testMap_emptyRows() {
+    final List<DatasourceRow> emptyRows = Collections.emptyList();
+    final List<Datasource> datasources = DatasourceMapper.map(emptyRows);
+    assertThat(datasources).isNotNull();
+    assertThat(datasources).isEmpty();
+  }
+
+  public void testMap_throwsException_onNullRows() {
+    final List<DatasourceRow> nullRows = null;
+    assertThatNullPointerException().isThrownBy(() -> DatasourceMapper.map(nullRows));
   }
 }

--- a/src/test/java/marquez/service/models/ServiceModelGenerator.java
+++ b/src/test/java/marquez/service/models/ServiceModelGenerator.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package marquez.service.models;
+
+import static java.util.stream.Collectors.toList;
+import static marquez.common.models.CommonModelGenerator.newConnectionUrl;
+import static marquez.common.models.CommonModelGenerator.newDatasourceName;
+import static marquez.common.models.CommonModelGenerator.newDatasourceUrn;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Stream;
+
+public final class ServiceModelGenerator {
+  private ServiceModelGenerator() {}
+
+  public static List<Datasource> newDatasources(int limit) {
+    return Stream.generate(() -> newDatasource()).limit(limit).collect(toList());
+  }
+
+  public static Datasource newDatasource() {
+    return Datasource.builder()
+        .name(newDatasourceName())
+        .createdAt(newTimestamp())
+        .urn(newDatasourceUrn())
+        .connectionUrl(newConnectionUrl())
+        .build();
+  }
+
+  private static Instant newTimestamp() {
+    return Instant.now();
+  }
+}


### PR DESCRIPTION
This PR refactors the models and mappers for handling datasource objects, now following our recommended approach when defining them.