### PR TITLE
Add docker version in requirements section of Readme.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ We invite everyone to help us improve and keep documentation up to date. Documen
 * [Java 8](https://openjdk.java.net/install)+
 * [PostgreSQL 9.6](https://www.postgresql.org/download)
 * [Gradle 4.10](https://gradle.org/releases)+ (_optional_)
+* [Docker 17.05](https://docs.docker.com/develop/develop-images/multistage-build/)+ (_optional_)
 
 ## Building
 


### PR DESCRIPTION
Marquez only works with multi-stage docker and any version less than 17.05 doesn't work. 
