### PR TITLE
Remove config.h2.test.yml

### DIFF
--- a/src/test/resources/config.h2.test.yml
+++ b/src/test/resources/config.h2.test.yml
@@ -1,3 +1,0 @@
-db:
-  driverClass : org.h2.Driver
-  url: 'jdbc:h2:./build/test_db?DB_CLOSE_DELAY=-1'


### PR DESCRIPTION
This PR removes the configuration file for `h2` driver that is no longer used.