### PR TITLE
Add tasks testIntegration and testDataAccessTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,9 +44,21 @@ compileTestJava {
   options.compilerArgs << '-parameters'
 }
 
-task testUnit(type: Test) {  
+task testUnit(type: Test) {
   useJUnit {
     includeCategories 'marquez.UnitTests'
+  }
+}
+
+task testIntegration(type: Test) {
+  useJUnit {
+    includeCategories 'marquez.IntegrationTests'
+  }
+}
+
+task testDataAccessTest(type: Test) {
+  useJUnit {
+    includeCategories 'marquez.DataAccessTests'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ task testIntegration(type: Test) {
   }
 }
 
-task testDataAccessTest(type: Test) {
+task testDataAccess(type: Test) {
   useJUnit {
     includeCategories 'marquez.DataAccessTests'
   }


### PR DESCRIPTION
This PR adds the following gradle tasks:

- [`testIntegration`](https://github.com/MarquezProject/marquez/blob/feature/tntegration-and-data-access-tasks/build.gradle#L53) - Runs tests annotated with the category [**IntegrationTests**](https://github.com/MarquezProject/marquez/blob/master/src/test/java/marquez/IntegrationTests.java)
- [`testDataAccess`](https://github.com/MarquezProject/marquez/blob/feature/tntegration-and-data-access-tasks/build.gradle#L59) - Runs tests annotated with the category [**DataAccessTests**](https://github.com/MarquezProject/marquez/blob/master/src/test/java/marquez/DataAccessTests.java)