### PR TITLE
Link dataset versions with run inputs

### DIFF
--- a/src/main/java/marquez/MarquezApp.java
+++ b/src/main/java/marquez/MarquezApp.java
@@ -175,6 +175,7 @@ public final class MarquezApp extends Application<MarquezConfig> {
         new JobService(
             namespaceDao,
             datasetDao,
+            datasetVersionDao,
             jobDao,
             jobVersionDao,
             jobContextDao,

--- a/src/main/java/marquez/db/DatasetVersionDao.java
+++ b/src/main/java/marquez/db/DatasetVersionDao.java
@@ -14,6 +14,8 @@
 
 package marquez.db;
 
+import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.NULL_STRING;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -26,6 +28,7 @@ import marquez.db.models.StreamVersionRow;
 import org.jdbi.v3.sqlobject.CreateSqlObject;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
@@ -94,6 +97,16 @@ public interface DatasetVersionDao {
         return findBy(version);
     }
   }
+
+  @SqlQuery(
+      "SELECT *, "
+          + "ARRAY(SELECT dataset_field_uuid "
+          + "      FROM dataset_versions_field_mapping "
+          + "      WHERE dataset_version_uuid = uuid) AS field_uuids "
+          + "FROM dataset_versions "
+          + "WHERE dataset_uuid IN (<datasetUuids>)")
+  List<DatasetVersionRow> findAllInUuidList(
+      @BindList(onEmpty = NULL_STRING) List<UUID> datasetUuids);
 
   @SqlQuery("SELECT COUNT(*) FROM dataset_versions")
   int count();

--- a/src/main/java/marquez/db/RunDao.java
+++ b/src/main/java/marquez/db/RunDao.java
@@ -33,6 +33,12 @@ public interface RunDao extends SqlObject {
   JobVersionDao createJobVersionDao();
 
   @Transaction
+  default void insertWith(RunRow row, List<UUID> inputVersionUuids) {
+    insert(row);
+    inputVersionUuids.forEach(inputVersionUuid -> insert(row.getUuid(), inputVersionUuid));
+  }
+
+  @Transaction
   default void insert(RunRow row) {
     getHandle()
         .createUpdate(
@@ -43,6 +49,11 @@ public interface RunDao extends SqlObject {
 
     createJobVersionDao().update(row.getJobVersionUuid(), row.getCreatedAt(), row.getUuid());
   }
+
+  @SqlUpdate(
+      "INSERT INTO runs_input_mapping (run_uuid, dataset_version_uuid) "
+          + "VALUES (:runUuid, :datasetVersionUuid)")
+  void insert(UUID runUuid, UUID datasetVersionUuid);
 
   @SqlQuery("SELECT EXISTS (SELECT 1 FROM runs WHERE uuid = :rowUuid)")
   boolean exists(UUID rowUuid);


### PR DESCRIPTION
This PR links input dataset versions to a given run using the table [`runs_input_mapping`](https://github.com/MarquezProject/marquez/blob/master/src/main/resources/db/migration/V1__initial_schema.sql#L119).