### PR TITLE
 Add datasource urn to DatasetAPI

### DIFF
--- a/src/main/java/marquez/api/mappers/DatasetResponseMapper.java
+++ b/src/main/java/marquez/api/mappers/DatasetResponseMapper.java
@@ -22,19 +22,18 @@ import java.util.List;
 import lombok.NonNull;
 import marquez.api.models.DatasetResponse;
 import marquez.api.models.DatasetsResponse;
-import marquez.common.models.Description;
 import marquez.service.models.Dataset;
 
 public final class DatasetResponseMapper {
   private DatasetResponseMapper() {}
 
   public static DatasetResponse map(@NonNull Dataset dataset) {
-    final Description description = dataset.getDescription();
     return new DatasetResponse(
         dataset.getName().getValue(),
         ISO_INSTANT.format(dataset.getCreatedAt()),
         dataset.getUrn().getValue(),
-        (description == null) ? null : description.getValue());
+        dataset.getDatasourceUrn().getValue(),
+        (dataset.getDescription() == null) ? null : dataset.getDescription().getValue());
   }
 
   public static List<DatasetResponse> map(@NonNull List<Dataset> datasets) {

--- a/src/main/java/marquez/api/models/DatasetResponse.java
+++ b/src/main/java/marquez/api/models/DatasetResponse.java
@@ -35,6 +35,7 @@ public final class DatasetResponse {
       @NonNull final String name,
       @NonNull final String createdAt,
       @NonNull final String urn,
+      @NonNull final String datasourceUrn,
       @Nullable final String description) {
     this.name = checkNotBlank(name);
     this.createdAt = checkNotBlank(createdAt);

--- a/src/main/java/marquez/api/models/DatasetResponse.java
+++ b/src/main/java/marquez/api/models/DatasetResponse.java
@@ -29,6 +29,7 @@ public final class DatasetResponse {
   @Getter private final String name;
   @Getter private final String createdAt;
   @Getter private final String urn;
+  @Getter private final String datasourceUrn;
   private final String description;
 
   public DatasetResponse(
@@ -40,6 +41,7 @@ public final class DatasetResponse {
     this.name = checkNotBlank(name);
     this.createdAt = checkNotBlank(createdAt);
     this.urn = checkNotBlank(urn);
+    this.datasourceUrn = checkNotBlank(datasourceUrn);
     this.description = description;
   }
 

--- a/src/main/java/marquez/db/Columns.java
+++ b/src/main/java/marquez/db/Columns.java
@@ -63,6 +63,7 @@ public final class Columns {
   public static final String DATASET_UUID = "dataset_uuid";
   public static final String URN = "urn";
   public static final String DATASOURCE_UUID = "datasource_uuid";
+  public static final String DATASOURCE_URN = "datasource_urn";
   public static final String CONNECTION_URL = "connection_url";
   public static final String DB_TABLE_INFO_UUID = "db_table_info_uuid";
   public static final String DB_NAME = "db";

--- a/src/main/java/marquez/db/DatasetDao.java
+++ b/src/main/java/marquez/db/DatasetDao.java
@@ -101,7 +101,7 @@ public interface DatasetDao {
           + "    ON (n.guid = d.namespace_guid AND n.name = :value) "
           + "INNER JOIN datasources AS s "
           + "    ON (s.guid = d.datasource_uuid)"
-          + "ORDER BY d.created_at "
+          + "ORDER BY n.name "
           + "LIMIT :limit OFFSET :offset")
   @RegisterRowMapper(DatasetRowExtendedMapper.class)
   List<DatasetRowExtended> findAll(

--- a/src/main/java/marquez/db/DatasetDao.java
+++ b/src/main/java/marquez/db/DatasetDao.java
@@ -95,12 +95,12 @@ public interface DatasetDao {
   Optional<DatasetRowExtended> findBy(@BindBean DatasetUrn urn);
 
   @SqlQuery(
-      "SELECT d.*, s.urn AS datasource_urn "
+      "SELECT d.*, ds.urn AS datasource_urn "
           + "FROM datasets AS d "
           + "INNER JOIN namespaces AS n "
           + "    ON (n.guid = d.namespace_guid AND n.name = :value) "
-          + "INNER JOIN datasources AS s "
-          + "    ON (s.guid = d.datasource_uuid)"
+          + "INNER JOIN datasources AS ds "
+          + "    ON (ds.guid = d.datasource_uuid)"
           + "ORDER BY n.name "
           + "LIMIT :limit OFFSET :offset")
   @RegisterRowMapper(DatasetRowExtendedMapper.class)

--- a/src/main/java/marquez/db/DatasetDao.java
+++ b/src/main/java/marquez/db/DatasetDao.java
@@ -95,13 +95,13 @@ public interface DatasetDao {
   Optional<DatasetRowExtended> findBy(@BindBean DatasetUrn urn);
 
   @SqlQuery(
-      "SELECT d.*, ds.urn AS datasource_urn "
+      "SELECT d.*, s.urn AS datasource_urn "
           + "FROM datasets AS d "
           + "INNER JOIN namespaces AS n "
           + "    ON (n.guid = d.namespace_guid AND n.name = :value) "
-          + "INNER JOIN datasources AS ds "
-          + "    ON (ds.guid = d.datasource_uuid)"
-          + "ORDER BY n.name "
+          + "INNER JOIN datasources AS s "
+          + "    ON (s.guid = d.datasource_uuid)"
+          + "ORDER BY d.created_at "
           + "LIMIT :limit OFFSET :offset")
   @RegisterRowMapper(DatasetRowExtendedMapper.class)
   List<DatasetRowExtended> findAll(

--- a/src/main/java/marquez/db/DatasetDao.java
+++ b/src/main/java/marquez/db/DatasetDao.java
@@ -19,8 +19,10 @@ import java.util.Optional;
 import java.util.UUID;
 import marquez.common.models.DatasetUrn;
 import marquez.common.models.NamespaceName;
+import marquez.db.mappers.DatasetRowExtendedMapper;
 import marquez.db.mappers.DatasetRowMapper;
 import marquez.db.models.DatasetRow;
+import marquez.db.models.DatasetRowExtended;
 import marquez.db.models.DatasourceRow;
 import marquez.db.models.DbTableInfoRow;
 import marquez.db.models.DbTableVersionRow;
@@ -31,7 +33,6 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 
-@RegisterRowMapper(DatasetRowMapper.class)
 public interface DatasetDao {
   @CreateSqlObject
   DatasourceDao createDatasourceDao();
@@ -42,12 +43,14 @@ public interface DatasetDao {
   @SqlUpdate(
       "INSERT INTO datasets (guid, namespace_guid, datasource_uuid, urn, description, name) "
           + "VALUES (:uuid, :namespaceUuid, :datasourceUuid, :urn, :description, :name)")
+  @RegisterRowMapper(DatasetRowMapper.class)
   void insert(@BindBean DatasetRow datasetRow);
 
   @SqlQuery(
       "INSERT INTO datasets (guid, namespace_guid, datasource_uuid, urn, description, name) "
           + "VALUES (:uuid, :namespaceUuid, :datasourceUuid, :urn, :description, :name) "
           + "RETURNING *")
+  @RegisterRowMapper(DatasetRowMapper.class)
   Optional<DatasetRow> insertAndGet(@BindBean DatasetRow datasetRow);
 
   @Deprecated
@@ -73,20 +76,36 @@ public interface DatasetDao {
           + "WHERE guid = :uuid")
   void updateCurrentVersionUuid(UUID uuid, UUID currentVersionUuid);
 
-  @SqlQuery("SELECT * FROM datasets WHERE guid = :uuid")
-  Optional<DatasetRow> findBy(UUID uuid);
-
-  @SqlQuery("SELECT * FROM datasets WHERE urn = :value")
-  Optional<DatasetRow> findBy(@BindBean DatasetUrn urn);
+  @SqlQuery(
+      "SELECT d.*, ds.urn AS datasource_urn "
+          + "FROM datasets AS d "
+          + "INNER JOIN datasources AS ds "
+          + "    ON (ds.guid = d.datasource_uuid) "
+          + "WHERE d.guid = :uuid")
+  @RegisterRowMapper(DatasetRowExtendedMapper.class)
+  Optional<DatasetRowExtended> findBy(UUID uuid);
 
   @SqlQuery(
-      "SELECT * "
-          + "FROM datasets d "
-          + "INNER JOIN namespaces n "
-          + "    ON (n.guid = d.namespace_guid AND n.name = :value)"
+      "SELECT d.*, ds.urn AS datasource_urn "
+          + "FROM datasets AS d "
+          + "INNER JOIN datasources AS ds "
+          + "    ON (ds.guid = d.datasource_uuid) "
+          + "WHERE d.urn = :value")
+  @RegisterRowMapper(DatasetRowExtendedMapper.class)
+  Optional<DatasetRowExtended> findBy(@BindBean DatasetUrn urn);
+
+  @SqlQuery(
+      "SELECT d.*, ds.urn AS datasource_urn "
+          + "FROM datasets AS d "
+          + "INNER JOIN namespaces AS n "
+          + "    ON (n.guid = d.namespace_guid AND n.name = :value) "
+          + "INNER JOIN datasources AS ds "
+          + "    ON (ds.guid = d.datasource_uuid)"
           + "ORDER BY n.name "
           + "LIMIT :limit OFFSET :offset")
-  List<DatasetRow> findAll(@BindBean NamespaceName namespaceName, Integer limit, Integer offset);
+  @RegisterRowMapper(DatasetRowExtendedMapper.class)
+  List<DatasetRowExtended> findAll(
+      @BindBean NamespaceName namespaceName, Integer limit, Integer offset);
 
   @SqlQuery("SELECT COUNT(*) FROM datasets")
   Integer count();

--- a/src/main/java/marquez/db/DatasetDao.java
+++ b/src/main/java/marquez/db/DatasetDao.java
@@ -97,11 +97,11 @@ public interface DatasetDao {
   @SqlQuery(
       "SELECT d.*, ds.urn AS datasource_urn "
           + "FROM datasets AS d "
-          + "INNER JOIN namespaces AS n "
-          + "    ON (n.guid = d.namespace_guid AND n.name = :value) "
+          + "INNER JOIN namespaces AS ns "
+          + "    ON (ns.guid = d.namespace_guid AND ns.name = :value) "
           + "INNER JOIN datasources AS ds "
           + "    ON (ds.guid = d.datasource_uuid)"
-          + "ORDER BY n.name "
+          + "ORDER BY ns.name "
           + "LIMIT :limit OFFSET :offset")
   @RegisterRowMapper(DatasetRowExtendedMapper.class)
   List<DatasetRowExtended> findAll(

--- a/src/main/java/marquez/db/mappers/DatasetRowExtendedMapper.java
+++ b/src/main/java/marquez/db/mappers/DatasetRowExtendedMapper.java
@@ -16,9 +16,9 @@ package marquez.db.mappers;
 
 import static marquez.db.Columns.stringOrNull;
 import static marquez.db.Columns.stringOrThrow;
-import static marquez.db.Columns.timestampOrNull;
 import static marquez.db.Columns.timestampOrThrow;
 import static marquez.db.Columns.uuidOrNull;
+import static marquez.db.Columns.uuidOrThrow;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -35,9 +35,9 @@ public final class DatasetRowExtendedMapper implements RowMapper<DatasetRowExten
     return DatasetRowExtended.builder()
         .uuid(uuidOrNull(results, Columns.ROW_UUID))
         .createdAt(timestampOrThrow(results, Columns.CREATED_AT))
-        .updatedAt(timestampOrNull(results, Columns.UPDATED_AT))
-        .namespaceUuid(uuidOrNull(results, Columns.NAMESPACE_UUID))
-        .datasourceUuid(uuidOrNull(results, Columns.DATASOURCE_UUID))
+        .updatedAt(timestampOrThrow(results, Columns.UPDATED_AT))
+        .namespaceUuid(uuidOrThrow(results, Columns.NAMESPACE_UUID))
+        .datasourceUuid(uuidOrThrow(results, Columns.DATASOURCE_UUID))
         .name(stringOrThrow(results, Columns.NAME))
         .urn(stringOrThrow(results, Columns.URN))
         .datasourceUrn(stringOrThrow(results, Columns.DATASOURCE_URN))

--- a/src/main/java/marquez/db/mappers/DatasetRowExtendedMapper.java
+++ b/src/main/java/marquez/db/mappers/DatasetRowExtendedMapper.java
@@ -32,7 +32,7 @@ public final class DatasetRowExtendedMapper implements RowMapper<DatasetRowExten
   @Override
   public DatasetRowExtended map(@NonNull ResultSet results, @NonNull StatementContext context)
       throws SQLException {
-    return DatasetRowExtended.builder()
+    return DatasetRowExtended.builderExtended()
         .uuid(uuidOrNull(results, Columns.ROW_UUID))
         .createdAt(timestampOrThrow(results, Columns.CREATED_AT))
         .updatedAt(timestampOrThrow(results, Columns.UPDATED_AT))

--- a/src/main/java/marquez/db/mappers/DatasetRowExtendedMapper.java
+++ b/src/main/java/marquez/db/mappers/DatasetRowExtendedMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package marquez.db.mappers;
+
+import static marquez.db.Columns.stringOrNull;
+import static marquez.db.Columns.stringOrThrow;
+import static marquez.db.Columns.timestampOrNull;
+import static marquez.db.Columns.timestampOrThrow;
+import static marquez.db.Columns.uuidOrNull;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import lombok.NonNull;
+import marquez.db.Columns;
+import marquez.db.models.DatasetRowExtended;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public final class DatasetRowExtendedMapper implements RowMapper<DatasetRowExtended> {
+  @Override
+  public DatasetRowExtended map(@NonNull ResultSet results, @NonNull StatementContext context)
+      throws SQLException {
+    return DatasetRowExtended.builder()
+        .uuid(uuidOrNull(results, Columns.ROW_UUID))
+        .createdAt(timestampOrThrow(results, Columns.CREATED_AT))
+        .updatedAt(timestampOrNull(results, Columns.UPDATED_AT))
+        .namespaceUuid(uuidOrNull(results, Columns.NAMESPACE_UUID))
+        .datasourceUuid(uuidOrNull(results, Columns.DATASOURCE_UUID))
+        .name(stringOrThrow(results, Columns.NAME))
+        .urn(stringOrThrow(results, Columns.URN))
+        .datasourceUrn(stringOrThrow(results, Columns.DATASOURCE_URN))
+        .description(stringOrNull(results, Columns.DESCRIPTION))
+        .currentVersionUuid(uuidOrNull(results, Columns.CURRENT_VERSION_UUID))
+        .build();
+  }
+}

--- a/src/main/java/marquez/db/mappers/DatasetRowMapper.java
+++ b/src/main/java/marquez/db/mappers/DatasetRowMapper.java
@@ -38,8 +38,8 @@ public final class DatasetRowMapper implements RowMapper<DatasetRow> {
         .updatedAt(timestampOrNull(results, Columns.UPDATED_AT))
         .namespaceUuid(uuidOrNull(results, Columns.NAMESPACE_UUID))
         .datasourceUuid(uuidOrNull(results, Columns.DATASOURCE_UUID))
-        .urn(stringOrThrow(results, Columns.URN))
         .name(stringOrThrow(results, Columns.NAME))
+        .urn(stringOrThrow(results, Columns.URN))
         .description(stringOrNull(results, Columns.DESCRIPTION))
         .currentVersionUuid(uuidOrNull(results, Columns.CURRENT_VERSION_UUID))
         .build();

--- a/src/main/java/marquez/db/models/DatasetRow.java
+++ b/src/main/java/marquez/db/models/DatasetRow.java
@@ -21,7 +21,7 @@ import lombok.Data;
 
 @Data
 @Builder
-public final class DatasetRow {
+public class DatasetRow {
   private UUID uuid;
   private Instant createdAt;
   private Instant updatedAt;

--- a/src/main/java/marquez/db/models/DatasetRowExtended.java
+++ b/src/main/java/marquez/db/models/DatasetRowExtended.java
@@ -17,19 +17,37 @@ package marquez.db.models;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
-@Data
-@Builder
-public final class DatasetRowExtended {
-  private UUID uuid;
-  private Instant createdAt;
-  private Instant updatedAt;
-  private UUID namespaceUuid;
-  private UUID datasourceUuid;
-  private String name;
-  private String urn;
-  private String datasourceUrn;
-  private String description;
-  private UUID currentVersionUuid;
+@EqualsAndHashCode(callSuper = true)
+@ToString
+public final class DatasetRowExtended extends DatasetRow {
+  @Getter private String datasourceUrn;
+
+  @Builder(builderMethodName = "builderExtended")
+  public DatasetRowExtended(
+      final UUID uuid,
+      final Instant createdAt,
+      final Instant updatedAt,
+      final UUID namespaceUuid,
+      final UUID datasourceUuid,
+      final String name,
+      final String urn,
+      final String datasourceUrn,
+      final String description,
+      final UUID currentVersionUuid) {
+    super(
+        uuid,
+        createdAt,
+        updatedAt,
+        namespaceUuid,
+        datasourceUuid,
+        name,
+        urn,
+        description,
+        currentVersionUuid);
+    this.datasourceUrn = datasourceUrn;
+  }
 }

--- a/src/main/java/marquez/db/models/DatasetRowExtended.java
+++ b/src/main/java/marquez/db/models/DatasetRowExtended.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package marquez.db.models;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public final class DatasetRowExtended {
+  private UUID uuid;
+  private Instant createdAt;
+  private Instant updatedAt;
+  private UUID namespaceUuid;
+  private UUID datasourceUuid;
+  private String name;
+  private String urn;
+  private String datasourceUrn;
+  private String description;
+  private UUID currentVersionUuid;
+}

--- a/src/main/java/marquez/service/DatasetService.java
+++ b/src/main/java/marquez/service/DatasetService.java
@@ -83,8 +83,11 @@ public class DatasetService {
       return datasetDao
           .insertAndGet(newDatasetRow)
           .map(
-              datasetRow ->
-                  DatasetMapper.map(DatasourceUrn.fromString(datasourceRow.getUrn()), datasetRow))
+              datasetRow -> {
+                final DatasourceUrn datasourceUrn =
+                    DatasourceUrn.fromString(datasourceRow.getUrn());
+                return DatasetMapper.map(datasourceUrn, datasetRow);
+              })
           .orElseThrow(
               () ->
                   new MarquezServiceException(

--- a/src/main/java/marquez/service/DatasetService.java
+++ b/src/main/java/marquez/service/DatasetService.java
@@ -21,11 +21,13 @@ import java.util.Optional;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import marquez.common.models.DatasetUrn;
+import marquez.common.models.DatasourceUrn;
 import marquez.common.models.NamespaceName;
 import marquez.db.DatasetDao;
 import marquez.db.DatasourceDao;
 import marquez.db.NamespaceDao;
 import marquez.db.models.DatasetRow;
+import marquez.db.models.DatasetRowExtended;
 import marquez.db.models.DatasourceRow;
 import marquez.db.models.DbTableInfoRow;
 import marquez.db.models.DbTableVersionRow;
@@ -73,14 +75,16 @@ public class DatasetService {
                       new MarquezServiceException(
                           "Datasource row not found: " + dataset.getDatasourceUrn().getValue()));
       final DatasetRow newDatasetRow = DatasetRowMapper.map(namespaceRow, datasourceRow, dataset);
-      final DatasetUrn urn = DatasetUrn.fromString(newDatasetRow.getUrn());
-      final Optional<Dataset> datasetIfFound = get(urn);
+      final DatasetUrn datasetUrn = DatasetUrn.fromString(newDatasetRow.getUrn());
+      final Optional<Dataset> datasetIfFound = get(datasetUrn);
       if (datasetIfFound.isPresent()) {
         return datasetIfFound.get();
       }
       return datasetDao
           .insertAndGet(newDatasetRow)
-          .map(DatasetMapper::map)
+          .map(
+              datasetRow ->
+                  DatasetMapper.map(DatasourceUrn.fromString(datasourceRow.getUrn()), datasetRow))
           .orElseThrow(
               () ->
                   new MarquezServiceException(
@@ -102,8 +106,11 @@ public class DatasetService {
         DbTableVersionRowMapper.map(datasetRow, dbTableInfoRow, dbTableVersion);
     try {
       datasetDao.insertAll(datasourceRow, datasetRow, dbTableInfoRow, dbTableVersionRow);
-      final Optional<DatasetRow> datasetRowIfFound = datasetDao.findBy(datasetRow.getUuid());
-      return datasetRowIfFound.map(DatasetMapper::map).orElseThrow(MarquezServiceException::new);
+      final Optional<DatasetRowExtended> datasetRowExtendedIfFound =
+          datasetDao.findBy(datasetRow.getUuid());
+      return datasetRowExtendedIfFound
+          .map(DatasetMapper::map)
+          .orElseThrow(MarquezServiceException::new);
     } catch (UnableToExecuteStatementException e) {
       log.error(e.getMessage());
       throw new MarquezServiceException();
@@ -132,8 +139,9 @@ public class DatasetService {
       @NonNull NamespaceName namespaceName, @NonNull Integer limit, @NonNull Integer offset)
       throws MarquezServiceException {
     try {
-      final List<DatasetRow> datasetRows = datasetDao.findAll(namespaceName, limit, offset);
-      return unmodifiableList(DatasetMapper.map(datasetRows));
+      final List<DatasetRowExtended> datasetRowsExtended =
+          datasetDao.findAll(namespaceName, limit, offset);
+      return unmodifiableList(DatasetMapper.map(datasetRowsExtended));
     } catch (UnableToExecuteStatementException e) {
       log.error("Failed to get datasets for namespace: {}", namespaceName.getValue(), e);
       throw new MarquezServiceException();

--- a/src/main/java/marquez/service/mappers/DatasetMapper.java
+++ b/src/main/java/marquez/service/mappers/DatasetMapper.java
@@ -21,23 +21,36 @@ import java.util.List;
 import lombok.NonNull;
 import marquez.common.models.DatasetName;
 import marquez.common.models.DatasetUrn;
+import marquez.common.models.DatasourceUrn;
 import marquez.common.models.Description;
 import marquez.db.models.DatasetRow;
+import marquez.db.models.DatasetRowExtended;
 import marquez.service.models.Dataset;
 
 public final class DatasetMapper {
   private DatasetMapper() {}
 
-  public static Dataset map(@NonNull DatasetRow row) {
+  public static Dataset map(@NonNull DatasourceUrn datasourceUrn, @NonNull DatasetRow row) {
     return Dataset.builder()
         .name(DatasetName.fromString(row.getName()))
         .createdAt(row.getCreatedAt())
         .urn(DatasetUrn.fromString(row.getUrn()))
+        .datasourceUrn(datasourceUrn)
         .description(Description.fromString(row.getDescription()))
         .build();
   }
 
-  public static List<Dataset> map(@NonNull List<DatasetRow> rows) {
+  public static Dataset map(@NonNull DatasetRowExtended row) {
+    return Dataset.builder()
+        .name(DatasetName.fromString(row.getName()))
+        .createdAt(row.getCreatedAt())
+        .urn(DatasetUrn.fromString(row.getUrn()))
+        .datasourceUrn(DatasourceUrn.fromString(row.getDatasourceUrn()))
+        .description(Description.fromString(row.getDescription()))
+        .build();
+  }
+
+  public static List<Dataset> map(@NonNull List<DatasetRowExtended> rows) {
     return unmodifiableList(rows.stream().map(row -> map(row)).collect(toList()));
   }
 }

--- a/src/main/java/marquez/service/mappers/DatasetMapper.java
+++ b/src/main/java/marquez/service/mappers/DatasetMapper.java
@@ -40,17 +40,18 @@ public final class DatasetMapper {
         .build();
   }
 
-  public static Dataset map(@NonNull DatasetRowExtended row) {
+  public static Dataset map(@NonNull DatasetRowExtended rowExtended) {
     return Dataset.builder()
-        .name(DatasetName.fromString(row.getName()))
-        .createdAt(row.getCreatedAt())
-        .urn(DatasetUrn.fromString(row.getUrn()))
-        .datasourceUrn(DatasourceUrn.fromString(row.getDatasourceUrn()))
-        .description(Description.fromString(row.getDescription()))
+        .name(DatasetName.fromString(rowExtended.getName()))
+        .createdAt(rowExtended.getCreatedAt())
+        .urn(DatasetUrn.fromString(rowExtended.getUrn()))
+        .datasourceUrn(DatasourceUrn.fromString(rowExtended.getDatasourceUrn()))
+        .description(Description.fromString(rowExtended.getDescription()))
         .build();
   }
 
-  public static List<Dataset> map(@NonNull List<DatasetRowExtended> rows) {
-    return unmodifiableList(rows.stream().map(row -> map(row)).collect(toList()));
+  public static List<Dataset> map(@NonNull List<DatasetRowExtended> rowsExtended) {
+    return unmodifiableList(
+        rowsExtended.stream().map(rowExtended -> map(rowExtended)).collect(toList()));
   }
 }

--- a/src/test/java/marquez/db/DatasetDaoTest.java
+++ b/src/test/java/marquez/db/DatasetDaoTest.java
@@ -29,6 +29,7 @@ import marquez.IntegrationTests;
 import marquez.common.models.DatasetUrn;
 import marquez.common.models.NamespaceName;
 import marquez.db.models.DatasetRow;
+import marquez.db.models.DatasetRowExtended;
 import marquez.db.models.DatasourceRow;
 import marquez.db.models.NamespaceRow;
 import org.jdbi.v3.core.Jdbi;
@@ -137,10 +138,11 @@ public class DatasetDaoTest {
     final UUID currentVersionUuid = UUID.randomUUID();
     datasetDao.updateCurrentVersionUuid(datasetRow.getUuid(), currentVersionUuid);
 
-    final DatasetRow datasetRowWithVersion = datasetDao.findBy(datasetRow.getUuid()).orElse(null);
-    assertThat(datasetRowWithVersion.getCurrentVersionUuid()).isNotNull();
-    assertThat(datasetRowWithVersion.getCurrentVersionUuid()).isEqualTo(currentVersionUuid);
-    assertThat(datasetRowWithVersion.getUpdatedAt()).isAfter(datasetRow.getUpdatedAt());
+    final DatasetRowExtended datasetRowExtendedWithVersion =
+        datasetDao.findBy(datasetRow.getUuid()).orElse(null);
+    assertThat(datasetRowExtendedWithVersion.getCurrentVersionUuid()).isNotNull();
+    assertThat(datasetRowExtendedWithVersion.getCurrentVersionUuid()).isEqualTo(currentVersionUuid);
+    assertThat(datasetRowExtendedWithVersion.getUpdatedAt()).isAfter(datasetRow.getUpdatedAt());
   }
 
   @Test
@@ -161,9 +163,9 @@ public class DatasetDaoTest {
         newDatasetRowWith(uuid, namespaceRow.getUuid(), datasourceRow.getUuid());
     datasetDao.insert(newDatasetRow);
 
-    final DatasetRow datasetRow = datasetDao.findBy(uuid).orElse(null);
-    assertThat(datasetRow).isNotNull();
-    assertThat(datasetRow.getUuid()).isEqualTo(uuid);
+    final DatasetRowExtended datasetRowExtended = datasetDao.findBy(uuid).orElse(null);
+    assertThat(datasetRowExtended).isNotNull();
+    assertThat(datasetRowExtended.getUuid()).isEqualTo(uuid);
   }
 
   @Test
@@ -178,9 +180,9 @@ public class DatasetDaoTest {
         newDatasetRowWith(namespaceRow.getUuid(), datasourceRow.getUuid(), datasetUrn);
     datasetDao.insert(newDatasetRow);
 
-    final DatasetRow datasetRow = datasetDao.findBy(datasetUrn).orElse(null);
-    assertThat(datasetRow).isNotNull();
-    assertThat(datasetRow.getUrn()).isEqualTo(datasetUrn.getValue());
+    final DatasetRowExtended datasetRowExtended = datasetDao.findBy(datasetUrn).orElse(null);
+    assertThat(datasetRowExtended).isNotNull();
+    assertThat(datasetRowExtended.getUrn()).isEqualTo(datasetUrn.getValue());
   }
 
   @Test
@@ -190,15 +192,17 @@ public class DatasetDaoTest {
         newDatasetRowsWith(namespaceRow.getUuid(), datasourceRow.getUuid(), rowsToInsert);
     newDatasetRows.forEach(newDatasetRow -> datasetDao.insert(newDatasetRow));
 
-    final List<DatasetRow> datasetRows = datasetDao.findAll(namespaceName, LIMIT, OFFSET);
-    assertThat(datasetRows).isNotNull();
-    assertThat(datasetRows).hasSize(rowsToInsert);
+    final List<DatasetRowExtended> datasetRowsExtended =
+        datasetDao.findAll(namespaceName, LIMIT, OFFSET);
+    assertThat(datasetRowsExtended).isNotNull();
+    assertThat(datasetRowsExtended).hasSize(rowsToInsert);
   }
 
   @Test
   public void testFindAll_noRowsFound() {
-    final List<DatasetRow> datasetRows = datasetDao.findAll(namespaceName, LIMIT, OFFSET);
-    assertThat(datasetRows).isEmpty();
+    final List<DatasetRowExtended> datasetRowsExtended =
+        datasetDao.findAll(namespaceName, LIMIT, OFFSET);
+    assertThat(datasetRowsExtended).isEmpty();
   }
 
   @Test
@@ -207,11 +211,12 @@ public class DatasetDaoTest {
         newDatasetRowsWith(namespaceRow.getUuid(), datasourceRow.getUuid(), 4);
     newDatasetRows.forEach(newDatasetRow -> datasetDao.insert(newDatasetRow));
 
-    final List<DatasetRow> datasetRows = datasetDao.findAll(namespaceName, 2, OFFSET);
-    assertThat(datasetRows).isNotNull();
-    assertThat(datasetRows).hasSize(2);
-    assertThat(datasetRows.get(0).getUuid()).isEqualTo(newDatasetRows.get(0).getUuid());
-    assertThat(datasetRows.get(1).getUuid()).isEqualTo(newDatasetRows.get(1).getUuid());
+    final List<DatasetRowExtended> datasetRowsExtended =
+        datasetDao.findAll(namespaceName, 2, OFFSET);
+    assertThat(datasetRowsExtended).isNotNull();
+    assertThat(datasetRowsExtended).hasSize(2);
+    assertThat(datasetRowsExtended.get(0).getUuid()).isEqualTo(newDatasetRows.get(0).getUuid());
+    assertThat(datasetRowsExtended.get(1).getUuid()).isEqualTo(newDatasetRows.get(1).getUuid());
   }
 
   @Test
@@ -220,10 +225,11 @@ public class DatasetDaoTest {
         newDatasetRowsWith(namespaceRow.getUuid(), datasourceRow.getUuid(), 4);
     newDatasetRows.forEach(newDatasetRow -> datasetDao.insert(newDatasetRow));
 
-    final List<DatasetRow> datasetRows = datasetDao.findAll(namespaceName, LIMIT, 2);
-    assertThat(datasetRows).isNotNull();
-    assertThat(datasetRows).hasSize(2);
-    assertThat(datasetRows.get(0).getUuid()).isEqualTo(newDatasetRows.get(2).getUuid());
-    assertThat(datasetRows.get(1).getUuid()).isEqualTo(newDatasetRows.get(3).getUuid());
+    final List<DatasetRowExtended> datasetRowsExtended =
+        datasetDao.findAll(namespaceName, LIMIT, 2);
+    assertThat(datasetRowsExtended).isNotNull();
+    assertThat(datasetRowsExtended).hasSize(2);
+    assertThat(datasetRowsExtended.get(0).getUuid()).isEqualTo(newDatasetRows.get(2).getUuid());
+    assertThat(datasetRowsExtended.get(1).getUuid()).isEqualTo(newDatasetRows.get(3).getUuid());
   }
 }

--- a/src/test/java/marquez/db/mappers/DatasetRowExtendedMapperTest.java
+++ b/src/test/java/marquez/db/mappers/DatasetRowExtendedMapperTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package marquez.db.mappers;
+
+import static marquez.common.models.CommonModelGenerator.newDatasetName;
+import static marquez.common.models.CommonModelGenerator.newDatasetUrn;
+import static marquez.common.models.CommonModelGenerator.newDatasourceUrn;
+import static marquez.common.models.CommonModelGenerator.newDescription;
+import static marquez.common.models.Description.NO_DESCRIPTION;
+import static marquez.db.models.DbModelGenerator.newRowUuid;
+import static marquez.db.models.DbModelGenerator.newTimestamp;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+import marquez.UnitTests;
+import marquez.common.models.DatasetName;
+import marquez.common.models.DatasetUrn;
+import marquez.common.models.DatasourceUrn;
+import marquez.common.models.Description;
+import marquez.db.Columns;
+import marquez.db.models.DatasetRowExtended;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(UnitTests.class)
+public class DatasetRowExtendedMapperTest {
+  private static final UUID ROW_UUID = newRowUuid();
+  private static final Instant CREATED_AT = newTimestamp();
+  private static final Instant UPDATED_AT = CREATED_AT;
+  private static final UUID NAMESPACE_ROW_UUID = newRowUuid();
+  private static final UUID DATASOURCE_ROW_UUID = newRowUuid();
+  private static final DatasetName NAME = newDatasetName();
+  private static final DatasetUrn URN = newDatasetUrn();
+  private static final DatasourceUrn DATASOURCE_URN = newDatasourceUrn();
+  private static final Description DESCRIPTION = newDescription();
+  private static final UUID CURRENT_VERSION_UUID = newRowUuid();
+
+  @Test
+  public void testMap_row() throws SQLException {
+    final Object exists = mock(Object.class);
+    final ResultSet results = mock(ResultSet.class);
+    when(results.getObject(Columns.ROW_UUID)).thenReturn(exists);
+    when(results.getObject(Columns.CREATED_AT)).thenReturn(exists);
+    when(results.getObject(Columns.UPDATED_AT)).thenReturn(exists);
+    when(results.getObject(Columns.NAMESPACE_UUID)).thenReturn(exists);
+    when(results.getObject(Columns.DATASOURCE_UUID)).thenReturn(exists);
+    when(results.getObject(Columns.NAME)).thenReturn(exists);
+    when(results.getObject(Columns.URN)).thenReturn(exists);
+    when(results.getObject(Columns.DATASOURCE_URN)).thenReturn(exists);
+    when(results.getObject(Columns.DESCRIPTION)).thenReturn(exists);
+    when(results.getObject(Columns.CURRENT_VERSION_UUID)).thenReturn(exists);
+
+    when(results.getObject(Columns.ROW_UUID, UUID.class)).thenReturn(ROW_UUID);
+    when(results.getTimestamp(Columns.CREATED_AT)).thenReturn(Timestamp.from(CREATED_AT));
+    when(results.getTimestamp(Columns.UPDATED_AT)).thenReturn(Timestamp.from(UPDATED_AT));
+    when(results.getObject(Columns.NAMESPACE_UUID, UUID.class)).thenReturn(NAMESPACE_ROW_UUID);
+    when(results.getObject(Columns.DATASOURCE_UUID, UUID.class)).thenReturn(DATASOURCE_ROW_UUID);
+    when(results.getString(Columns.NAME)).thenReturn(NAME.getValue());
+    when(results.getString(Columns.URN)).thenReturn(URN.getValue());
+    when(results.getString(Columns.DATASOURCE_URN)).thenReturn(DATASOURCE_URN.getValue());
+    when(results.getString(Columns.DESCRIPTION)).thenReturn(DESCRIPTION.getValue());
+    when(results.getObject(Columns.CURRENT_VERSION_UUID, UUID.class))
+        .thenReturn(CURRENT_VERSION_UUID);
+
+    final StatementContext context = mock(StatementContext.class);
+
+    final DatasetRowExtendedMapper rowExtendedMapper = new DatasetRowExtendedMapper();
+    final DatasetRowExtended rowExtended = rowExtendedMapper.map(results, context);
+    assertThat(rowExtended.getUuid()).isEqualTo(ROW_UUID);
+    assertThat(rowExtended.getCreatedAt()).isEqualTo(CREATED_AT);
+    assertThat(rowExtended.getUpdatedAt()).isEqualTo(UPDATED_AT);
+    assertThat(rowExtended.getNamespaceUuid()).isEqualTo(NAMESPACE_ROW_UUID);
+    assertThat(rowExtended.getDatasourceUuid()).isEqualTo(DATASOURCE_ROW_UUID);
+    assertThat(rowExtended.getName()).isEqualTo(NAME.getValue());
+    assertThat(rowExtended.getUrn()).isEqualTo(URN.getValue());
+    assertThat(rowExtended.getDatasourceUrn()).isEqualTo(DATASOURCE_URN.getValue());
+    assertThat(rowExtended.getDescription()).isEqualTo(DESCRIPTION.getValue());
+    assertThat(rowExtended.getCurrentVersionUuid()).isEqualTo(CURRENT_VERSION_UUID);
+  }
+
+  @Test
+  public void testMap_row_noDescription() throws SQLException {
+    final Object exists = mock(Object.class);
+    final ResultSet results = mock(ResultSet.class);
+    when(results.getObject(Columns.ROW_UUID)).thenReturn(exists);
+    when(results.getObject(Columns.CREATED_AT)).thenReturn(exists);
+    when(results.getObject(Columns.UPDATED_AT)).thenReturn(exists);
+    when(results.getObject(Columns.NAMESPACE_UUID)).thenReturn(exists);
+    when(results.getObject(Columns.DATASOURCE_UUID)).thenReturn(exists);
+    when(results.getObject(Columns.NAME)).thenReturn(exists);
+    when(results.getObject(Columns.URN)).thenReturn(exists);
+    when(results.getObject(Columns.DATASOURCE_URN)).thenReturn(exists);
+    when(results.getObject(Columns.DESCRIPTION)).thenReturn(NO_DESCRIPTION.getValue());
+    when(results.getObject(Columns.CURRENT_VERSION_UUID)).thenReturn(exists);
+
+    when(results.getObject(Columns.ROW_UUID, UUID.class)).thenReturn(ROW_UUID);
+    when(results.getTimestamp(Columns.CREATED_AT)).thenReturn(Timestamp.from(CREATED_AT));
+    when(results.getTimestamp(Columns.UPDATED_AT)).thenReturn(Timestamp.from(UPDATED_AT));
+    when(results.getObject(Columns.NAMESPACE_UUID, UUID.class)).thenReturn(NAMESPACE_ROW_UUID);
+    when(results.getObject(Columns.DATASOURCE_UUID, UUID.class)).thenReturn(DATASOURCE_ROW_UUID);
+    when(results.getString(Columns.NAME)).thenReturn(NAME.getValue());
+    when(results.getString(Columns.URN)).thenReturn(URN.getValue());
+    when(results.getString(Columns.DATASOURCE_URN)).thenReturn(DATASOURCE_URN.getValue());
+    when(results.getObject(Columns.CURRENT_VERSION_UUID, UUID.class))
+        .thenReturn(CURRENT_VERSION_UUID);
+
+    final StatementContext context = mock(StatementContext.class);
+
+    final DatasetRowExtendedMapper rowExtendedMapper = new DatasetRowExtendedMapper();
+    final DatasetRowExtended rowExtended = rowExtendedMapper.map(results, context);
+    assertThat(rowExtended.getUuid()).isEqualTo(ROW_UUID);
+    assertThat(rowExtended.getCreatedAt()).isEqualTo(CREATED_AT);
+    assertThat(rowExtended.getUpdatedAt()).isEqualTo(UPDATED_AT);
+    assertThat(rowExtended.getNamespaceUuid()).isEqualTo(NAMESPACE_ROW_UUID);
+    assertThat(rowExtended.getDatasourceUuid()).isEqualTo(DATASOURCE_ROW_UUID);
+    assertThat(rowExtended.getName()).isEqualTo(NAME.getValue());
+    assertThat(rowExtended.getUrn()).isEqualTo(URN.getValue());
+    assertThat(rowExtended.getDatasourceUrn()).isEqualTo(DATASOURCE_URN.getValue());
+    assertThat(rowExtended.getDescription()).isNull();
+    assertThat(rowExtended.getCurrentVersionUuid()).isEqualTo(CURRENT_VERSION_UUID);
+
+    verify(results, never()).getString(Columns.DESCRIPTION);
+  }
+
+  @Test
+  public void testMap_throwsException_onNullResults() throws SQLException {
+    final ResultSet nullResults = null;
+    final StatementContext context = mock(StatementContext.class);
+    final DatasetRowExtendedMapper rowExtendedMapper = new DatasetRowExtendedMapper();
+    assertThatNullPointerException().isThrownBy(() -> rowExtendedMapper.map(nullResults, context));
+  }
+
+  @Test
+  public void testMap_throwsException_onNullContext() throws SQLException {
+    final ResultSet results = mock(ResultSet.class);
+    final StatementContext nullContext = null;
+    final DatasetRowExtendedMapper rowExtendedMapper = new DatasetRowExtendedMapper();
+    assertThatNullPointerException().isThrownBy(() -> rowExtendedMapper.map(results, nullContext));
+  }
+}

--- a/src/test/java/marquez/db/mappers/DatasetRowExtendedMapperTest.java
+++ b/src/test/java/marquez/db/mappers/DatasetRowExtendedMapperTest.java
@@ -41,6 +41,7 @@ import marquez.common.models.Description;
 import marquez.db.Columns;
 import marquez.db.models.DatasetRowExtended;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -57,10 +58,19 @@ public class DatasetRowExtendedMapperTest {
   private static final Description DESCRIPTION = newDescription();
   private static final UUID CURRENT_VERSION_UUID = newRowUuid();
 
+  private Object exists;
+  private ResultSet results;
+  private StatementContext context;
+
+  @Before
+  public void setUp() {
+    exists = mock(Object.class);
+    results = mock(ResultSet.class);
+    context = mock(StatementContext.class);
+  }
+
   @Test
   public void testMap_row() throws SQLException {
-    final Object exists = mock(Object.class);
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(Columns.ROW_UUID)).thenReturn(exists);
     when(results.getObject(Columns.CREATED_AT)).thenReturn(exists);
     when(results.getObject(Columns.UPDATED_AT)).thenReturn(exists);
@@ -83,8 +93,6 @@ public class DatasetRowExtendedMapperTest {
     when(results.getString(Columns.DESCRIPTION)).thenReturn(DESCRIPTION.getValue());
     when(results.getObject(Columns.CURRENT_VERSION_UUID, UUID.class))
         .thenReturn(CURRENT_VERSION_UUID);
-
-    final StatementContext context = mock(StatementContext.class);
 
     final DatasetRowExtendedMapper rowExtendedMapper = new DatasetRowExtendedMapper();
     final DatasetRowExtended rowExtended = rowExtendedMapper.map(results, context);
@@ -126,8 +134,6 @@ public class DatasetRowExtendedMapperTest {
     when(results.getObject(Columns.CURRENT_VERSION_UUID, UUID.class))
         .thenReturn(CURRENT_VERSION_UUID);
 
-    final StatementContext context = mock(StatementContext.class);
-
     final DatasetRowExtendedMapper rowExtendedMapper = new DatasetRowExtendedMapper();
     final DatasetRowExtended rowExtended = rowExtendedMapper.map(results, context);
     assertThat(rowExtended.getUuid()).isEqualTo(ROW_UUID);
@@ -138,7 +144,7 @@ public class DatasetRowExtendedMapperTest {
     assertThat(rowExtended.getName()).isEqualTo(NAME.getValue());
     assertThat(rowExtended.getUrn()).isEqualTo(URN.getValue());
     assertThat(rowExtended.getDatasourceUrn()).isEqualTo(DATASOURCE_URN.getValue());
-    assertThat(rowExtended.getDescription()).isNull();
+    assertThat(rowExtended.getDescription()).isEqualTo(NO_DESCRIPTION.getValue());
     assertThat(rowExtended.getCurrentVersionUuid()).isEqualTo(CURRENT_VERSION_UUID);
 
     verify(results, never()).getString(Columns.DESCRIPTION);

--- a/src/test/java/marquez/db/models/DbModelGenerator.java
+++ b/src/test/java/marquez/db/models/DbModelGenerator.java
@@ -52,7 +52,7 @@ public final class DbModelGenerator {
   public static NamespaceRow newNamespaceRowWith(NamespaceName namespaceName, boolean wasUpdated) {
     final NamespaceRow.NamespaceRowBuilder builder =
         NamespaceRow.builder()
-            .uuid(UUID.randomUUID())
+            .uuid(newRowUuid())
             .createdAt(newTimestamp())
             .updatedAt(newTimestamp())
             .name(namespaceName.getValue())
@@ -78,7 +78,7 @@ public final class DbModelGenerator {
   public static DatasourceRow newDatasourceRowWith(
       DatasourceName datasourceName, DatasourceUrn datasourceUrn) {
     return DatasourceRow.builder()
-        .uuid(UUID.randomUUID())
+        .uuid(newRowUuid())
         .createdAt(newTimestamp())
         .name(datasourceName.getValue())
         .urn(datasourceUrn.getValue())
@@ -107,7 +107,7 @@ public final class DbModelGenerator {
 
   public static DatasetRow newDatasetRowWith(DatasetUrn datasetUrn) {
     return newDatasetRowWith(
-        UUID.randomUUID(),
+        newRowUuid(),
         newNamespaceRow().getUuid(),
         newDatasourceRow().getUuid(),
         datasetUrn,
@@ -117,7 +117,7 @@ public final class DbModelGenerator {
 
   public static DatasetRow newDatasetRowWith(Description description) {
     return newDatasetRowWith(
-        UUID.randomUUID(),
+        newRowUuid(),
         newNamespaceRow().getUuid(),
         newDatasourceRow().getUuid(),
         newDatasetUrn(),
@@ -127,7 +127,7 @@ public final class DbModelGenerator {
 
   public static DatasetRow newDatasetRowWith(boolean wasUpdated) {
     return newDatasetRowWith(
-        UUID.randomUUID(),
+        newRowUuid(),
         newNamespaceRow().getUuid(),
         newDatasourceRow().getUuid(),
         newDatasetUrn(),
@@ -147,13 +147,13 @@ public final class DbModelGenerator {
 
   public static DatasetRow newDatasetRowWith(UUID namespaceUuid, UUID datasourceUuid) {
     return newDatasetRowWith(
-        UUID.randomUUID(), namespaceUuid, datasourceUuid, newDatasetUrn(), newDescription(), false);
+        newRowUuid(), namespaceUuid, datasourceUuid, newDatasetUrn(), newDescription(), false);
   }
 
   public static DatasetRow newDatasetRowWith(
       UUID namespaceUuid, UUID datasourceUuid, DatasetUrn datasetUrn) {
     return newDatasetRowWith(
-        UUID.randomUUID(), namespaceUuid, datasourceUuid, datasetUrn, newDescription(), false);
+        newRowUuid(), namespaceUuid, datasourceUuid, datasetUrn, newDescription(), false);
   }
 
   public static DatasetRow newDatasetRowWith(UUID uuid, UUID namespaceUuid, UUID datasourceUuid) {
@@ -180,7 +180,7 @@ public final class DbModelGenerator {
 
     if (wasUpdated) {
       builder.updatedAt(newTimestamp());
-      builder.currentVersionUuid(UUID.randomUUID());
+      builder.currentVersionUuid(newRowUuid());
     }
 
     return builder.build();
@@ -210,7 +210,7 @@ public final class DbModelGenerator {
       boolean wasUpdated) {
     final DatasetRowExtended.DatasetRowExtendedBuilder builder =
         DatasetRowExtended.builder()
-            .uuid(UUID.randomUUID())
+            .uuid(newRowUuid())
             .createdAt(newTimestamp())
             .namespaceUuid(newNamespaceRow().getUuid())
             .datasourceUuid(newDatasourceRow().getUuid())
@@ -221,13 +221,17 @@ public final class DbModelGenerator {
 
     if (wasUpdated) {
       builder.updatedAt(newTimestamp());
-      builder.currentVersionUuid(UUID.randomUUID());
+      builder.currentVersionUuid(newRowUuid());
     }
 
     return builder.build();
   }
 
-  private static Instant newTimestamp() {
+  public static UUID newRowUuid() {
+    return UUID.randomUUID();
+  }
+
+  public static Instant newTimestamp() {
     return Instant.now();
   }
 }

--- a/src/test/java/marquez/db/models/DbModelGenerator.java
+++ b/src/test/java/marquez/db/models/DbModelGenerator.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 import marquez.common.models.DatasetUrn;
 import marquez.common.models.DatasourceName;
 import marquez.common.models.DatasourceUrn;
+import marquez.common.models.Description;
 import marquez.common.models.NamespaceName;
 
 public final class DbModelGenerator {
@@ -106,31 +107,58 @@ public final class DbModelGenerator {
 
   public static DatasetRow newDatasetRowWith(DatasetUrn datasetUrn) {
     return newDatasetRowWith(
-        UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), datasetUrn, false);
+        UUID.randomUUID(),
+        newNamespaceRow().getUuid(),
+        newDatasourceRow().getUuid(),
+        datasetUrn,
+        newDescription(),
+        false);
+  }
+
+  public static DatasetRow newDatasetRowWith(Description description) {
+    return newDatasetRowWith(
+        UUID.randomUUID(),
+        newNamespaceRow().getUuid(),
+        newDatasourceRow().getUuid(),
+        newDatasetUrn(),
+        description,
+        false);
   }
 
   public static DatasetRow newDatasetRowWith(boolean wasUpdated) {
     return newDatasetRowWith(
-        UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), newDatasetUrn(), wasUpdated);
+        UUID.randomUUID(),
+        newNamespaceRow().getUuid(),
+        newDatasourceRow().getUuid(),
+        newDatasetUrn(),
+        newDescription(),
+        wasUpdated);
   }
 
   public static DatasetRow newDatasetRowWith(UUID uuid, boolean wasUpdated) {
     return newDatasetRowWith(
-        uuid, UUID.randomUUID(), UUID.randomUUID(), newDatasetUrn(), wasUpdated);
+        uuid,
+        newNamespaceRow().getUuid(),
+        newDatasourceRow().getUuid(),
+        newDatasetUrn(),
+        newDescription(),
+        wasUpdated);
   }
 
   public static DatasetRow newDatasetRowWith(UUID namespaceUuid, UUID datasourceUuid) {
     return newDatasetRowWith(
-        UUID.randomUUID(), namespaceUuid, datasourceUuid, newDatasetUrn(), false);
+        UUID.randomUUID(), namespaceUuid, datasourceUuid, newDatasetUrn(), newDescription(), false);
   }
 
   public static DatasetRow newDatasetRowWith(
       UUID namespaceUuid, UUID datasourceUuid, DatasetUrn datasetUrn) {
-    return newDatasetRowWith(UUID.randomUUID(), namespaceUuid, datasourceUuid, datasetUrn, false);
+    return newDatasetRowWith(
+        UUID.randomUUID(), namespaceUuid, datasourceUuid, datasetUrn, newDescription(), false);
   }
 
   public static DatasetRow newDatasetRowWith(UUID uuid, UUID namespaceUuid, UUID datasourceUuid) {
-    return newDatasetRowWith(uuid, namespaceUuid, datasourceUuid, newDatasetUrn(), false);
+    return newDatasetRowWith(
+        uuid, namespaceUuid, datasourceUuid, newDatasetUrn(), newDescription(), false);
   }
 
   public static DatasetRow newDatasetRowWith(
@@ -138,6 +166,7 @@ public final class DbModelGenerator {
       UUID namespaceUuid,
       UUID datasourceUuid,
       DatasetUrn datasetUrn,
+      Description description,
       boolean wasUpdated) {
     final DatasetRow.DatasetRowBuilder builder =
         DatasetRow.builder()
@@ -147,7 +176,48 @@ public final class DbModelGenerator {
             .datasourceUuid(datasourceUuid)
             .name(newDatasetName().getValue())
             .urn(datasetUrn.getValue())
-            .description(newDescription().getValue());
+            .description(description.getValue());
+
+    if (wasUpdated) {
+      builder.updatedAt(newTimestamp());
+      builder.currentVersionUuid(UUID.randomUUID());
+    }
+
+    return builder.build();
+  }
+
+  public static List<DatasetRowExtended> newDatasetRowsExtended(int limit) {
+    return Stream.generate(() -> newDatasetRowExtended()).limit(limit).collect(toList());
+  }
+
+  public static DatasetRowExtended newDatasetRowExtended() {
+    return newDatasetRowExtendedWith(newDatasetUrn(), newDatasourceUrn());
+  }
+
+  public static DatasetRowExtended newDatasetRowExtendedWith(
+      DatasetUrn datasetUrn, DatasourceUrn datasourceUrn) {
+    return newDatasetRowExtendedWith(datasetUrn, datasourceUrn, newDescription(), false);
+  }
+
+  public static DatasetRowExtended newDatasetRowExtendedWith(Description description) {
+    return newDatasetRowExtendedWith(newDatasetUrn(), newDatasourceUrn(), description, false);
+  }
+
+  public static DatasetRowExtended newDatasetRowExtendedWith(
+      DatasetUrn datasetUrn,
+      DatasourceUrn datasourceUrn,
+      Description description,
+      boolean wasUpdated) {
+    final DatasetRowExtended.DatasetRowExtendedBuilder builder =
+        DatasetRowExtended.builder()
+            .uuid(UUID.randomUUID())
+            .createdAt(newTimestamp())
+            .namespaceUuid(newNamespaceRow().getUuid())
+            .datasourceUuid(newDatasourceRow().getUuid())
+            .name(newDatasetName().getValue())
+            .urn(datasetUrn.getValue())
+            .datasourceUrn(datasourceUrn.getValue())
+            .description(description.getValue());
 
     if (wasUpdated) {
       builder.updatedAt(newTimestamp());

--- a/src/test/java/marquez/db/models/DbModelGenerator.java
+++ b/src/test/java/marquez/db/models/DbModelGenerator.java
@@ -209,7 +209,7 @@ public final class DbModelGenerator {
       Description description,
       boolean wasUpdated) {
     final DatasetRowExtended.DatasetRowExtendedBuilder builder =
-        DatasetRowExtended.builder()
+        DatasetRowExtended.builderExtended()
             .uuid(newRowUuid())
             .createdAt(newTimestamp())
             .namespaceUuid(newNamespaceRow().getUuid())

--- a/src/test/java/marquez/service/DatasetServiceTest.java
+++ b/src/test/java/marquez/service/DatasetServiceTest.java
@@ -19,8 +19,8 @@ import static marquez.common.models.CommonModelGenerator.newDatasetName;
 import static marquez.common.models.CommonModelGenerator.newDatasourceName;
 import static marquez.common.models.CommonModelGenerator.newDescription;
 import static marquez.common.models.CommonModelGenerator.newNamespaceName;
-import static marquez.db.models.DbModelGenerator.newDatasetRowWith;
-import static marquez.db.models.DbModelGenerator.newDatasetRows;
+import static marquez.db.models.DbModelGenerator.newDatasetRowExtendedWith;
+import static marquez.db.models.DbModelGenerator.newDatasetRowsExtended;
 import static marquez.db.models.DbModelGenerator.newDatasourceRowWith;
 import static marquez.db.models.DbModelGenerator.newNamespaceRowWith;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,6 +49,7 @@ import marquez.db.DatasetDao;
 import marquez.db.DatasourceDao;
 import marquez.db.NamespaceDao;
 import marquez.db.models.DatasetRow;
+import marquez.db.models.DatasetRowExtended;
 import marquez.db.models.DatasourceRow;
 import marquez.db.models.NamespaceRow;
 import marquez.service.exceptions.MarquezServiceException;
@@ -132,7 +133,7 @@ public class DatasetServiceTest {
             .build();
     when(datasetDao.insertAndGet(any(DatasetRow.class))).thenReturn(Optional.of(datasetRow));
 
-    final Dataset expected = DatasetMapper.map(datasetRow);
+    final Dataset expected = DatasetMapper.map(DATASOURCE_URN, datasetRow);
     final Dataset actual = datasetService.create(NAMESPACE_NAME, NEW_DATASET);
     assertThat(actual).isEqualTo(expected);
 
@@ -221,8 +222,9 @@ public class DatasetServiceTest {
 
   @Test
   public void testGet() throws MarquezServiceException {
-    final DatasetRow datasetRow = newDatasetRowWith(DATASET_URN);
-    when(datasetDao.findBy(DATASET_URN)).thenReturn(Optional.of(datasetRow));
+    final DatasetRowExtended datasetRowExtended =
+        newDatasetRowExtendedWith(DATASET_URN, DATASOURCE_URN);
+    when(datasetDao.findBy(DATASET_URN)).thenReturn(Optional.of(datasetRowExtended));
 
     final Dataset dataset = datasetService.get(DATASET_URN).orElse(null);
     assertThat(dataset).isNotNull();
@@ -251,8 +253,8 @@ public class DatasetServiceTest {
 
   @Test
   public void testList() throws MarquezServiceException {
-    final List<DatasetRow> datasetRows = newDatasetRows(4);
-    when(datasetDao.findAll(NAMESPACE_NAME, LIMIT, OFFSET)).thenReturn(datasetRows);
+    final List<DatasetRowExtended> datasetRowsExtended = newDatasetRowsExtended(4);
+    when(datasetDao.findAll(NAMESPACE_NAME, LIMIT, OFFSET)).thenReturn(datasetRowsExtended);
 
     final List<Dataset> datasets = datasetService.getAll(NAMESPACE_NAME, LIMIT, OFFSET);
     assertThat(datasets).isNotNull();


### PR DESCRIPTION
This PR updates **class** [DatasetResponse](https://github.com/MarquezProject/marquez/blob/feature/return-datasource-urn/src/main/java/marquez/api/models/DatasetResponse.java) by adding the field `datasource_urn`. To support table joins, the concept of _extended_ rows has also been introduced, see example usage [here](https://github.com/MarquezProject/marquez/blob/feature/return-datasource-urn/src/main/java/marquez/db/DatasetDao.java#L107)

## Examples

### Create a dataset

#### REQUEST

#### `POST` `/namespaces/wedata/datasets`

```json
{
  "name": "public.room_bookings_7_days",
  "datasourceUrn": "urn:datasource:postgresql:analytics_db",
  "description": "All global room bookings for each office."
}
```

#### RESPONSE

```json
{
  "name": "public.room_bookings_7_days",
  "createdAt": "2019-05-10T20:21:01.543169Z",
  "urn": "urn:dataset:analytics_db:public.room_bookings_7_days",
  "datasourceUrn": "urn:datasource:postgresql:analytics_db",
  "description": "All global room bookings for each office."
}
```

### Retrieve a dataset

#### REQUEST

#### `GET` `/namespaces/wedata/datasets/urn:dataset:analytics_db:public.room_bookings_7_days`

#### RESPONSE

```json
{
  "name": "public.room_bookings_7_days",
  "createdAt": "2019-05-10T20:21:01.543169Z",
  "urn": "urn:dataset:analytics_db:public.room_bookings_7_days",
  "datasourceUrn": "urn:datasource:postgresql:analytics_db",
  "description": "All global room bookings for each office."
}
```

### List all dataset

#### REQUEST

#### `GET` `/namespaces/wedata/datasets`

#### RESPONSE

```json
{
  "datasets": [
    {
      "name": "public.room_bookings_7_days",
      "createdAt": "2019-05-10T20:21:01.543169Z",
      "urn": "urn:dataset:analytics_db:public.room_bookings_7_days",
      "datasourceUrn": "urn:datasource:postgresql:analytics_db",
      "description": "All global room bookings for each office."
    }
  ]
}
```