### PR TITLE
Bump jdbi3 to 3.7.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,10 @@ dependencies {
   compileOnly 'org.projectlombok:lombok:1.18.6'
   annotationProcessor 'org.projectlombok:lombok:1.18.6'
 
-  testCompile 'junit:junit:4.12'
+  testCompile "org.jdbi:jdbi3-testing:${jdbi3Version}"
+  testCompile 'com.opentable.components:otj-pg-embedded:0.13.1'
   testCompile 'io.dropwizard:dropwizard-testing:1.3.9'
-  testCompile 'org.jdbi:jdbi3-testing:3.3.0'
+  testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:2.25.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,14 +16,18 @@ repositories {
   mavenCentral()
 }
 
+ext {
+  jdbi3Version = '3.7.1'
+}
+
 dependencies {
   compile 'io.dropwizard.metrics:metrics-jdbi3:4.1.0-rc3'
   compile 'io.dropwizard.modules:dropwizard-flyway:1.3.0-4'
   compile 'io.dropwizard:dropwizard-core:1.3.9'
   compile 'io.dropwizard:dropwizard-jdbi3:1.3.9'
   compile 'io.dropwizard:dropwizard-json-logging:1.3.9'
-  compile 'org.jdbi:jdbi3-postgres:3.6.0'
-  compile 'org.jdbi:jdbi3-sqlobject:3.6.0'
+  compile "org.jdbi:jdbi3-postgres:${jdbi3Version}"
+  compile "org.jdbi:jdbi3-sqlobject:${jdbi3Version}"
   compile 'org.postgresql:postgresql:42.2.5'
   compileOnly 'org.projectlombok:lombok:1.18.6'
   annotationProcessor 'org.projectlombok:lombok:1.18.6'


### PR DESCRIPTION
This PR bumps jdbi3 to 3.7.1 (see [release notes](https://github.com/jdbi/jdbi/blob/master/RELEASE_NOTES.md))