### PR TITLE
Issue 533: Update test classes on Mock usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .settings
 .vscode/
 ./out/*
+out/*
 ./**/*.class
 bin/
 build/

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ You will then need to set the following environment variables (we recommend addi
 
 By default, Marquez uses the following ports:
 
-* TCP port **`8080`** is available for the HTTP API server.
-* TCP port **`8081`** is available for the admin interface.
+* TCP port `8080` is available for the HTTP API server.
+* TCP port `8081` is available for the admin interface.
 
 **Note:** All of the configuration settings in `config.yml` can be specified either in the configuration file or in an environment variable.
 
@@ -65,7 +65,7 @@ Then browse to the admin interface: http://localhost:8081
 $ docker-compose up
 ```
 
-Marquez listens on port **`5000`** for all API calls and port **`5001`** for the admin interface.
+Marquez listens on port `5000` for all API calls and port `5001` for the admin interface.
 
 ## Getting involved
 

--- a/src/test/java/marquez/api/resources/DatasetResourceTest.java
+++ b/src/test/java/marquez/api/resources/DatasetResourceTest.java
@@ -26,7 +26,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -54,8 +53,13 @@ import marquez.service.NamespaceService;
 import marquez.service.exceptions.MarquezServiceException;
 import marquez.service.models.Dataset;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 @Category(UnitTests.class)
 public class DatasetResourceTest {
@@ -80,14 +84,13 @@ public class DatasetResourceTest {
           .description(DESCRIPTION)
           .build();
 
-  private NamespaceService namespaceService;
-  private DatasetService datasetService;
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+  @Mock private NamespaceService namespaceService;
+  @Mock private DatasetService datasetService;
   private DatasetResource datasetResource;
 
   @Before
   public void setUp() {
-    namespaceService = mock(NamespaceService.class);
-    datasetService = mock(DatasetService.class);
     datasetResource = new DatasetResource(namespaceService, datasetService);
   }
 

--- a/src/test/java/marquez/api/resources/NamespaceResourceTest.java
+++ b/src/test/java/marquez/api/resources/NamespaceResourceTest.java
@@ -41,11 +41,21 @@ import marquez.service.exceptions.MarquezServiceException;
 import marquez.service.models.Namespace;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 public class NamespaceResourceTest extends NamespaceBaseTest {
 
-  NamespaceName namespaceName = NamespaceName.fromString(NAMESPACE_NAME);
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Mock private NamespaceService namespaceService;
+
+  private NamespaceName namespaceName = NamespaceName.fromString(NAMESPACE_NAME);
+
   private static final NamespaceService NAMESPACE_SERVICE = mock(NamespaceService.class);
 
   @ClassRule
@@ -78,7 +88,7 @@ public class NamespaceResourceTest extends NamespaceBaseTest {
   @Test
   public void testValidNamespace() throws MarquezServiceException {
     Optional<Namespace> returnedOptionalNamespace = Optional.of(TEST_NAMESPACE);
-    NamespaceService namespaceService = mock(NamespaceService.class);
+
     NamespaceResource namespaceResource = new NamespaceResource(namespaceService);
 
     when(namespaceService.get(namespaceName)).thenReturn(returnedOptionalNamespace);
@@ -104,7 +114,6 @@ public class NamespaceResourceTest extends NamespaceBaseTest {
   @Test
   public void testListNamespaceWithNoResults() throws MarquezServiceException {
     final List<Namespace> existingCoreModelNamespaces = Collections.emptyList();
-    NamespaceService namespaceService = mock(NamespaceService.class);
     NamespaceResource namespaceResource = new NamespaceResource(namespaceService);
     when(namespaceService.getAll()).thenReturn(existingCoreModelNamespaces);
 
@@ -117,7 +126,6 @@ public class NamespaceResourceTest extends NamespaceBaseTest {
   @Test
   public void testListNamespaceWithSingleResultSet() throws MarquezServiceException {
     final List<Namespace> existingCoreModelNamespaces = Collections.singletonList(TEST_NAMESPACE);
-    NamespaceService namespaceService = mock(NamespaceService.class);
     NamespaceResource namespaceResource = new NamespaceResource(namespaceService);
     when(namespaceService.getAll()).thenReturn(existingCoreModelNamespaces);
 
@@ -132,7 +140,6 @@ public class NamespaceResourceTest extends NamespaceBaseTest {
   public void testAllNamespaceFieldsPresentInListNamespacesResponse()
       throws MarquezServiceException {
     final List<Namespace> existingNamespaces = Collections.singletonList(TEST_NAMESPACE);
-    NamespaceService namespaceService = mock(NamespaceService.class);
     NamespaceResource namespaceResource = new NamespaceResource(namespaceService);
 
     when(namespaceService.getAll()).thenReturn(existingNamespaces);
@@ -148,7 +155,6 @@ public class NamespaceResourceTest extends NamespaceBaseTest {
 
   @Test
   public void testListNamespaceWithMultipleResultSet() throws MarquezServiceException {
-    NamespaceService namespaceService = mock(NamespaceService.class);
     NamespaceResource namespaceResource = new NamespaceResource(namespaceService);
 
     final List<Namespace> existingCoreModelNamespaces = new ArrayList<>();

--- a/src/test/java/marquez/db/ColumnsTest.java
+++ b/src/test/java/marquez/db/ColumnsTest.java
@@ -32,11 +32,10 @@ import org.junit.experimental.categories.Category;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.mockito.quality.Strictness;
 
 @Category(UnitTests.class)
 public class ColumnsTest {
-  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.WARN);
+  @Rule public MockitoRule rule = MockitoJUnit.rule();
 
   @Mock private ResultSet results;
   @Mock private Array array;

--- a/src/test/java/marquez/db/ColumnsTest.java
+++ b/src/test/java/marquez/db/ColumnsTest.java
@@ -15,7 +15,6 @@
 package marquez.db;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.sql.Array;
@@ -27,16 +26,25 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import marquez.UnitTests;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 @Category(UnitTests.class)
 public class ColumnsTest {
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.WARN);
+
+  @Mock private ResultSet results;
+  @Mock private Array array;
+
   @Test
   public void testUuidOrNull_uuid() throws SQLException {
     final String column = "with_uuid";
     final UUID expected = UUID.randomUUID();
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(column)).thenReturn(expected);
     when(results.getObject(column, UUID.class)).thenReturn(expected);
 
@@ -48,9 +56,7 @@ public class ColumnsTest {
   public void testUuidOrNull_null() throws SQLException {
     final String column = "with_null_uuid";
     final UUID expected = null;
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(column)).thenReturn(expected);
-    when(results.getObject(column, UUID.class)).thenReturn(expected);
 
     final UUID actual = Columns.uuidOrNull(results, column);
     assertThat(actual).isEqualTo(expected);
@@ -60,7 +66,6 @@ public class ColumnsTest {
   public void testUuidOrThrow_uuid() throws SQLException {
     final String column = "with_uuid";
     final UUID expected = UUID.randomUUID();
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(column)).thenReturn(expected);
     when(results.getObject(column, UUID.class)).thenReturn(expected);
 
@@ -72,7 +77,6 @@ public class ColumnsTest {
   public void testUuidOrThrow_throw() throws SQLException {
     final String column = "with_null_uuid";
     final UUID nullUuid = null;
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(column)).thenReturn(nullUuid);
 
     Columns.uuidOrThrow(results, column);
@@ -82,7 +86,6 @@ public class ColumnsTest {
   public void testTimestampOrNull_timestamp() throws SQLException {
     final String column = "with_timestamp";
     final Instant expected = Instant.now();
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(column)).thenReturn(Timestamp.from(expected));
     when(results.getTimestamp(column)).thenReturn(Timestamp.from(expected));
 
@@ -94,7 +97,6 @@ public class ColumnsTest {
   public void testTimestampOrNull_null() throws SQLException {
     final String column = "with_null_timestamp";
     final Instant expected = null;
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(column)).thenReturn(expected);
 
     final Instant actual = Columns.timestampOrNull(results, column);
@@ -105,7 +107,6 @@ public class ColumnsTest {
   public void testTimestampOrThrow_timestamp() throws SQLException {
     final String column = "with_timestamp";
     final Instant expected = Instant.now();
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(Columns.CREATED_AT)).thenReturn(expected);
 
     final Instant actual = Columns.timestampOrThrow(results, column);
@@ -116,7 +117,6 @@ public class ColumnsTest {
   public void testTimestampOrThrow_throw() throws SQLException {
     final String column = "with_null_timestamp";
     final Timestamp nullTimestamp = null;
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(Columns.CREATED_AT)).thenReturn(nullTimestamp);
 
     Columns.timestampOrThrow(results, column);
@@ -126,7 +126,6 @@ public class ColumnsTest {
   public void testStringOrNull_string() throws SQLException {
     final String column = "with_string";
     final String expected = "string";
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(column)).thenReturn(expected);
     when(results.getString(column)).thenReturn(expected);
 
@@ -138,9 +137,7 @@ public class ColumnsTest {
   public void testStringOrNull_null() throws SQLException {
     final String column = "with_null_string";
     final String expected = null;
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(column)).thenReturn(expected);
-    when(results.getString(column)).thenReturn(expected);
 
     final String actual = Columns.stringOrNull(results, column);
     assertThat(actual).isEqualTo(expected);
@@ -149,7 +146,6 @@ public class ColumnsTest {
   public void testStringOrThrow_string() throws SQLException {
     final String column = "with_string";
     final String expected = "string";
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(column)).thenReturn(expected);
     when(results.getString(column)).thenReturn(expected);
 
@@ -161,7 +157,6 @@ public class ColumnsTest {
   public void testStringOrThrow_throw() throws SQLException {
     final String column = "with_null_string";
     final String nullString = null;
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(column)).thenReturn(nullString);
 
     Columns.stringOrThrow(results, column);
@@ -171,9 +166,7 @@ public class ColumnsTest {
   public void testArrayOrThrow_array() throws SQLException {
     final String column = "with_array";
     final String[] values = new String[] {"test_value0", "test_value1", "test_value2"};
-    final Array array = mock(Array.class);
     when(array.getArray()).thenReturn(values);
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(column)).thenReturn(array);
     when(results.getArray(column)).thenReturn(array);
 
@@ -186,7 +179,6 @@ public class ColumnsTest {
   public void testArrayOrThrow_throw() throws SQLException {
     final String column = "with_null_array";
     final Array nullArray = null;
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(column)).thenReturn(nullArray);
 
     Columns.arrayOrThrow(results, column);

--- a/src/test/java/marquez/db/mappers/DatasetRowExtendedMapperTest.java
+++ b/src/test/java/marquez/db/mappers/DatasetRowExtendedMapperTest.java
@@ -23,7 +23,6 @@ import static marquez.db.models.DbModelGenerator.newRowUuid;
 import static marquez.db.models.DbModelGenerator.newTimestamp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -41,9 +40,13 @@ import marquez.common.models.Description;
 import marquez.db.Columns;
 import marquez.db.models.DatasetRowExtended;
 import org.jdbi.v3.core.statement.StatementContext;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 @Category(UnitTests.class)
 public class DatasetRowExtendedMapperTest {
@@ -58,16 +61,11 @@ public class DatasetRowExtendedMapperTest {
   private static final Description DESCRIPTION = newDescription();
   private static final UUID CURRENT_VERSION_UUID = newRowUuid();
 
-  private Object exists;
-  private ResultSet results;
-  private StatementContext context;
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
 
-  @Before
-  public void setUp() {
-    exists = mock(Object.class);
-    results = mock(ResultSet.class);
-    context = mock(StatementContext.class);
-  }
+  @Mock private Object exists;
+  @Mock private ResultSet results;
+  @Mock private StatementContext context;
 
   @Test
   public void testMap_row() throws SQLException {
@@ -110,8 +108,6 @@ public class DatasetRowExtendedMapperTest {
 
   @Test
   public void testMap_row_noDescription() throws SQLException {
-    final Object exists = mock(Object.class);
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(Columns.ROW_UUID)).thenReturn(exists);
     when(results.getObject(Columns.CREATED_AT)).thenReturn(exists);
     when(results.getObject(Columns.UPDATED_AT)).thenReturn(exists);
@@ -153,14 +149,12 @@ public class DatasetRowExtendedMapperTest {
   @Test
   public void testMap_throwsException_onNullResults() throws SQLException {
     final ResultSet nullResults = null;
-    final StatementContext context = mock(StatementContext.class);
     final DatasetRowExtendedMapper rowExtendedMapper = new DatasetRowExtendedMapper();
     assertThatNullPointerException().isThrownBy(() -> rowExtendedMapper.map(nullResults, context));
   }
 
   @Test
   public void testMap_throwsException_onNullContext() throws SQLException {
-    final ResultSet results = mock(ResultSet.class);
     final StatementContext nullContext = null;
     final DatasetRowExtendedMapper rowExtendedMapper = new DatasetRowExtendedMapper();
     assertThatNullPointerException().isThrownBy(() -> rowExtendedMapper.map(results, nullContext));

--- a/src/test/java/marquez/db/mappers/DatasetRowMapperTest.java
+++ b/src/test/java/marquez/db/mappers/DatasetRowMapperTest.java
@@ -38,11 +38,13 @@ import marquez.common.models.Description;
 import marquez.db.Columns;
 import marquez.db.models.DatasetRow;
 import org.jdbi.v3.core.statement.StatementContext;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 @Category(UnitTests.class)
 public class DatasetRowMapperTest {
@@ -56,14 +58,11 @@ public class DatasetRowMapperTest {
   private static final Description DESCRIPTION = newDescription();
   private static final UUID CURRENT_VERSION_UUID = newRowUuid();
 
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
   @Mock private Object exists;
   @Mock private ResultSet results;
   @Mock private StatementContext context;
-
-  @Before
-  public void setup() {
-    MockitoAnnotations.initMocks(this);
-  }
 
   @Test
   public void testMap_row() throws SQLException {

--- a/src/test/java/marquez/db/mappers/DatasourceRowMapperTest.java
+++ b/src/test/java/marquez/db/mappers/DatasourceRowMapperTest.java
@@ -18,7 +18,6 @@ import static marquez.common.models.CommonModelGenerator.newConnectionUrl;
 import static marquez.common.models.CommonModelGenerator.newDatasourceName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.sql.ResultSet;
@@ -33,8 +32,13 @@ import marquez.common.models.DatasourceUrn;
 import marquez.db.Columns;
 import marquez.db.models.DatasourceRow;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 @Category(UnitTests.class)
 public class DatasourceRowMapperTest {
@@ -44,10 +48,14 @@ public class DatasourceRowMapperTest {
   private static final ConnectionUrl CONNECTION_URL = newConnectionUrl();
   private static final DatasourceUrn URN = DatasourceUrn.from(CONNECTION_URL, NAME);
 
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Mock private Object exists;
+  @Mock private ResultSet results;
+  @Mock private StatementContext context;
+
   @Test
   public void testMap() throws SQLException {
-    final Object exists = mock(Object.class);
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(Columns.ROW_UUID)).thenReturn(exists);
     when(results.getObject(Columns.CREATED_AT)).thenReturn(exists);
     when(results.getObject(Columns.NAME)).thenReturn(exists);
@@ -59,8 +67,6 @@ public class DatasourceRowMapperTest {
     when(results.getString(Columns.NAME)).thenReturn(NAME.getValue());
     when(results.getString(Columns.URN)).thenReturn(URN.getValue());
     when(results.getString(Columns.CONNECTION_URL)).thenReturn(CONNECTION_URL.getRawValue());
-
-    final StatementContext context = mock(StatementContext.class);
 
     final DatasourceRowMapper rowMapper = new DatasourceRowMapper();
     final DatasourceRow row = rowMapper.map(results, context);
@@ -74,14 +80,12 @@ public class DatasourceRowMapperTest {
   @Test
   public void testMap_throwsException_onNullResults() throws SQLException {
     final ResultSet nullResults = null;
-    final StatementContext context = mock(StatementContext.class);
     final DatasourceRowMapper rowMapper = new DatasourceRowMapper();
     assertThatNullPointerException().isThrownBy(() -> rowMapper.map(nullResults, context));
   }
 
   @Test
   public void testMap_throwsException_onNullContext() throws SQLException {
-    final ResultSet results = mock(ResultSet.class);
     final StatementContext nullContext = null;
     final DatasourceRowMapper rowMapper = new DatasourceRowMapper();
     assertThatNullPointerException().isThrownBy(() -> rowMapper.map(results, nullContext));

--- a/src/test/java/marquez/db/mappers/DbTableInfoRowMapperTest.java
+++ b/src/test/java/marquez/db/mappers/DbTableInfoRowMapperTest.java
@@ -15,7 +15,6 @@
 package marquez.db.mappers;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.sql.ResultSet;
@@ -27,8 +26,13 @@ import marquez.UnitTests;
 import marquez.db.Columns;
 import marquez.db.models.DbTableInfoRow;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 @Category(UnitTests.class)
 public class DbTableInfoRowMapperTest {
@@ -37,17 +41,20 @@ public class DbTableInfoRowMapperTest {
   private static final String DBNAME = "db";
   private static final String DBSCHEMA = "db_schema";
 
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Mock private Object exists;
+  @Mock private ResultSet results;
+  @Mock private StatementContext context;
+
   @Test
   public void testMap() throws SQLException {
-    final Object exists = mock(Object.class);
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(Columns.CREATED_AT)).thenReturn(exists);
 
     when(results.getObject(Columns.ROW_UUID, UUID.class)).thenReturn(ROW_UUID);
     when(results.getTimestamp(Columns.CREATED_AT)).thenReturn(Timestamp.from(CREATED_AT));
     when(results.getString(Columns.DB_NAME)).thenReturn(DBNAME);
     when(results.getString(Columns.DB_SCHEMA_NAME)).thenReturn(DBSCHEMA);
-    final StatementContext context = mock(StatementContext.class);
 
     final DbTableInfoRowMapper dbTableInfoRowMapper = new DbTableInfoRowMapper();
     final DbTableInfoRow dbTableInfoRow = dbTableInfoRowMapper.map(results, context);
@@ -60,14 +67,12 @@ public class DbTableInfoRowMapperTest {
   @Test(expected = NullPointerException.class)
   public void testMap_throwsException_onNullResults() throws SQLException {
     final ResultSet nullResults = null;
-    final StatementContext context = mock(StatementContext.class);
     final DbTableInfoRowMapper datasourceRowMapper = new DbTableInfoRowMapper();
     datasourceRowMapper.map(nullResults, context);
   }
 
   @Test(expected = NullPointerException.class)
   public void testMap_throwsException_onNullContext() throws SQLException {
-    final ResultSet results = mock(ResultSet.class);
     final StatementContext nullContext = null;
     final DbTableInfoRowMapper datasourceRowMapper = new DbTableInfoRowMapper();
     datasourceRowMapper.map(results, nullContext);

--- a/src/test/java/marquez/db/mappers/DbTableVersionRowMapperTest.java
+++ b/src/test/java/marquez/db/mappers/DbTableVersionRowMapperTest.java
@@ -15,7 +15,6 @@
 package marquez.db.mappers;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.sql.ResultSet;
@@ -27,8 +26,13 @@ import marquez.UnitTests;
 import marquez.db.Columns;
 import marquez.db.models.DbTableVersionRow;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 @Category(UnitTests.class)
 public class DbTableVersionRowMapperTest {
@@ -38,10 +42,14 @@ public class DbTableVersionRowMapperTest {
   private static final UUID DB_TABLE_INFO_UUID = UUID.randomUUID();
   private static final String DB_TABLE_NAME = "Test_Table_Name";
 
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Mock private Object exists;
+  @Mock private ResultSet results;
+  @Mock private StatementContext context;
+
   @Test
   public void testMap() throws SQLException {
-    final Object exists = mock(Object.class);
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(Columns.CREATED_AT)).thenReturn(exists);
 
     when(results.getObject(Columns.ROW_UUID, UUID.class)).thenReturn(ROW_UUID);
@@ -49,8 +57,6 @@ public class DbTableVersionRowMapperTest {
     when(results.getObject(Columns.DATASET_UUID, UUID.class)).thenReturn(DATASET_UUID);
     when(results.getObject(Columns.DB_TABLE_INFO_UUID, UUID.class)).thenReturn(DB_TABLE_INFO_UUID);
     when(results.getString(Columns.DB_TABLE_NAME)).thenReturn(DB_TABLE_NAME);
-
-    final StatementContext context = mock(StatementContext.class);
 
     final DbTableVersionRowMapper dbTableVersionRowMapper = new DbTableVersionRowMapper();
     final DbTableVersionRow dbTableVersionRow = dbTableVersionRowMapper.map(results, context);
@@ -64,14 +70,12 @@ public class DbTableVersionRowMapperTest {
   @Test(expected = NullPointerException.class)
   public void testMap_throwsException_onNullResults() throws SQLException {
     final ResultSet nullResults = null;
-    final StatementContext context = mock(StatementContext.class);
     final DbTableVersionRowMapper dbTableVersionRowMapper = new DbTableVersionRowMapper();
     dbTableVersionRowMapper.map(nullResults, context);
   }
 
   @Test(expected = NullPointerException.class)
   public void testMap_throwsException_onNullContext() throws SQLException {
-    final ResultSet results = mock(ResultSet.class);
     final StatementContext nullContext = null;
     final DbTableVersionRowMapper dbTableVersionRowMapper = new DbTableVersionRowMapper();
     dbTableVersionRowMapper.map(results, nullContext);

--- a/src/test/java/marquez/db/mappers/NamespaceRowMapperTest.java
+++ b/src/test/java/marquez/db/mappers/NamespaceRowMapperTest.java
@@ -39,7 +39,6 @@ import org.junit.experimental.categories.Category;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.mockito.quality.Strictness;
 
 @Category(UnitTests.class)
 public class NamespaceRowMapperTest {
@@ -49,7 +48,7 @@ public class NamespaceRowMapperTest {
   private static final Description DESCRIPTION = newDescription();
   private static final OwnerName CURRENT_OWNER_NAME = newOwnerName();
 
-  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.WARN);
+  @Rule public MockitoRule rule = MockitoJUnit.rule();
 
   @Mock private Object exists;
   @Mock private ResultSet results;

--- a/src/test/java/marquez/db/mappers/NamespaceRowMapperTest.java
+++ b/src/test/java/marquez/db/mappers/NamespaceRowMapperTest.java
@@ -19,7 +19,6 @@ import static marquez.common.models.CommonModelGenerator.newNamespaceName;
 import static marquez.common.models.CommonModelGenerator.newOwnerName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.sql.ResultSet;
@@ -34,8 +33,13 @@ import marquez.common.models.OwnerName;
 import marquez.db.Columns;
 import marquez.db.models.NamespaceRow;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 @Category(UnitTests.class)
 public class NamespaceRowMapperTest {
@@ -45,10 +49,14 @@ public class NamespaceRowMapperTest {
   private static final Description DESCRIPTION = newDescription();
   private static final OwnerName CURRENT_OWNER_NAME = newOwnerName();
 
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.WARN);
+
+  @Mock private Object exists;
+  @Mock private ResultSet results;
+  @Mock private StatementContext context;
+
   @Test
   public void testMap_row() throws SQLException {
-    final Object exists = mock(Object.class);
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(Columns.ROW_UUID)).thenReturn(exists);
     when(results.getObject(Columns.CREATED_AT)).thenReturn(exists);
     when(results.getObject(Columns.NAME)).thenReturn(exists);
@@ -61,8 +69,6 @@ public class NamespaceRowMapperTest {
     when(results.getString(Columns.DESCRIPTION)).thenReturn(DESCRIPTION.getValue());
     when(results.getString(Columns.CURRENT_OWNER_NAME)).thenReturn(CURRENT_OWNER_NAME.getValue());
 
-    final StatementContext context = mock(StatementContext.class);
-
     final NamespaceRowMapper rowMapper = new NamespaceRowMapper();
     final NamespaceRow row = rowMapper.map(results, context);
     assertThat(row.getUuid()).isEqualTo(ROW_UUID);
@@ -74,8 +80,6 @@ public class NamespaceRowMapperTest {
 
   @Test
   public void testMap_row_noDescription() throws SQLException {
-    final Object exists = mock(Object.class);
-    final ResultSet results = mock(ResultSet.class);
     when(results.getObject(Columns.ROW_UUID)).thenReturn(exists);
     when(results.getObject(Columns.CREATED_AT)).thenReturn(exists);
     when(results.getObject(Columns.NAME)).thenReturn(exists);
@@ -86,8 +90,6 @@ public class NamespaceRowMapperTest {
     when(results.getTimestamp(Columns.CREATED_AT)).thenReturn(Timestamp.from(CREATED_AT));
     when(results.getString(Columns.NAME)).thenReturn(NAME.getValue());
     when(results.getString(Columns.CURRENT_OWNER_NAME)).thenReturn(CURRENT_OWNER_NAME.getValue());
-
-    final StatementContext context = mock(StatementContext.class);
 
     final NamespaceRowMapper rowMapper = new NamespaceRowMapper();
     final NamespaceRow row = rowMapper.map(results, context);
@@ -101,14 +103,12 @@ public class NamespaceRowMapperTest {
   @Test
   public void testMap_throwsException_onNullResults() throws SQLException {
     final ResultSet nullResults = null;
-    final StatementContext context = mock(StatementContext.class);
     final NamespaceRowMapper rowMapper = new NamespaceRowMapper();
     assertThatNullPointerException().isThrownBy(() -> rowMapper.map(nullResults, context));
   }
 
   @Test
   public void testMap_throwsException_onNullContext() throws SQLException {
-    final ResultSet results = mock(ResultSet.class);
     final StatementContext nullContext = null;
     final NamespaceRowMapper rowMapper = new NamespaceRowMapper();
     assertThatNullPointerException().isThrownBy(() -> rowMapper.map(results, nullContext));

--- a/src/test/java/marquez/service/DatasetServiceTest.java
+++ b/src/test/java/marquez/service/DatasetServiceTest.java
@@ -27,7 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -57,8 +56,13 @@ import marquez.service.mappers.DatasetMapper;
 import marquez.service.models.Dataset;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 @Category(UnitTests.class)
 public class DatasetServiceTest {
@@ -80,16 +84,15 @@ public class DatasetServiceTest {
           .description(DESCRIPTION)
           .build();
 
-  private NamespaceDao namespaceDao;
-  private DatasourceDao datasourceDao;
-  private DatasetDao datasetDao;
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Mock private NamespaceDao namespaceDao;
+  @Mock private DatasourceDao datasourceDao;
+  @Mock private DatasetDao datasetDao;
   private DatasetService datasetService;
 
   @Before
   public void setUp() {
-    namespaceDao = mock(NamespaceDao.class);
-    datasourceDao = mock(DatasourceDao.class);
-    datasetDao = mock(DatasetDao.class);
     datasetService = new DatasetService(namespaceDao, datasourceDao, datasetDao);
   }
 

--- a/src/test/java/marquez/service/DatasourceServiceTest.java
+++ b/src/test/java/marquez/service/DatasourceServiceTest.java
@@ -16,8 +16,6 @@ package marquez.service;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -33,24 +31,23 @@ import marquez.service.exceptions.MarquezServiceException;
 import marquez.service.models.Datasource;
 import marquez.service.models.Generator;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 public class DatasourceServiceTest {
 
-  private static DatasourceService datasourceService;
+  private DatasourceService datasourceService;
 
-  private static final DatasourceDao datasourceDao = mock(DatasourceDao.class);
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
 
-  @BeforeClass
-  public static void setUp() {
+  @Mock private DatasourceDao datasourceDao;
+
+  @Before
+  public void setUp() {
     datasourceService = new DatasourceService(datasourceDao);
-  }
-
-  @After
-  public void tearDown() {
-    reset(datasourceDao);
   }
 
   @Test

--- a/src/test/java/marquez/service/JobServiceTest.java
+++ b/src/test/java/marquez/service/JobServiceTest.java
@@ -31,12 +31,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.mockito.quality.Strictness;
 
 public class JobServiceTest {
   final String TEST_NS = "test_namespace";
 
-  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.WARN);
+  @Rule public MockitoRule rule = MockitoJUnit.rule();
 
   @Mock private JobDao jobDao;
   @Mock private JobVersionDao jobVersionDao;

--- a/src/test/java/marquez/service/JobServiceTest.java
+++ b/src/test/java/marquez/service/JobServiceTest.java
@@ -5,9 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,18 +26,22 @@ import marquez.service.models.JobRun;
 import marquez.service.models.JobRunState;
 import marquez.service.models.JobVersion;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 public class JobServiceTest {
   final String TEST_NS = "test_namespace";
-  private static final JobDao jobDao = mock(JobDao.class);
-  private static final JobVersionDao jobVersionDao = mock(JobVersionDao.class);
-  private static final JobRunDao jobRunDao = mock(JobRunDao.class);
-  private static final JobRunArgsDao jobRunArgsDao = mock(JobRunArgsDao.class);
+
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.WARN);
+
+  @Mock private JobDao jobDao;
+  @Mock private JobVersionDao jobVersionDao;
+  @Mock private JobRunDao jobRunDao;
+  @Mock private JobRunArgsDao jobRunArgsDao;
   private static final UUID namespaceID = UUID.randomUUID();
 
   JobService jobService;
@@ -47,14 +49,6 @@ public class JobServiceTest {
   @Before
   public void setUp() {
     jobService = new JobService(jobDao, jobVersionDao, jobRunDao, jobRunArgsDao);
-  }
-
-  @After
-  public void tearDown() {
-    reset(jobDao);
-    reset(jobVersionDao);
-    reset(jobRunDao);
-    reset(jobRunArgsDao);
   }
 
   private void assertJobFieldsMatch(Job job1, Job job2) {

--- a/src/test/java/marquez/service/NamespaceServiceTest.java
+++ b/src/test/java/marquez/service/NamespaceServiceTest.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,8 +30,13 @@ import marquez.service.mappers.NamespaceMapper;
 import marquez.service.models.Namespace;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
 @Category(UnitTests.class)
 public class NamespaceServiceTest {
@@ -43,12 +47,13 @@ public class NamespaceServiceTest {
       new Namespace(
           null, NAMESPACE_NAME.getValue(), CURRENT_OWNER_NAME.getValue(), DESCRIPTION.getValue());
 
-  private NamespaceDao namespaceDao;
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Mock private NamespaceDao namespaceDao;
   private NamespaceService namespaceService;
 
   @Before
   public void setUp() throws MarquezServiceException {
-    namespaceDao = mock(NamespaceDao.class);
     namespaceService = new NamespaceService(namespaceDao);
   }
 


### PR DESCRIPTION
@wslulciuc 
Mock usage optimization was applied to all the test classes. For below test classes, where it had mock usage at @ClassRule level, simplified mock usage was not applied, as it required to change object scopes. Kindly review, and let me know your feedback, thanks

- JobResourceTest
- NamespaceResourceTest
- DatasourceResourceTest