### PR TITLE
Deprecate class Generator

### DIFF
--- a/src/test/java/marquez/service/models/Generator.java
+++ b/src/test/java/marquez/service/models/Generator.java
@@ -29,6 +29,7 @@ import marquez.db.models.DatasourceRow;
 import marquez.db.models.DbTableInfoRow;
 import marquez.db.models.DbTableVersionRow;
 
+@Deprecated
 public class Generator {
   private static Random rand = new Random();
 


### PR DESCRIPTION
This PR deprecates **class** [`Generator`](https://github.com/MarquezProject/marquez/blob/master/src/test/java/marquez/service/models/Generator.java) in favor of:

- **class** [`ApiModelGenerator`](https://github.com/MarquezProject/marquez/blob/master/src/test/java/marquez/api/models/ApiModelGenerator.java)
- **class** [`ServiceModelGenerator`](https://github.com/MarquezProject/marquez/blob/master/src/test/java/marquez/service/models/ServiceModelGenerator.java) 
- **class** [`DbModelGenerator`](https://github.com/MarquezProject/marquez/blob/master/src/test/java/marquez/db/models/DbModelGenerator.java)