### PR TITLE
Bump release plugin to 2.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
   id 'com.diffplug.gradle.spotless' version '3.20.0'
   id 'com.github.jk1.dependency-license-report' version '1.3'
   id 'com.github.johnrengelman.shadow' version '4.0.4'
-  id 'net.researchgate.release' version '2.6.0'
+  id 'net.researchgate.release' version '2.8.0'
 }
 
 repositories {


### PR DESCRIPTION
see: https://github.com/researchgate/gradle-release/commits/2.8.0