### PR TITLE
Bump dropwizard 1.3.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 ext {
-  dropwizardVersion = '1.3.11'
+  dropwizardVersion = '1.3.12'
   jdbi3Version = '3.8.2'
   lombokVersion = '1.18.8'
 }


### PR DESCRIPTION
Fixes [CVE-2019-12086](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12086)