### PR TITLE
 Bump mockito-core to 2.27.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
   testCompile 'com.opentable.components:otj-pg-embedded:0.13.1'
   testCompile 'io.dropwizard:dropwizard-testing:1.3.9'
   testCompile 'junit:junit:4.12'
-  testCompile 'org.mockito:mockito-core:2.25.1'
+  testCompile 'org.mockito:mockito-core:2.27.0'
 }
 
 compileJava {


### PR DESCRIPTION
This PR bumps mockito-core to `2.27.0`

see: https://github.com/mockito/mockito/releases/tag/v2.27.0