### PR TITLE
Endpoint to get job runs by job

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -152,9 +152,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/jobRunId'
+    
     get:
-      summary: List all job runs
-      description: Returns a list of job runs.
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      summary: Retrieve job runs for a job
+      description: Returns a list of job runs, sorted reverse chronologically
       tags:
         - Jobs
       responses:
@@ -414,6 +418,22 @@ components:
         format: URN
         maxLength: 1024
         example: urn:dataset:analytics_db:wedata.room_bookings
+
+    limit:
+      name: limit
+      in: query
+      description: The number of results to return from offset
+      required: false
+      schema:
+        type: integer
+
+    offset:
+      name: offset
+      in: query
+      description: The initial position from which to return results
+      required: false
+      schema:
+        type: integer
 
   schemas:
     createNamespace:

--- a/src/main/java/marquez/api/resources/JobResource.java
+++ b/src/main/java/marquez/api/resources/JobResource.java
@@ -150,10 +150,23 @@ public final class JobResource {
   }
 
   @Timed
-  @ResponseMetered
-  @ExceptionMetered
+  @Path("/namespaces/{namespace}/jobs/{job}/runs")
+  public Response getJobRuns(
+      @PathParam("namespace") final NamespaceName namespaceName, @PathParam("job") final String job)
+      throws MarquezServiceException {
+    if (!namespaceService.exists(namespaceName)) {
+      return Response.status(Response.Status.NOT_FOUND).entity("Namespace not found").build();
+    }
+    final Optional<List<JobRun>> jobRuns = jobService.getAllRunsOfJob(namespaceName, job);
+    if (jobRuns.isPresent()) {
+      return Response.ok().entity(coreJobRunToApiJobRunMapper.map(jobRuns.get())).build();
+    }
+    return Response.status(Response.Status.NOT_FOUND).build();
+  }
+
   @GET
   @Path("/namespaces/{namespace}/jobs/{job}/runs")
