### PR TITLE
Cleanup namespace response mapper test

### DIFF
--- a/src/main/java/marquez/api/mappers/NamespaceResponseMapper.java
+++ b/src/main/java/marquez/api/mappers/NamespaceResponseMapper.java
@@ -20,6 +20,7 @@ import static java.util.stream.Collectors.toList;
 import java.util.List;
 import lombok.NonNull;
 import marquez.api.models.NamespaceResponse;
+import marquez.api.models.NamespacesResponse;
 import marquez.service.models.Namespace;
 
 public final class NamespaceResponseMapper {
@@ -36,5 +37,9 @@ public final class NamespaceResponseMapper {
   public static List<NamespaceResponse> map(@NonNull List<Namespace> namespaces) {
     return unmodifiableList(
         namespaces.stream().map(datasource -> map(datasource)).collect(toList()));
+  }
+
+  public static NamespacesResponse toNamespacesResponse(@NonNull List<Namespace> namespaces) {
+    return new NamespacesResponse(map(namespaces));
   }
 }

--- a/src/main/java/marquez/api/mappers/NamespaceResponseMapper.java
+++ b/src/main/java/marquez/api/mappers/NamespaceResponseMapper.java
@@ -14,9 +14,9 @@
 
 package marquez.api.mappers;
 
+import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
 
-import java.util.Collections;
 import java.util.List;
 import lombok.NonNull;
 import marquez.api.models.NamespaceResponse;
@@ -34,9 +34,7 @@ public final class NamespaceResponseMapper {
   }
 
   public static List<NamespaceResponse> map(@NonNull List<Namespace> namespaces) {
-    return namespaces.isEmpty()
-        ? Collections.emptyList()
-        : Collections.unmodifiableList(
-            namespaces.stream().map(namespace -> map(namespace)).collect(toList()));
+    return unmodifiableList(
+        namespaces.stream().map(datasource -> map(datasource)).collect(toList()));
   }
 }

--- a/src/test/java/marquez/api/mappers/NamespaceResponseMapperTest.java
+++ b/src/test/java/marquez/api/mappers/NamespaceResponseMapperTest.java
@@ -14,70 +14,93 @@
 
 package marquez.api.mappers;
 
+import static marquez.service.models.ServiceModelGenerator.newNamespace;
+import static marquez.service.models.ServiceModelGenerator.newNamespaces;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
+import marquez.UnitTests;
 import marquez.api.models.NamespaceResponse;
