### PR TITLE
Return JobRunsResponse for getRunsforJob method

### DIFF
--- a/src/main/java/marquez/api/resources/JobResource.java
+++ b/src/main/java/marquez/api/resources/JobResource.java
@@ -167,7 +167,7 @@ public final class JobResource {
     throwIfNotExists(namespaceName);
     final List<JobRun> jobRuns =
         jobService.getAllRunsOfJob(namespaceName, jobAsString, limit, offset);
-    return Response.ok().entity(JobRunResponseMapper.map(jobRuns)).build();
+    return Response.ok().entity(JobRunResponseMapper.toJobRunsResponse(jobRuns)).build();
   }
 
   @Timed

--- a/src/test/java/marquez/api/resources/JobResourceTest.java
+++ b/src/test/java/marquez/api/resources/JobResourceTest.java
@@ -358,10 +358,10 @@ public class JobResourceTest {
     when(MOCK_JOB_SERVICE.getAllRunsOfJob(NAMESPACE_NAME, job.getName(), TEST_LIMIT, TEST_OFFSET))
         .thenReturn(jobRuns);
 
-    Response response =
+    final Response response =
         JOB_RESOURCE.getRunsForJob(
             NAMESPACE_NAME.getValue(), job.getName(), TEST_LIMIT, TEST_OFFSET);
-    JobRunsResponse jobRunsResponse = (JobRunsResponse) response.getEntity();
+    final JobRunsResponse jobRunsResponse = (JobRunsResponse) response.getEntity();
 
     assertEquals(jobRuns.size(), jobRunsResponse.getRuns().size());
   }
@@ -385,10 +385,10 @@ public class JobResourceTest {
     when(MOCK_JOB_SERVICE.getAllRunsOfJob(NAMESPACE_NAME, job.getName(), TEST_LIMIT, TEST_OFFSET))
         .thenReturn(noJobRuns);
 
-    Response response =
+    final Response response =
         JOB_RESOURCE.getRunsForJob(
             NAMESPACE_NAME.getValue(), job.getName(), TEST_LIMIT, TEST_OFFSET);
-    JobRunsResponse jobRunsResponse = (JobRunsResponse) response.getEntity();
+    final JobRunsResponse jobRunsResponse = (JobRunsResponse) response.getEntity();
 
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     assertEquals(0, jobRunsResponse.getRuns().size());

--- a/src/test/java/marquez/api/resources/JobResourceTest.java
+++ b/src/test/java/marquez/api/resources/JobResourceTest.java
@@ -46,6 +46,7 @@ import marquez.api.models.JobRequest;
 import marquez.api.models.JobResponse;
 import marquez.api.models.JobRunRequest;
 import marquez.api.models.JobRunResponse;
+import marquez.api.models.JobRunsResponse;
 import marquez.common.models.NamespaceName;
 import marquez.service.JobService;
 import marquez.service.NamespaceService;
@@ -360,12 +361,9 @@ public class JobResourceTest {
     Response response =
         JOB_RESOURCE.getRunsForJob(
             NAMESPACE_NAME.getValue(), job.getName(), TEST_LIMIT, TEST_OFFSET);
+    JobRunsResponse jobRunsResponse = (JobRunsResponse) response.getEntity();
 
-    List<JobRunResponse> responseJobRuns = new ArrayList<JobRunResponse>();
-    for (Object resItem : (List<?>) response.getEntity()) {
-      responseJobRuns.add((JobRunResponse) resItem);
-    }
-    assertEquals(jobRuns.size(), responseJobRuns.size());
+    assertEquals(jobRuns.size(), jobRunsResponse.getRuns().size());
   }
 
   @Test
@@ -390,13 +388,10 @@ public class JobResourceTest {
     Response response =
         JOB_RESOURCE.getRunsForJob(
             NAMESPACE_NAME.getValue(), job.getName(), TEST_LIMIT, TEST_OFFSET);
+    JobRunsResponse jobRunsResponse = (JobRunsResponse) response.getEntity();
 
-    List<JobRunResponse> responseJobRuns = new ArrayList<JobRunResponse>();
-    for (Object resItem : (List<?>) response.getEntity()) {
-      responseJobRuns.add((JobRunResponse) resItem);
-    }
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    assertEquals(0, responseJobRuns.size());
+    assertEquals(0, jobRunsResponse.getRuns().size());
   }
 
   @Test(expected = MarquezServiceException.class)


### PR DESCRIPTION
Updated getRunsforJob method in api/resources/JobResource to return JobRunsResponse instead of List<JobRunResponse> and updated tests accordingly