+  @Produces(APPLICATION_JSON)
   public Response getJobRuns(
       @PathParam("namespace") final NamespaceName namespaceName, @PathParam("job") final String job)
       throws MarquezServiceException {
@@ -167,6 +180,21 @@ public final class JobResource {
 
   @GET
   @Produces(APPLICATION_JSON)
+  @Path("/namespaces/{namespace}/jobs/{job}/runs")
+  public Response getJobRuns(
+      @PathParam("namespace") final NamespaceName namespaceName, @PathParam("job") final String job)
+      throws MarquezServiceException {
+    if (!namespaceService.exists(namespaceName)) {
+      return Response.status(Response.Status.NOT_FOUND).entity("Namespace not found").build();
+    }
+    final Optional<List<JobRun>> jobRuns = jobService.getAllRunsOfJob(namespaceName, job);
+    if (jobRuns.isPresent()) {
+      return Response.ok().entity(coreJobRunToApiJobRunMapper.map(jobRuns.get())).build();
+    }
+    return Response.status(Response.Status.NOT_FOUND).build();
+  }
+
+  @GET
   @Timed
   @Path("/jobs/runs/{id}")
   public Response get(@PathParam("id") final UUID runId) throws MarquezServiceException {

--- a/src/main/java/marquez/api/resources/JobResource.java
+++ b/src/main/java/marquez/api/resources/JobResource.java
@@ -153,8 +153,24 @@ public final class JobResource {
   @ResponseMetered
   @ExceptionMetered
   @GET
-  @Path("/jobs/runs/{id}")
+  @Path("/namespaces/{namespace}/jobs/{job}/runs")
+  public Response getJobRuns(
+      @PathParam("namespace") final NamespaceName namespaceName, @PathParam("job") final String job)
+      throws MarquezServiceException {
+    if (!namespaceService.exists(namespaceName)) {
+      return Response.status(Response.Status.NOT_FOUND).entity("Namespace not found").build();
+    }
+    final Optional<List<JobRun>> jobRuns = jobService.getAllRunsOfJob(namespaceName, job);
+    if (jobRuns.isPresent()) {
+      return Response.ok().entity(coreJobRunToApiJobRunMapper.map(jobRuns.get())).build();
+    }
+    return Response.status(Response.Status.NOT_FOUND).build();
+  }
+
+  @GET
   @Produces(APPLICATION_JSON)
+  @Timed
+  @Path("/jobs/runs/{id}")
   public Response get(@PathParam("id") final UUID runId) throws MarquezServiceException {
     final Optional<JobRun> jobRun = jobService.getJobRun(runId);
     if (jobRun.isPresent()) {

--- a/src/main/java/marquez/api/resources/JobResource.java
+++ b/src/main/java/marquez/api/resources/JobResource.java
@@ -160,11 +160,9 @@ public final class JobResource {
     if (!namespaceService.exists(namespaceName)) {
       return Response.status(Response.Status.NOT_FOUND).entity("Namespace not found").build();
     }
-    final Optional<List<JobRun>> jobRuns = jobService.getAllRunsOfJob(namespaceName, job);
-    if (jobRuns.isPresent()) {
-      return Response.ok().entity(coreJobRunToApiJobRunMapper.map(jobRuns.get())).build();
-    }
-    return Response.status(Response.Status.NOT_FOUND).build();
+    return Response.ok()
+        .entity(coreJobRunToApiJobRunMapper.map(jobService.getAllRunsOfJob(namespaceName, job)))
+        .build();
   }
 
   @GET

--- a/src/main/java/marquez/api/resources/JobResource.java
+++ b/src/main/java/marquez/api/resources/JobResource.java
@@ -152,7 +152,7 @@ public final class JobResource {
   @GET
   @Produces(APPLICATION_JSON)
   @Path("/namespaces/{namespace}/jobs/{job}/runs")
-  public Response getJobRuns(
+  public Response getRunsForJob(
       @PathParam("namespace") final NamespaceName namespaceName, @PathParam("job") final String job)
       throws MarquezServiceException {
     if (!namespaceService.exists(namespaceName)) {

--- a/src/main/java/marquez/api/resources/JobResource.java
+++ b/src/main/java/marquez/api/resources/JobResource.java
@@ -161,7 +161,7 @@ public final class JobResource {
       return Response.status(Response.Status.NOT_FOUND).entity("Namespace not found").build();
     }
     return Response.ok()
-        .entity(coreJobRunToApiJobRunMapper.map(jobService.getAllRunsOfJob(namespaceName, job)))
+        .entity(JobRunResponseMapper.map(jobService.getAllRunsOfJob(namespaceName, job)))
         .build();
   }
 

--- a/src/main/java/marquez/api/resources/JobResource.java
+++ b/src/main/java/marquez/api/resources/JobResource.java
@@ -149,35 +149,6 @@ public final class JobResource {
         .build();
   }
 
-  @Timed
-  @Path("/namespaces/{namespace}/jobs/{job}/runs")
-  public Response getJobRuns(
-      @PathParam("namespace") final NamespaceName namespaceName, @PathParam("job") final String job)
-      throws MarquezServiceException {
-    if (!namespaceService.exists(namespaceName)) {
-      return Response.status(Response.Status.NOT_FOUND).entity("Namespace not found").build();
-    }
-    final Optional<List<JobRun>> jobRuns = jobService.getAllRunsOfJob(namespaceName, job);
-    if (jobRuns.isPresent()) {
-      return Response.ok().entity(coreJobRunToApiJobRunMapper.map(jobRuns.get())).build();
-    }
-    return Response.status(Response.Status.NOT_FOUND).build();
-  }
-
-  @GET
-  @Path("/namespaces/{namespace}/jobs/{job}/runs")
-  @Produces(APPLICATION_JSON)
-  public Response getJobRuns(
-      @PathParam("namespace") final NamespaceName namespaceName, @PathParam("job") final String job)
-      throws MarquezServiceException {
-    if (!namespaceService.exists(namespaceName)) {
-      return Response.status(Response.Status.NOT_FOUND).entity("Namespace not found").build();
-    }
-    return Response.ok()
-        .entity(JobRunResponseMapper.map(jobService.getAllRunsOfJob(namespaceName, job)))
-        .build();
-  }
-
   @GET
   @Produces(APPLICATION_JSON)
   @Path("/namespaces/{namespace}/jobs/{job}/runs")
@@ -187,11 +158,8 @@ public final class JobResource {
     if (!namespaceService.exists(namespaceName)) {
       return Response.status(Response.Status.NOT_FOUND).entity("Namespace not found").build();
     }
-    final Optional<List<JobRun>> jobRuns = jobService.getAllRunsOfJob(namespaceName, job);
-    if (jobRuns.isPresent()) {
-      return Response.ok().entity(coreJobRunToApiJobRunMapper.map(jobRuns.get())).build();
-    }
-    return Response.status(Response.Status.NOT_FOUND).build();
+    final List<JobRun> jobRuns = jobService.getAllRunsOfJob(namespaceName, job);
+    return Response.ok().entity(JobRunResponseMapper.map(jobRuns)).build();
   }
 
   @GET

--- a/src/main/java/marquez/api/resources/JobResource.java
+++ b/src/main/java/marquez/api/resources/JobResource.java
@@ -25,12 +25,14 @@ import java.util.Optional;
 import java.util.UUID;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import marquez.api.mappers.JobMapper;
@@ -153,12 +155,15 @@ public final class JobResource {
   @Produces(APPLICATION_JSON)
   @Path("/namespaces/{namespace}/jobs/{job}/runs")
   public Response getRunsForJob(
-      @PathParam("namespace") final NamespaceName namespaceName, @PathParam("job") final String job)
+      @PathParam("namespace") final NamespaceName namespaceName,
+      @PathParam("job") final String job,
+      @QueryParam("limit") @DefaultValue("100") Integer limit,
+      @QueryParam("offset") @DefaultValue("0") Integer offset)
       throws MarquezServiceException {
     if (!namespaceService.exists(namespaceName)) {
       return Response.status(Response.Status.NOT_FOUND).entity("Namespace not found").build();
     }
-    final List<JobRun> jobRuns = jobService.getAllRunsOfJob(namespaceName, job);
+    final List<JobRun> jobRuns = jobService.getAllRunsOfJob(namespaceName, job, limit, offset);
     return Response.ok().entity(JobRunResponseMapper.map(jobRuns)).build();
   }
 

--- a/src/main/java/marquez/api/resources/JobResource.java
+++ b/src/main/java/marquez/api/resources/JobResource.java
@@ -151,9 +151,12 @@ public final class JobResource {
         .build();
   }
 
+  @Timed
+  @ResponseMetered
+  @ExceptionMetered
   @GET
-  @Produces(APPLICATION_JSON)
   @Path("/namespaces/{namespace}/jobs/{job}/runs")
+  @Produces(APPLICATION_JSON)
   public Response getRunsForJob(
       @PathParam("namespace") final NamespaceName namespaceName,
       @PathParam("job") final String job,

--- a/src/main/java/marquez/api/resources/JobResource.java
+++ b/src/main/java/marquez/api/resources/JobResource.java
@@ -167,9 +167,12 @@ public final class JobResource {
     return Response.ok().entity(JobRunResponseMapper.map(jobRuns)).build();
   }
 
-  @GET
   @Timed
+  @ResponseMetered
+  @ExceptionMetered
+  @GET
   @Path("/jobs/runs/{id}")
+  @Produces(APPLICATION_JSON)
   public Response get(@PathParam("id") final UUID runId) throws MarquezServiceException {
     final Optional<JobRun> jobRun = jobService.getJobRun(runId);
     if (jobRun.isPresent()) {

--- a/src/main/java/marquez/db/JobRunDao.java
+++ b/src/main/java/marquez/db/JobRunDao.java
@@ -14,6 +14,7 @@
 
 package marquez.db;
 
+import java.util.List;
 import java.util.UUID;
 import marquez.db.mappers.JobRunRowMapper;
 import marquez.service.models.JobRun;
@@ -68,4 +69,14 @@ public interface JobRunDao {
           + " ON (jr.guid = :guid AND jr.job_run_args_hex_digest = jra.hex_digest) "
           + "WHERE jr.guid = :guid")
   JobRun findJobRunById(UUID guid);
+
+  @SqlQuery(
+      "SELECT jr.*, jra.args_json "
+          + "FROM job_runs jr "
+          + "INNER JOIN job_versions jv "
+          + " ON (jr.job_version_guid = jv.guid AND jv.job_guid = :jobUuid)"
+          + "LEFT JOIN job_run_args jra "
+          + " ON (jr.job_run_args_hex_digest = jra.hex_digest) "
+          + "ORDER BY created_at DESC")
+  List<JobRun> findAllByJobUuid(UUID jobUuid);
 }

--- a/src/main/java/marquez/db/JobRunDao.java
+++ b/src/main/java/marquez/db/JobRunDao.java
@@ -77,6 +77,7 @@ public interface JobRunDao {
           + " ON (jr.job_version_guid = jv.guid AND jv.job_guid = :jobUuid)"
           + "LEFT JOIN job_run_args jra "
           + " ON (jr.job_run_args_hex_digest = jra.hex_digest) "
-          + "ORDER BY created_at DESC")
-  List<JobRun> findAllByJobUuid(UUID jobUuid);
+          + "ORDER BY created_at DESC "
+          + "LIMIT :limit OFFSET :offset")
+  List<JobRun> findAllByJobUuid(UUID jobUuid, int limit, int offset);
 }

--- a/src/main/java/marquez/service/JobService.java
+++ b/src/main/java/marquez/service/JobService.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import marquez.common.models.NamespaceName;
 import marquez.db.JobDao;
 import marquez.db.JobRunArgsDao;
 import marquez.db.JobRunDao;
@@ -150,6 +151,21 @@ public class JobService {
     } catch (UnableToExecuteStatementException e) {
       String err = "error fetching job run";
       log.error(err, e);
+      throw new MarquezServiceException();
+    }
+  }
+
+  public Optional<List<JobRun>> getAllRunsOfJob(NamespaceName namespace, String jobName)
+      throws MarquezServiceException {
+    try {
+      final Optional<Job> job =
+          Optional.ofNullable(jobDao.findByName(namespace.getValue(), jobName));
+      if (job.isPresent()) {
+        return Optional.ofNullable(jobRunDao.findAllByJobUuid(job.get().getGuid()));
+      }
+      return Optional.of(null);
+    } catch (UnableToExecuteStatementException e) {
+      log.error(e.getMessage(), e);
       throw new MarquezServiceException();
     }
   }

--- a/src/main/java/marquez/service/JobService.java
+++ b/src/main/java/marquez/service/JobService.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import marquez.common.models.NamespaceName;
 import marquez.db.JobDao;
@@ -156,13 +157,14 @@ public class JobService {
     }
   }
 
-  public List<JobRun> getAllRunsOfJob(NamespaceName namespace, String jobName)
+  public List<JobRun> getAllRunsOfJob(
+      NamespaceName namespace, String jobName, @NonNull Integer limit, @NonNull Integer offset)
       throws MarquezServiceException {
     try {
       final Optional<Job> job =
           Optional.ofNullable(jobDao.findByName(namespace.getValue(), jobName));
       if (job.isPresent()) {
-        return jobRunDao.findAllByJobUuid(job.get().getGuid());
+        return jobRunDao.findAllByJobUuid(job.get().getGuid(), limit, offset);
       }
       return Collections.emptyList();
     } catch (UnableToExecuteStatementException e) {

--- a/src/main/java/marquez/service/JobService.java
+++ b/src/main/java/marquez/service/JobService.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -155,15 +156,15 @@ public class JobService {
     }
   }
 
-  public Optional<List<JobRun>> getAllRunsOfJob(NamespaceName namespace, String jobName)
+  public List<JobRun> getAllRunsOfJob(NamespaceName namespace, String jobName)
       throws MarquezServiceException {
     try {
       final Optional<Job> job =
           Optional.ofNullable(jobDao.findByName(namespace.getValue(), jobName));
       if (job.isPresent()) {
-        return Optional.ofNullable(jobRunDao.findAllByJobUuid(job.get().getGuid()));
+        return jobRunDao.findAllByJobUuid(job.get().getGuid());
       }
-      return Optional.of(null);
+      return Collections.emptyList();
     } catch (UnableToExecuteStatementException e) {
       log.error(e.getMessage(), e);
       throw new MarquezServiceException();

--- a/src/test/java/marquez/api/resources/JobResourceTest.java
+++ b/src/test/java/marquez/api/resources/JobResourceTest.java
@@ -334,6 +334,16 @@ public class JobResourceTest {
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
   }
 
+  @Test
+  public void testGetAllRunsOfJob_namespaceNotFound() throws MarquezServiceException {
+    JobResponse job = generateApiJob();
+    when(MOCK_NAMESPACE_SERVICE.exists(NAMESPACE_NAME)).thenReturn(false);
+
+    Response response = JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, job.getName());
+
+    assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
   private Response getJobRun(String jobRunId) {
     String path = format("/api/v1/jobs/runs/%s", NAMESPACE_NAME.getValue(), jobRunId);
     return resources.client().target(path).request(MediaType.APPLICATION_JSON).get();

--- a/src/test/java/marquez/api/resources/JobResourceTest.java
+++ b/src/test/java/marquez/api/resources/JobResourceTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.when;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -340,7 +339,7 @@ public class JobResourceTest {
         JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, job.getName(), DEFAULT_LIMIT, DEFAULT_OFFSET);
 
     List<JobRunResponse> responseJobRuns = new ArrayList<JobRunResponse>();
-    for (Object resItem : (Collection<?>) response.getEntity()) {
+    for (Object resItem : (List<?>) response.getEntity()) {
       responseJobRuns.add((JobRunResponse) resItem);
     }
     assertEquals(jobRuns.size(), responseJobRuns.size());

--- a/src/test/java/marquez/api/resources/JobResourceTest.java
+++ b/src/test/java/marquez/api/resources/JobResourceTest.java
@@ -358,16 +358,10 @@ public class JobResourceTest {
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
   }
 
-  @Test
+  @Test(expected = MarquezServiceException.class)
   public void testGetAllRunsOfJob_NamespaceService_Exception() throws MarquezServiceException {
-    JobResponse job = generateApiJob();
-    when(MOCK_NAMESPACE_SERVICE.exists(NAMESPACE_NAME)).thenReturn(false);
-    when(MOCK_JOB_SERVICE.getAllRunsOfJob(NAMESPACE_NAME, job.getName()))
-        .thenThrow(MarquezServiceException.class);
-
-    Response response = JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, job.getName());
-
-    assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+    when(MOCK_NAMESPACE_SERVICE.exists(NAMESPACE_NAME)).thenThrow(MarquezServiceException.class);
+    JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, "some job");
   }
 
   private Response getJobRun(String jobRunId) {

--- a/src/test/java/marquez/api/resources/JobResourceTest.java
+++ b/src/test/java/marquez/api/resources/JobResourceTest.java
@@ -60,8 +60,8 @@ public class JobResourceTest {
   private static final NamespaceName NAMESPACE_NAME = NamespaceName.fromString("test");
   private static final Entity<?> EMPTY_PUT_BODY = Entity.json("");
 
-  private static final int DEFAULT_LIMIT = 0;
-  private static final int DEFAULT_OFFSET = 100;
+  private static final int TEST_LIMIT = 0;
+  private static final int TEST_OFFSET = 100;
 
   final int UNPROCESSABLE_ENTRY_STATUS_CODE = 422;
 
@@ -331,12 +331,11 @@ public class JobResourceTest {
     JobResponse job = generateApiJob();
     List<JobRun> jobRuns = Arrays.asList(Generator.genJobRun(), Generator.genJobRun());
     when(MOCK_NAMESPACE_SERVICE.exists(NAMESPACE_NAME)).thenReturn(true);
-    when(MOCK_JOB_SERVICE.getAllRunsOfJob(
-            NAMESPACE_NAME, job.getName(), DEFAULT_LIMIT, DEFAULT_OFFSET))
+    when(MOCK_JOB_SERVICE.getAllRunsOfJob(NAMESPACE_NAME, job.getName(), TEST_LIMIT, TEST_OFFSET))
         .thenReturn(jobRuns);
 
     Response response =
-        JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, job.getName(), DEFAULT_LIMIT, DEFAULT_OFFSET);
+        JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, job.getName(), TEST_LIMIT, TEST_OFFSET);
 
     List<JobRunResponse> responseJobRuns = new ArrayList<JobRunResponse>();
     for (Object resItem : (List<?>) response.getEntity()) {
@@ -350,8 +349,7 @@ public class JobResourceTest {
     when(MOCK_NAMESPACE_SERVICE.exists(NAMESPACE_NAME)).thenReturn(false);
 
     Response response =
-        JOB_RESOURCE.getRunsForJob(
-            NAMESPACE_NAME, "nonexistent_job", DEFAULT_LIMIT, DEFAULT_OFFSET);
+        JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, "nonexistent_job", TEST_LIMIT, TEST_OFFSET);
 
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
   }
@@ -361,12 +359,11 @@ public class JobResourceTest {
     JobResponse job = generateApiJob();
     when(MOCK_NAMESPACE_SERVICE.exists(NAMESPACE_NAME)).thenReturn(false);
     List<JobRun> noJobRuns = new ArrayList<JobRun>();
-    when(MOCK_JOB_SERVICE.getAllRunsOfJob(
-            NAMESPACE_NAME, job.getName(), DEFAULT_LIMIT, DEFAULT_OFFSET))
+    when(MOCK_JOB_SERVICE.getAllRunsOfJob(NAMESPACE_NAME, job.getName(), TEST_LIMIT, TEST_OFFSET))
         .thenReturn(noJobRuns);
 
     Response response =
-        JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, job.getName(), DEFAULT_LIMIT, DEFAULT_OFFSET);
+        JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, job.getName(), TEST_LIMIT, TEST_OFFSET);
 
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
   }
@@ -375,18 +372,17 @@ public class JobResourceTest {
   public void testGetAllRunsOfJob_NamespaceService_Exception() throws MarquezServiceException {
     when(MOCK_NAMESPACE_SERVICE.exists(NAMESPACE_NAME)).thenThrow(MarquezServiceException.class);
 
-    JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, "some job", DEFAULT_LIMIT, DEFAULT_OFFSET);
+    JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, "some job", TEST_LIMIT, TEST_OFFSET);
   }
 
   @Test(expected = MarquezServiceException.class)
   public void testGetAllRunsOfJob_JobService_Exception() throws MarquezServiceException {
     JobResponse job = generateApiJob();
     when(MOCK_NAMESPACE_SERVICE.exists(NAMESPACE_NAME)).thenReturn(true);
-    when(MOCK_JOB_SERVICE.getAllRunsOfJob(
-            NAMESPACE_NAME, job.getName(), DEFAULT_LIMIT, DEFAULT_OFFSET))
+    when(MOCK_JOB_SERVICE.getAllRunsOfJob(NAMESPACE_NAME, job.getName(), TEST_LIMIT, TEST_OFFSET))
         .thenThrow(MarquezServiceException.class);
 
-    JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, job.getName(), DEFAULT_LIMIT, DEFAULT_OFFSET);
+    JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, job.getName(), TEST_LIMIT, TEST_OFFSET);
   }
 
   private Response getJobRun(String jobRunId) {

--- a/src/test/java/marquez/api/resources/JobResourceTest.java
+++ b/src/test/java/marquez/api/resources/JobResourceTest.java
@@ -322,6 +322,18 @@ public class JobResourceTest {
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), res.getStatus());
   }
 
+  @Test
+  public void testGetAllRunsOfJob() throws MarquezServiceException {
+    JobResponse job = generateApiJob();
+    List<JobRun> jobRuns = Arrays.asList(Generator.genJobRun(), Generator.genJobRun());
+    when(MOCK_NAMESPACE_SERVICE.exists(NAMESPACE_NAME)).thenReturn(true);
+    when(MOCK_JOB_SERVICE.getAllRunsOfJob(NAMESPACE_NAME, job.getName())).thenReturn(jobRuns);
+
+    Response response = JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, job.getName());
+
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+  }
+
   private Response getJobRun(String jobRunId) {
     String path = format("/api/v1/jobs/runs/%s", NAMESPACE_NAME.getValue(), jobRunId);
     return resources.client().target(path).request(MediaType.APPLICATION_JSON).get();

--- a/src/test/java/marquez/api/resources/JobResourceTest.java
+++ b/src/test/java/marquez/api/resources/JobResourceTest.java
@@ -364,6 +364,15 @@ public class JobResourceTest {
     JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, "some job");
   }
 
+  @Test(expected = MarquezServiceException.class)
+  public void testGetAllRunsOfJob_JobService_Exception() throws MarquezServiceException {
+    JobResponse job = generateApiJob();
+    when(MOCK_NAMESPACE_SERVICE.exists(NAMESPACE_NAME)).thenReturn(true);
+    when(MOCK_JOB_SERVICE.getAllRunsOfJob(NAMESPACE_NAME, job.getName()))
+        .thenThrow(MarquezServiceException.class);
+    JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, job.getName());
+  }
+
   private Response getJobRun(String jobRunId) {
     String path = format("/api/v1/jobs/runs/%s", NAMESPACE_NAME.getValue(), jobRunId);
     return resources.client().target(path).request(MediaType.APPLICATION_JSON).get();

--- a/src/test/java/marquez/api/resources/JobResourceTest.java
+++ b/src/test/java/marquez/api/resources/JobResourceTest.java
@@ -357,7 +357,7 @@ public class JobResourceTest {
   @Test
   public void testGetAllRunsOfJob_noJobRuns() throws MarquezServiceException {
     JobResponse job = generateApiJob();
-    when(MOCK_NAMESPACE_SERVICE.exists(NAMESPACE_NAME)).thenReturn(false);
+    when(MOCK_NAMESPACE_SERVICE.exists(NAMESPACE_NAME)).thenReturn(true);
     List<JobRun> noJobRuns = new ArrayList<JobRun>();
     when(MOCK_JOB_SERVICE.getAllRunsOfJob(NAMESPACE_NAME, job.getName(), TEST_LIMIT, TEST_OFFSET))
         .thenReturn(noJobRuns);
@@ -365,7 +365,12 @@ public class JobResourceTest {
     Response response =
         JOB_RESOURCE.getRunsForJob(NAMESPACE_NAME, job.getName(), TEST_LIMIT, TEST_OFFSET);
 
-    assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    List<JobRunResponse> responseJobRuns = new ArrayList<JobRunResponse>();
+    for (Object resItem : (List<?>) response.getEntity()) {
+      responseJobRuns.add((JobRunResponse) resItem);
+    }
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertEquals(0, responseJobRuns.size());
   }
 
   @Test(expected = MarquezServiceException.class)

--- a/src/test/java/marquez/db/JobRunDaoTest.java
+++ b/src/test/java/marquez/db/JobRunDaoTest.java
@@ -116,6 +116,11 @@ public class JobRunDaoTest extends JobRunBaseTest {
         .isEqualTo(getLatestJobRunStateForJobId(CREATED_JOB_RUN_UUID));
   }
 
+  @Test
+  public void testFindAllByJobUuid(UUID jobUuid) {
+    
+  }
+
   private JobRunState getLatestJobRunStateForJobId(UUID jobRunId) {
     Handle handle = APP.getJDBI().open();
     Query qr =

--- a/src/test/java/marquez/db/JobRunDaoTest.java
+++ b/src/test/java/marquez/db/JobRunDaoTest.java
@@ -54,6 +54,9 @@ public class JobRunDaoTest extends JobRunBaseTest {
   protected static final JobRunStateDao jobRunStateDao = APP.onDemand(JobRunStateDao.class);
   protected static final JobRunArgsDao jobRunArgsDao = APP.onDemand(JobRunArgsDao.class);
 
+  protected static final int DEFAULT_OFFSET = 0;
+  protected static final int DEFAULT_LIMIT = 10;
+
   protected static NamespaceService namespaceService;
   protected static final JobService jobService =
       new JobService(jobDao, jobVersionDao, jobRunDao, jobRunArgsDao);
@@ -121,19 +124,44 @@ public class JobRunDaoTest extends JobRunBaseTest {
   @Test
   public void testFindAllByJobUuid() throws MarquezServiceException {
     List<JobRun> jobRuns =
-        jobService.getAllRunsOfJob(NamespaceName.fromString(NAMESPACE_NAME), CREATED_JOB_NAME);
+        jobService.getAllRunsOfJob(
+            NamespaceName.fromString(NAMESPACE_NAME),
+            CREATED_JOB_NAME,
+            DEFAULT_LIMIT,
+            DEFAULT_OFFSET);
     assertEquals(jobRuns.size(), 1);
     jobService.createJobRun(NAMESPACE_NAME, CREATED_JOB_NAME, JOB_RUN_ARGS, null, null);
     jobRuns =
-        jobService.getAllRunsOfJob(NamespaceName.fromString(NAMESPACE_NAME), CREATED_JOB_NAME);
+        jobService.getAllRunsOfJob(
+            NamespaceName.fromString(NAMESPACE_NAME),
+            CREATED_JOB_NAME,
+            DEFAULT_LIMIT,
+            DEFAULT_OFFSET);
     assertEquals(jobRuns.size(), 2);
+  }
+
+  @Test
+  public void testFindAllByJobUuid_withLimit() throws MarquezServiceException {
+    int singleJobLimit = 1;
+    jobService.createJobRun(NAMESPACE_NAME, CREATED_JOB_NAME, JOB_RUN_ARGS, null, null);
+    List<JobRun> jobRuns =
+        jobService.getAllRunsOfJob(
+            NamespaceName.fromString(NAMESPACE_NAME),
+            CREATED_JOB_NAME,
+            singleJobLimit,
+            DEFAULT_OFFSET);
+    assertEquals(jobRuns.size(), 1);
   }
 
   @Test
   public void testFindAllByJobUuid_JobDoesntExist() throws MarquezServiceException {
     String nonexistentJobName = "this_job_doesnt_exist";
     List<JobRun> jobRuns =
-        jobService.getAllRunsOfJob(NamespaceName.fromString(NAMESPACE_NAME), nonexistentJobName);
+        jobService.getAllRunsOfJob(
+            NamespaceName.fromString(NAMESPACE_NAME),
+            nonexistentJobName,
+            DEFAULT_LIMIT,
+            DEFAULT_OFFSET);
     assertEquals(jobRuns.size(), 0);
   }
 
@@ -150,7 +178,11 @@ public class JobRunDaoTest extends JobRunBaseTest {
                   format("DELETE FROM job_runs WHERE guid = '%s'", CREATED_JOB_RUN_UUID));
             });
     List<JobRun> jobRuns =
-        jobService.getAllRunsOfJob(NamespaceName.fromString(NAMESPACE_NAME), CREATED_JOB_NAME);
+        jobService.getAllRunsOfJob(
+            NamespaceName.fromString(NAMESPACE_NAME),
+            CREATED_JOB_NAME,
+            DEFAULT_LIMIT,
+            DEFAULT_OFFSET);
     assertEquals(jobRuns.size(), 0);
   }
 

--- a/src/test/java/marquez/db/JobRunDaoTest.java
+++ b/src/test/java/marquez/db/JobRunDaoTest.java
@@ -19,8 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.util.List;
 import java.util.UUID;
 import marquez.api.resources.JobRunBaseTest;
+import marquez.common.models.NamespaceName;
 import marquez.service.JobService;
 import marquez.service.NamespaceService;
 import marquez.service.exceptions.MarquezServiceException;
@@ -117,8 +119,39 @@ public class JobRunDaoTest extends JobRunBaseTest {
   }
 
   @Test
-  public void testFindAllByJobUuid(UUID jobUuid) {
-    
+  public void testFindAllByJobUuid() throws MarquezServiceException {
+    List<JobRun> jobRuns =
+        jobService.getAllRunsOfJob(NamespaceName.fromString(NAMESPACE_NAME), CREATED_JOB_NAME);
+    assertEquals(jobRuns.size(), 1);
+    jobService.createJobRun(NAMESPACE_NAME, CREATED_JOB_NAME, JOB_RUN_ARGS, null, null);
+    jobRuns =
+        jobService.getAllRunsOfJob(NamespaceName.fromString(NAMESPACE_NAME), CREATED_JOB_NAME);
+    assertEquals(jobRuns.size(), 2);
+  }
+
+  @Test
+  public void testFindAllByJobUuid_JobDoesntExist() throws MarquezServiceException {
+    String nonexistentJobName = "this_job_doesnt_exist";
+    List<JobRun> jobRuns =
+        jobService.getAllRunsOfJob(NamespaceName.fromString(NAMESPACE_NAME), nonexistentJobName);
+    assertEquals(jobRuns.size(), 0);
+  }
+
+  @Test
+  public void testFindAllByJobUuid_NoRuns() throws MarquezServiceException {
+    APP.getJDBI()
+        .useHandle(
+            handle -> {
+              handle.execute(
+                  format(
+                      "DELETE FROM job_run_states WHERE job_run_guid = '%s'",
+                      CREATED_JOB_RUN_UUID));
+              handle.execute(
+                  format("DELETE FROM job_runs WHERE guid = '%s'", CREATED_JOB_RUN_UUID));
+            });
+    List<JobRun> jobRuns =
+        jobService.getAllRunsOfJob(NamespaceName.fromString(NAMESPACE_NAME), CREATED_JOB_NAME);
+    assertEquals(jobRuns.size(), 0);
   }
 
   private JobRunState getLatestJobRunStateForJobId(UUID jobRunId) {
@@ -136,12 +169,8 @@ public class JobRunDaoTest extends JobRunBaseTest {
     APP.getJDBI()
         .useHandle(
             handle -> {
-              handle.execute(
-                  format(
-                      "delete from job_run_states where job_run_guid = '%s'",
-                      CREATED_JOB_RUN_UUID));
-              handle.execute(
-                  format("delete from job_runs where guid = '%s'", CREATED_JOB_RUN_UUID));
+              handle.execute(format("delete from job_run_states;", CREATED_JOB_RUN_UUID));
+              handle.execute(format("delete from job_runs;", CREATED_JOB_RUN_UUID));
             });
   }
 
@@ -150,14 +179,9 @@ public class JobRunDaoTest extends JobRunBaseTest {
     APP.getJDBI()
         .useHandle(
             handle -> {
-              handle.execute(
-                  format(
-                      "DELETE from job_versions where guid in (select job_versions.guid as guid from jobs inner join job_versions on job_versions.job_guid=jobs.guid and jobs.namespace_guid='%s')",
-                      CREATED_NAMESPACE_UUID));
-              handle.execute(
-                  format("delete from jobs where namespace_guid = '%s'", CREATED_NAMESPACE_UUID));
-              handle.execute(
-                  format("delete from namespaces where guid = '%s'", CREATED_NAMESPACE_UUID));
+              handle.execute("delete from job_versions");
+              handle.execute("delete from jobs");
+              handle.execute("delete from namespaces");
             });
   }
 }

--- a/src/test/java/marquez/db/JobRunDaoTest.java
+++ b/src/test/java/marquez/db/JobRunDaoTest.java
@@ -54,8 +54,8 @@ public class JobRunDaoTest extends JobRunBaseTest {
   protected static final JobRunStateDao jobRunStateDao = APP.onDemand(JobRunStateDao.class);
   protected static final JobRunArgsDao jobRunArgsDao = APP.onDemand(JobRunArgsDao.class);
 
-  protected static final int DEFAULT_OFFSET = 0;
-  protected static final int DEFAULT_LIMIT = 10;
+  protected static final int TEST_OFFSET = 0;
+  protected static final int TEST_LIMIT = 10;
 
   protected static NamespaceService namespaceService;
   protected static final JobService jobService =
@@ -125,18 +125,12 @@ public class JobRunDaoTest extends JobRunBaseTest {
   public void testFindAllByJobUuid() throws MarquezServiceException {
     List<JobRun> jobRuns =
         jobService.getAllRunsOfJob(
-            NamespaceName.fromString(NAMESPACE_NAME),
-            CREATED_JOB_NAME,
-            DEFAULT_LIMIT,
-            DEFAULT_OFFSET);
+            NamespaceName.fromString(NAMESPACE_NAME), CREATED_JOB_NAME, TEST_LIMIT, TEST_OFFSET);
     assertEquals(jobRuns.size(), 1);
     jobService.createJobRun(NAMESPACE_NAME, CREATED_JOB_NAME, JOB_RUN_ARGS, null, null);
     jobRuns =
         jobService.getAllRunsOfJob(
-            NamespaceName.fromString(NAMESPACE_NAME),
-            CREATED_JOB_NAME,
-            DEFAULT_LIMIT,
-            DEFAULT_OFFSET);
+            NamespaceName.fromString(NAMESPACE_NAME), CREATED_JOB_NAME, TEST_LIMIT, TEST_OFFSET);
     assertEquals(jobRuns.size(), 2);
   }
 
@@ -149,7 +143,7 @@ public class JobRunDaoTest extends JobRunBaseTest {
             NamespaceName.fromString(NAMESPACE_NAME),
             CREATED_JOB_NAME,
             singleJobLimit,
-            DEFAULT_OFFSET);
+            TEST_OFFSET);
     assertEquals(jobRuns.size(), 1);
   }
 
@@ -158,10 +152,7 @@ public class JobRunDaoTest extends JobRunBaseTest {
     String nonexistentJobName = "this_job_doesnt_exist";
     List<JobRun> jobRuns =
         jobService.getAllRunsOfJob(
-            NamespaceName.fromString(NAMESPACE_NAME),
-            nonexistentJobName,
-            DEFAULT_LIMIT,
-            DEFAULT_OFFSET);
+            NamespaceName.fromString(NAMESPACE_NAME), nonexistentJobName, TEST_LIMIT, TEST_OFFSET);
     assertEquals(jobRuns.size(), 0);
   }
 
@@ -179,10 +170,7 @@ public class JobRunDaoTest extends JobRunBaseTest {
             });
     List<JobRun> jobRuns =
         jobService.getAllRunsOfJob(
-            NamespaceName.fromString(NAMESPACE_NAME),
-            CREATED_JOB_NAME,
-            DEFAULT_LIMIT,
-            DEFAULT_OFFSET);
+            NamespaceName.fromString(NAMESPACE_NAME), CREATED_JOB_NAME, TEST_LIMIT, TEST_OFFSET);
     assertEquals(jobRuns.size(), 0);
   }
 

--- a/src/test/java/marquez/service/JobServiceTest.java
+++ b/src/test/java/marquez/service/JobServiceTest.java
@@ -2,9 +2,9 @@ package marquez.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -27,7 +27,10 @@ import marquez.service.models.JobRun;
 import marquez.service.models.JobRunState;
 import marquez.service.models.JobVersion;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
@@ -38,10 +41,12 @@ public class JobServiceTest {
   private static final int DEFAULT_LIMIT = 20;
   private static final int DEFAULT_OFFSET = 0;
 
-  private static final JobDao jobDao = mock(JobDao.class);
-  private static final JobVersionDao jobVersionDao = mock(JobVersionDao.class);
-  private static final JobRunDao jobRunDao = mock(JobRunDao.class);
-  private static final JobRunArgsDao jobRunArgsDao = mock(JobRunArgsDao.class);
+  @Rule public MockitoRule rule = MockitoJUnit.rule();
+
+  @Mock private JobDao jobDao;
+  @Mock private JobVersionDao jobVersionDao;
+  @Mock private JobRunDao jobRunDao;
+  @Mock private JobRunArgsDao jobRunArgsDao;
   private static final UUID namespaceID = UUID.randomUUID();
 
   JobService jobService;

--- a/src/test/java/marquez/service/JobServiceTest.java
+++ b/src/test/java/marquez/service/JobServiceTest.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import marquez.common.models.NamespaceName;
 import marquez.db.JobDao;
 import marquez.db.JobRunArgsDao;
 import marquez.db.JobRunDao;
@@ -25,6 +27,8 @@ import marquez.service.models.Job;
 import marquez.service.models.JobRun;
 import marquez.service.models.JobRunState;
 import marquez.service.models.JobVersion;
+
+import org.assertj.core.util.Arrays;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.*;
 import org.mockito.ArgumentCaptor;
@@ -249,5 +253,18 @@ public class JobServiceTest {
         .when(jobRunDao)
         .updateState(jobRunID, JobRunState.State.toInt(state));
     jobService.updateJobRunState(jobRunID, state);
+  }
+
+  @Test
+  public void testGetAllRunsOfJob() throws MarquezServiceException{
+    Job job = Generator.genJob();
+    NamespaceName jobNamespace = NamespaceName.fromString(TEST_NS);
+    List<JobRun> jobRuns = new ArrayList<JobRun>();
+    jobRuns.add(Generator.genJobRun());
+    jobRuns.add(Generator.genJobRun());
+    when(jobDao.findByName(jobNamespace.getValue(), job.getName())).thenReturn(job);
+    when(jobRunDao.findAllByJobUuid(job.getGuid())).thenReturn(jobRuns);
+    List<JobRun> jobRunsFound = jobService.getAllRunsOfJob(jobNamespace, job.getName());
+    assertEquals(2, jobRunsFound.size());
   }
 }

--- a/src/test/java/marquez/service/JobServiceTest.java
+++ b/src/test/java/marquez/service/JobServiceTest.java
@@ -270,7 +270,7 @@ public class JobServiceTest {
     Job job = Generator.genJob();
     NamespaceName jobNamespace = NamespaceName.fromString(TEST_NS);
     when(jobDao.findByName(jobNamespace.getValue(), job.getName())).thenReturn(null);
-    jobService.getAllRunsOfJob(jobNamespace, job.getName());
+    assertEquals(0, jobService.getAllRunsOfJob(jobNamespace, job.getName()).size());
   }
 
   @Test

--- a/src/test/java/marquez/service/JobServiceTest.java
+++ b/src/test/java/marquez/service/JobServiceTest.java
@@ -285,7 +285,7 @@ public class JobServiceTest {
   }
 
   @Test(expected = MarquezServiceException.class)
-  public void testGetAllRunsOfJob_xception() throws MarquezServiceException {
+  public void testGetAllRunsOfJob_exception() throws MarquezServiceException {
     Job job = Generator.genJob();
     NamespaceName jobNamespace = NamespaceName.fromString(TEST_NS);
     when(jobDao.findByName(jobNamespace.getValue(), job.getName())).thenReturn(job);

--- a/src/test/java/marquez/service/JobServiceTest.java
+++ b/src/test/java/marquez/service/JobServiceTest.java
@@ -38,8 +38,8 @@ import org.mockito.junit.MockitoRule;
 
 public class JobServiceTest {
   final String TEST_NS = "test_namespace";
-  private static final int DEFAULT_LIMIT = 20;
-  private static final int DEFAULT_OFFSET = 0;
+  private static final int TEST_LIMIT = 20;
+  private static final int TEST_OFFSET = 0;
 
   @Rule public MockitoRule rule = MockitoJUnit.rule();
 
@@ -265,10 +265,9 @@ public class JobServiceTest {
     jobRuns.add(Generator.genJobRun());
     jobRuns.add(Generator.genJobRun());
     when(jobDao.findByName(jobNamespace.getValue(), job.getName())).thenReturn(job);
-    when(jobRunDao.findAllByJobUuid(job.getGuid(), DEFAULT_LIMIT, DEFAULT_OFFSET))
-        .thenReturn(jobRuns);
+    when(jobRunDao.findAllByJobUuid(job.getGuid(), TEST_LIMIT, TEST_OFFSET)).thenReturn(jobRuns);
     List<JobRun> jobRunsFound =
-        jobService.getAllRunsOfJob(jobNamespace, job.getName(), DEFAULT_LIMIT, DEFAULT_OFFSET);
+        jobService.getAllRunsOfJob(jobNamespace, job.getName(), TEST_LIMIT, TEST_OFFSET);
     assertEquals(2, jobRunsFound.size());
   }
 
@@ -278,10 +277,7 @@ public class JobServiceTest {
     NamespaceName jobNamespace = NamespaceName.fromString(TEST_NS);
     when(jobDao.findByName(jobNamespace.getValue(), job.getName())).thenReturn(null);
     assertEquals(
-        0,
-        jobService
-            .getAllRunsOfJob(jobNamespace, job.getName(), DEFAULT_LIMIT, DEFAULT_OFFSET)
-            .size());
+        0, jobService.getAllRunsOfJob(jobNamespace, job.getName(), TEST_LIMIT, TEST_OFFSET).size());
   }
 
   @Test
@@ -290,10 +286,9 @@ public class JobServiceTest {
     NamespaceName jobNamespace = NamespaceName.fromString(TEST_NS);
     List<JobRun> jobRuns = new ArrayList<JobRun>();
     when(jobDao.findByName(jobNamespace.getValue(), job.getName())).thenReturn(job);
-    when(jobRunDao.findAllByJobUuid(job.getGuid(), DEFAULT_LIMIT, DEFAULT_OFFSET))
-        .thenReturn(jobRuns);
+    when(jobRunDao.findAllByJobUuid(job.getGuid(), TEST_LIMIT, TEST_OFFSET)).thenReturn(jobRuns);
     List<JobRun> jobRunsFound =
-        jobService.getAllRunsOfJob(jobNamespace, job.getName(), DEFAULT_LIMIT, DEFAULT_OFFSET);
+        jobService.getAllRunsOfJob(jobNamespace, job.getName(), TEST_LIMIT, TEST_OFFSET);
     assertEquals(0, jobRunsFound.size());
   }
 
@@ -302,8 +297,8 @@ public class JobServiceTest {
     Job job = Generator.genJob();
     NamespaceName jobNamespace = NamespaceName.fromString(TEST_NS);
     when(jobDao.findByName(jobNamespace.getValue(), job.getName())).thenReturn(job);
-    when(jobRunDao.findAllByJobUuid(job.getGuid(), DEFAULT_LIMIT, DEFAULT_OFFSET))
+    when(jobRunDao.findAllByJobUuid(job.getGuid(), TEST_LIMIT, TEST_OFFSET))
         .thenThrow(UnableToExecuteStatementException.class);
-    jobService.getAllRunsOfJob(jobNamespace, job.getName(), DEFAULT_LIMIT, DEFAULT_OFFSET);
+    jobService.getAllRunsOfJob(jobNamespace, job.getName(), TEST_LIMIT, TEST_OFFSET);
   }
 }

--- a/src/test/java/marquez/service/JobServiceTest.java
+++ b/src/test/java/marquez/service/JobServiceTest.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
 import marquez.common.models.NamespaceName;
 import marquez.db.JobDao;
 import marquez.db.JobRunArgsDao;
@@ -27,8 +26,6 @@ import marquez.service.models.Job;
 import marquez.service.models.JobRun;
 import marquez.service.models.JobRunState;
 import marquez.service.models.JobVersion;
-
-import org.assertj.core.util.Arrays;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.*;
 import org.mockito.ArgumentCaptor;
@@ -256,7 +253,7 @@ public class JobServiceTest {
   }
 
   @Test
-  public void testGetAllRunsOfJob_jobAndRunsFound() throws MarquezServiceException{
+  public void testGetAllRunsOfJob_jobAndRunsFound() throws MarquezServiceException {
     Job job = Generator.genJob();
     NamespaceName jobNamespace = NamespaceName.fromString(TEST_NS);
     List<JobRun> jobRuns = new ArrayList<JobRun>();
@@ -266,5 +263,16 @@ public class JobServiceTest {
     when(jobRunDao.findAllByJobUuid(job.getGuid())).thenReturn(jobRuns);
     List<JobRun> jobRunsFound = jobService.getAllRunsOfJob(jobNamespace, job.getName());
     assertEquals(2, jobRunsFound.size());
+  }
+
+  @Test
+  public void testGetAllRunsOfJob_noRunsFound() throws MarquezServiceException {
+    Job job = Generator.genJob();
+    NamespaceName jobNamespace = NamespaceName.fromString(TEST_NS);
+    List<JobRun> jobRuns = new ArrayList<JobRun>();
+    when(jobDao.findByName(jobNamespace.getValue(), job.getName())).thenReturn(job);
+    when(jobRunDao.findAllByJobUuid(job.getGuid())).thenReturn(jobRuns);
+    List<JobRun> jobRunsFound = jobService.getAllRunsOfJob(jobNamespace, job.getName());
+    assertEquals(0, jobRunsFound.size());
   }
 }

--- a/src/test/java/marquez/service/JobServiceTest.java
+++ b/src/test/java/marquez/service/JobServiceTest.java
@@ -35,13 +35,13 @@ import org.mockito.junit.MockitoRule;
 
 public class JobServiceTest {
   final String TEST_NS = "test_namespace";
+  private static final int DEFAULT_LIMIT = 20;
+  private static final int DEFAULT_OFFSET = 0;
 
-  @Rule public MockitoRule rule = MockitoJUnit.rule();
-
-  @Mock private JobDao jobDao;
-  @Mock private JobVersionDao jobVersionDao;
-  @Mock private JobRunDao jobRunDao;
-  @Mock private JobRunArgsDao jobRunArgsDao;
+  private static final JobDao jobDao = mock(JobDao.class);
+  private static final JobVersionDao jobVersionDao = mock(JobVersionDao.class);
+  private static final JobRunDao jobRunDao = mock(JobRunDao.class);
+  private static final JobRunArgsDao jobRunArgsDao = mock(JobRunArgsDao.class);
   private static final UUID namespaceID = UUID.randomUUID();
 
   JobService jobService;
@@ -260,8 +260,10 @@ public class JobServiceTest {
     jobRuns.add(Generator.genJobRun());
     jobRuns.add(Generator.genJobRun());
     when(jobDao.findByName(jobNamespace.getValue(), job.getName())).thenReturn(job);
-    when(jobRunDao.findAllByJobUuid(job.getGuid())).thenReturn(jobRuns);
-    List<JobRun> jobRunsFound = jobService.getAllRunsOfJob(jobNamespace, job.getName());
+    when(jobRunDao.findAllByJobUuid(job.getGuid(), DEFAULT_LIMIT, DEFAULT_OFFSET))
+        .thenReturn(jobRuns);
+    List<JobRun> jobRunsFound =
+        jobService.getAllRunsOfJob(jobNamespace, job.getName(), DEFAULT_LIMIT, DEFAULT_OFFSET);
     assertEquals(2, jobRunsFound.size());
   }
 
@@ -270,7 +272,11 @@ public class JobServiceTest {
     Job job = Generator.genJob();
     NamespaceName jobNamespace = NamespaceName.fromString(TEST_NS);
     when(jobDao.findByName(jobNamespace.getValue(), job.getName())).thenReturn(null);
-    assertEquals(0, jobService.getAllRunsOfJob(jobNamespace, job.getName()).size());
+    assertEquals(
+        0,
+        jobService
+            .getAllRunsOfJob(jobNamespace, job.getName(), DEFAULT_LIMIT, DEFAULT_OFFSET)
+            .size());
   }
 
   @Test
@@ -279,8 +285,10 @@ public class JobServiceTest {
     NamespaceName jobNamespace = NamespaceName.fromString(TEST_NS);
     List<JobRun> jobRuns = new ArrayList<JobRun>();
     when(jobDao.findByName(jobNamespace.getValue(), job.getName())).thenReturn(job);
-    when(jobRunDao.findAllByJobUuid(job.getGuid())).thenReturn(jobRuns);
-    List<JobRun> jobRunsFound = jobService.getAllRunsOfJob(jobNamespace, job.getName());
+    when(jobRunDao.findAllByJobUuid(job.getGuid(), DEFAULT_LIMIT, DEFAULT_OFFSET))
+        .thenReturn(jobRuns);
+    List<JobRun> jobRunsFound =
+        jobService.getAllRunsOfJob(jobNamespace, job.getName(), DEFAULT_LIMIT, DEFAULT_OFFSET);
     assertEquals(0, jobRunsFound.size());
   }
 
@@ -289,8 +297,8 @@ public class JobServiceTest {
     Job job = Generator.genJob();
     NamespaceName jobNamespace = NamespaceName.fromString(TEST_NS);
     when(jobDao.findByName(jobNamespace.getValue(), job.getName())).thenReturn(job);
-    when(jobRunDao.findAllByJobUuid(job.getGuid()))
+    when(jobRunDao.findAllByJobUuid(job.getGuid(), DEFAULT_LIMIT, DEFAULT_OFFSET))
         .thenThrow(UnableToExecuteStatementException.class);
-    jobService.getAllRunsOfJob(jobNamespace, job.getName());
+    jobService.getAllRunsOfJob(jobNamespace, job.getName(), DEFAULT_LIMIT, DEFAULT_OFFSET);
   }
 }

--- a/src/test/java/marquez/service/JobServiceTest.java
+++ b/src/test/java/marquez/service/JobServiceTest.java
@@ -266,6 +266,14 @@ public class JobServiceTest {
   }
 
   @Test
+  public void testGetAllRunsOfJob_jobNotFound() throws MarquezServiceException {
+    Job job = Generator.genJob();
+    NamespaceName jobNamespace = NamespaceName.fromString(TEST_NS);
+    when(jobDao.findByName(jobNamespace.getValue(), job.getName())).thenReturn(null);
+    jobService.getAllRunsOfJob(jobNamespace, job.getName());
+  }
+
+  @Test
   public void testGetAllRunsOfJob_noRunsFound() throws MarquezServiceException {
     Job job = Generator.genJob();
     NamespaceName jobNamespace = NamespaceName.fromString(TEST_NS);

--- a/src/test/java/marquez/service/JobServiceTest.java
+++ b/src/test/java/marquez/service/JobServiceTest.java
@@ -256,7 +256,7 @@ public class JobServiceTest {
   }
 
   @Test
-  public void testGetAllRunsOfJob() throws MarquezServiceException{
+  public void testGetAllRunsOfJob_jobAndRunsFound() throws MarquezServiceException{
     Job job = Generator.genJob();
     NamespaceName jobNamespace = NamespaceName.fromString(TEST_NS);
     List<JobRun> jobRuns = new ArrayList<JobRun>();

--- a/src/test/java/marquez/service/JobServiceTest.java
+++ b/src/test/java/marquez/service/JobServiceTest.java
@@ -275,4 +275,14 @@ public class JobServiceTest {
     List<JobRun> jobRunsFound = jobService.getAllRunsOfJob(jobNamespace, job.getName());
     assertEquals(0, jobRunsFound.size());
   }
+
+  @Test(expected = MarquezServiceException.class)
+  public void testGetAllRunsOfJob_xception() throws MarquezServiceException {
+    Job job = Generator.genJob();
+    NamespaceName jobNamespace = NamespaceName.fromString(TEST_NS);
+    when(jobDao.findByName(jobNamespace.getValue(), job.getName())).thenReturn(job);
+    when(jobRunDao.findAllByJobUuid(job.getGuid()))
+        .thenThrow(UnableToExecuteStatementException.class);
+    jobService.getAllRunsOfJob(jobNamespace, job.getName());
+  }
 }


### PR DESCRIPTION
New endpoint to fetch job runs by job:
- Returns job runs in reverse chronological order
- Supports `LIMIT` and `OFFSET` for pagination