### PR TITLE
Modify args column in table run_args

### DIFF
--- a/src/main/resources/db/migration/V7__alter_run_args_to_modify_args.sql
+++ b/src/main/resources/db/migration/V7__alter_run_args_to_modify_args.sql
@@ -1,0 +1,1 @@
+ALTER TABLE run_args ALTER COLUMN args TYPE TEXT;


### PR DESCRIPTION
This PR modifies the `args` column in the `run_args` table from type `VARCHAR` to `TEXT`