+import marquez.api.models.NamespacesResponse;
 import marquez.service.models.Namespace;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(UnitTests.class)
 public class NamespaceResponseMapperTest {
-
-  UUID nsId = UUID.randomUUID();
-  String name = "nsName";
-  String ownerName = "someOwner";
-  Timestamp createdAt = Timestamp.from(Instant.now());
-  String description = "some description";
-  Namespace descriptionNamespace = new Namespace(nsId, createdAt, name, ownerName, description);
-  Namespace descriptionlessNamespace = new Namespace(nsId, createdAt, name, ownerName, null);
-
   @Test
-  public void testSingleNamespace() {
-    NamespaceResponse mappedResponse = NamespaceResponseMapper.map(descriptionNamespace);
-
-    assertThat(mappedResponse.getName()).isEqualTo(descriptionNamespace.getName());
-    assertThat(Timestamp.valueOf(mappedResponse.getCreatedAt()))
-        .isEqualTo(descriptionNamespace.getCreatedAt());
-    assertThat(mappedResponse.getOwner()).isEqualTo(descriptionNamespace.getOwnerName());
-    assertThat(mappedResponse.getDescription()).isEqualTo(descriptionNamespace.getDescription());
+  public void testMap_namespace() {
+    final Namespace namespace = newNamespace();
+    final NamespaceResponse response = NamespaceResponseMapper.map(namespace);
+    assertThat(response).isNotNull();
+    assertThat(response.getName()).isEqualTo(namespace.getName());
+    assertThat(response.getCreatedAt()).isEqualTo(namespace.getCreatedAt().toString());
+    assertThat(response.getOwner()).isEqualTo(namespace.getOwnerName());
+    assertThat(response.getDescription()).isEqualTo(namespace.getDescription());
   }
 
   @Test
-  public void testDescriptionOptional() {
-    NamespaceResponse mappedResponse = NamespaceResponseMapper.map(descriptionlessNamespace);
-
-    assertThat(mappedResponse.getDescription()).isNullOrEmpty();
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testNullMapListInputs() {
-    NamespaceResponseMapper.map((List<Namespace>) null);
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testNullMapSingleInput() {
-    NamespaceResponseMapper.map((Namespace) null);
+  public void testMap_namespace_noDescription() {
+    final Namespace namespace = newNamespace(false);
+    final NamespaceResponse response = NamespaceResponseMapper.map(namespace);
+    assertThat(response).isNotNull();
+    assertThat(response.getName()).isEqualTo(namespace.getName());
+    assertThat(response.getCreatedAt()).isEqualTo(namespace.getCreatedAt().toString());
+    assertThat(response.getOwner()).isEqualTo(namespace.getOwnerName());
+    assertThat(response.getDescription()).isNull();
   }
 
   @Test
-  public void testList() {
-    List<Namespace> namespaces = Arrays.asList(descriptionNamespace, descriptionlessNamespace);
-    List<NamespaceResponse> namespaceResponses = NamespaceResponseMapper.map(namespaces);
-    assertThat(namespaceResponses).hasSize(2);
-    namespaceResponses.stream().forEach(s -> assertThat(s.getName()).isEqualTo(name));
-    namespaceResponses.stream()
-        .forEach(s -> assertThat(Timestamp.valueOf(s.getCreatedAt())).isEqualTo(createdAt));
+  public void testMap_throwsException_onNullNamespace() {
+    final Namespace nullNamespace = null;
+    assertThatNullPointerException().isThrownBy(() -> NamespaceResponseMapper.map(nullNamespace));
   }
 
   @Test
-  public void testEmptyList() {
-    List<NamespaceResponse> namespaceResponses =
-        NamespaceResponseMapper.map(Collections.emptyList());
-    assertThat(namespaceResponses).hasSize(0);
+  public void testMap_namespaces() {
+    final List<Namespace> namespaces = newNamespaces(4);
+    final List<NamespaceResponse> responses = NamespaceResponseMapper.map(namespaces);
+    assertThat(responses).isNotNull();
+    assertThat(responses).hasSize(4);
+  }
+
+  @Test
+  public void testMap_emptyNamespaces() {
+    final List<Namespace> emptyNamespaces = Collections.emptyList();
+    final List<NamespaceResponse> emptyResponses = NamespaceResponseMapper.map(emptyNamespaces);
+    assertThat(emptyResponses).isNotNull();
+    assertThat(emptyResponses).isEmpty();
+  }
+
+  @Test
+  public void testMap_throwsException_onNullNamespaces() {
+    final List<Namespace> nullNamespaces = null;
+    assertThatNullPointerException().isThrownBy(() -> NamespaceResponseMapper.map(nullNamespaces));
+  }
+
+  @Test
+  public void testToNamespacesResponse() {
+    final List<Namespace> namespaces = newNamespaces(4);
+    final NamespacesResponse response = NamespaceResponseMapper.toNamespacesResponse(namespaces);
+    assertThat(response).isNotNull();
+    assertThat(response.getNamespaces()).hasSize(4);
+  }
+
+  @Test
+  public void testToNamespacesResponse_emptyNamespaces() {
+    final List<Namespace> emptyNamespaces = Collections.emptyList();
+    final NamespacesResponse response =
+        NamespaceResponseMapper.toNamespacesResponse(emptyNamespaces);
+    assertThat(response).isNotNull();
+    assertThat(response.getNamespaces()).isEmpty();
+  }
+
+  @Test
+  public void testToNamespacesResponse_throwsException_onNullNamespaces() {
+    final List<Namespace> nullNamespaces = null;
+    assertThatNullPointerException()
+        .isThrownBy(() -> NamespaceResponseMapper.toNamespacesResponse(nullNamespaces));
   }
 }

--- a/src/test/java/marquez/service/models/ServiceModelGenerator.java
+++ b/src/test/java/marquez/service/models/ServiceModelGenerator.java
@@ -24,6 +24,7 @@ import static marquez.common.models.CommonModelGenerator.newDescription;
 import static marquez.common.models.CommonModelGenerator.newNamespaceName;
 import static marquez.common.models.CommonModelGenerator.newOwnerName;
 
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
 import java.util.stream.Stream;
@@ -37,12 +38,21 @@ import marquez.common.models.Description;
 public final class ServiceModelGenerator {
   private ServiceModelGenerator() {}
 
+  public static List<Namespace> newNamespaces(int limit) {
+    return Stream.generate(() -> newNamespace()).limit(limit).collect(toList());
+  }
+
   public static Namespace newNamespace() {
+    return newNamespace(true);
+  }
+
+  public static Namespace newNamespace(boolean hasDescription) {
     return new Namespace(
         null,
+        Timestamp.from(Instant.now()),
         newNamespaceName().getValue(),
         newOwnerName().getValue(),
-        newDescription().getValue());
+        hasDescription ? newDescription().getValue() : null);
   }
 
   public static List<Datasource> newDatasources(int limit) {


### PR DESCRIPTION
This PR updates [`NamespaceResponseMapperTest`](https://github.com/MarquezProject/marquez/blob/master/src/test/java/marquez/api/mappers/NamespaceResponseMapperTest.java) to use [`ServiceModelGenerator`](https://github.com/MarquezProject/marquez/blob/master/src/test/java/marquez/service/models/ServiceModelGenerator.java) and closes #308