### PR TITLE
Fix marquez.jar rename on COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN ./gradlew --no-daemon shadowJar
 FROM openjdk:8-jre
 RUN apt-get update && apt-get install -y --no-install-recommends postgresql-client-9.6
 WORKDIR /usr/src/app
-COPY --from=build /usr/src/app/build/libs/marquez-*.jar marquez-*.jar
+COPY --from=build /usr/src/app/build/libs/marquez-*.jar /usr/src/app
 COPY docker/wait-for-db.sh wait-for-db.sh
 COPY docker/entrypoint.sh entrypoint.sh
 EXPOSE 5000 5001


### PR DESCRIPTION
This PR fixes the JAR name when building an image. For example,  instead of the JAR being incorrectly named **`marquez-*.jar`**:
```
root@a3524ae917e5:/usr/src/app# ls
config.yml  entrypoint.sh  marquez-*.jar  wait-for-db.sh
```

it’s now named **`marquez-0.4.1-SNAPSHOT.jar`**:
```
root@a7e2c660c610:/usr/src/app# ls
config.yml  entrypoint.sh  marquez-0.4.1-SNAPSHOT.jar  wait-for-db.sh
```