### PR TITLE
Add flyway config support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
 
 ext {
   dropwizardVersion = '1.3.12'
-  jdbi3Version = '3.10.1'
+  jdbi3Version = '3.12.0'
   lombokVersion = '1.18.10'
   prometheusVersion = '0.8.0'
 }
@@ -34,9 +34,7 @@ dependencies {
   compile "org.jdbi:jdbi3-postgres:${jdbi3Version}"
   compile "org.jdbi:jdbi3-sqlobject:${jdbi3Version}"
   compile 'com.google.guava:guava:28.0-jre'
-  compile 'org.flywaydb:flyway-core:5.2.4'
-  compile 'io.dropwizard.metrics:metrics-jdbi3:4.1.0'
-  compile 'io.dropwizard.modules:dropwizard-flyway:1.3.0-4'
+  compile 'org.flywaydb:flyway-core:6.1.1'
   compile 'org.postgresql:postgresql:42.2.5'
   compileOnly "org.projectlombok:lombok:${lombokVersion}"
   annotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/config.example.yml
+++ b/config.example.yml
@@ -18,7 +18,13 @@ db:
   user: ${POSTGRES_USER}
   password: ${POSTGRES_PASSWORD}
 
+# Enables flyway configuration overrides (see: https://flywaydb.org/documentation/configfiles)
+# flyway:
+#  cleanDisabled: true
+#  connectRetries: 3
+
 logging:
+  # Levels: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, ALL, OFF
   level: ${LOG_LEVEL:-INFO}
   appenders:
     - type: console

--- a/config.example.yml
+++ b/config.example.yml
@@ -20,8 +20,8 @@ db:
 
 # Enables flyway configuration overrides (see: https://flywaydb.org/documentation/configfiles)
 # flyway:
-#  cleanDisabled: true
-#  connectRetries: 3
+#   connectRetries: 3
+#   cleanDisabled: true
 
 logging:
   # Levels: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, ALL, OFF

--- a/docker/wait-for-db.sh
+++ b/docker/wait-for-db.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Usage: $ ./wait-for-db.sh <host> <port>
+# Usage: $ ./wait-for-db.sh <host> <port> [timeout]
 
 set -eu
 

--- a/src/main/java/marquez/MarquezApp.java
+++ b/src/main/java/marquez/MarquezApp.java
@@ -14,11 +14,11 @@
 
 package marquez;
 
-import com.codahale.metrics.jdbi3.InstrumentedSqlLogger;
 import io.dropwizard.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.jdbi3.JdbiFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -26,6 +26,7 @@ import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.exporter.MetricsServlet;
 import io.prometheus.client.hotspot.DefaultExports;
+import javax.sql.DataSource;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import marquez.api.DatasetResource;
@@ -37,6 +38,7 @@ import marquez.api.exceptions.MarquezServiceExceptionMapper;
 import marquez.db.DatasetDao;
 import marquez.db.DatasetFieldDao;
 import marquez.db.DatasetVersionDao;
+import marquez.db.FlywayFactory;
 import marquez.db.JobContextDao;
 import marquez.db.JobDao;
 import marquez.db.JobVersionDao;
@@ -62,7 +64,8 @@ import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 @Slf4j
 public final class MarquezApp extends Application<MarquezConfig> {
   private static final String APP_NAME = "MarquezApp";
-  private static final String POSTGRES_DB = "postgresql";
+  private static final String DB_SOURCE_NAME = APP_NAME + "-source";
+  private static final String DB_POSTGRES = "postgresql";
   private static final boolean ERROR_ON_UNDEFINED = false;
 
   // Monitoring
@@ -94,19 +97,20 @@ public final class MarquezApp extends Application<MarquezConfig> {
 
   @Override
   public void run(@NonNull MarquezConfig config, @NonNull Environment env) throws MarquezException {
+    final DataSourceFactory sourceFactory = config.getDataSourceFactory();
+    final DataSource source = sourceFactory.build(env.metrics(), DB_SOURCE_NAME);
+
     log.info("Running startup actions...");
-    migrateDbOrError(config);
-    registerResources(config, env);
+    migrateDbOrError(config, source);
+    registerResources(config, env, source);
 
     // Expose metrics for monitoring.
     env.servlets().addServlet(PROMETHEUS, new MetricsServlet()).addMapping(PROMETHEUS_ENDPOINT);
   }
 
-  private void migrateDbOrError(@NonNull MarquezConfig config) {
-    final Flyway flyway = new Flyway();
-    final DataSourceFactory db = config.getDataSourceFactory();
-    String initSql = config.getFlywayInitSql() == null ? "" : config.getFlywayInitSql();
-    flyway.setDataSource(db.getUrl(), db.getUser(), db.getPassword(), initSql);
+  private void migrateDbOrError(@NonNull MarquezConfig config, @NonNull DataSource source) {
+    final FlywayFactory flywayFactory = config.getFlywayFactory();
+    final Flyway flyway = flywayFactory.build(source);
     // Attempt to perform a database migration. An exception is thrown on failed migration attempts
     // requiring we handle the throwable and apply a repair on the database to fix any
     // issues before app termination.
@@ -130,15 +134,15 @@ public final class MarquezApp extends Application<MarquezConfig> {
     }
   }
 
-  private void registerResources(@NonNull MarquezConfig config, @NonNull Environment env)
+  private void registerResources(
+      @NonNull MarquezConfig config, @NonNull Environment env, @NonNull DataSource source)
       throws MarquezException {
     final JdbiFactory factory = new JdbiFactory();
     final Jdbi jdbi =
         factory
-            .build(env, config.getDataSourceFactory(), POSTGRES_DB)
+            .build(env, config.getDataSourceFactory(), (ManagedDataSource) source, DB_POSTGRES)
             .installPlugin(new SqlObjectPlugin())
             .installPlugin(new PostgresPlugin());
-    jdbi.setSqlLogger(new InstrumentedSqlLogger(env.metrics()));
 
     final NamespaceDao namespaceDao = jdbi.onDemand(NamespaceDao.class);
     final OwnerDao ownerDao = jdbi.onDemand(OwnerDao.class);
@@ -171,7 +175,6 @@ public final class MarquezApp extends Application<MarquezConfig> {
             runDao,
             runArgsDao,
             runStateDao);
-
     final TagService tagService = new TagService(tagDao);
 
     env.jersey().register(new NamespaceResource(namespaceService));

--- a/src/main/java/marquez/MarquezApp.java
+++ b/src/main/java/marquez/MarquezApp.java
@@ -116,8 +116,8 @@ public final class MarquezApp extends Application<MarquezConfig> {
     // issues before app termination.
     try {
       log.info("Migrating database...");
-      flyway.migrate();
-      log.info("Successfully migrated database.");
+      final int migrations = flyway.migrate();
+      log.info("Successfully applied '{}' migrations to database.", migrations);
     } catch (FlywayException errorOnDbMigrate) {
       log.error("Failed to apply migration to database.", errorOnDbMigrate);
       try {

--- a/src/main/java/marquez/MarquezConfig.java
+++ b/src/main/java/marquez/MarquezConfig.java
@@ -17,9 +17,9 @@ package marquez;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.flyway.FlywayFactory;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import marquez.db.FlywayFactory;
 
 @NoArgsConstructor
 public final class MarquezConfig extends Configuration {
@@ -30,8 +30,4 @@ public final class MarquezConfig extends Configuration {
   @Getter
   @JsonProperty("flyway")
   private final FlywayFactory flywayFactory = new FlywayFactory();
-
-  @Getter
-  @JsonProperty("flywayInitSql")
-  private String flywayInitSql;
 }

--- a/src/main/java/marquez/db/FlywayFactory.java
+++ b/src/main/java/marquez/db/FlywayFactory.java
@@ -45,7 +45,7 @@ public final class FlywayFactory {
   private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
   private static final String DEFAULT_TABLE = "flyway_schema_history";
   private static final boolean DEFAULT_PLACEHOLDER_REPLACEMENT = false;
-  private static final Map DEFAULT_PLACEHOLDERS = ImmutableMap.of();
+  private static final Map<String, String> DEFAULT_PLACEHOLDERS = ImmutableMap.of();
   private static final String DEFAULT_PLACEHOLDER_PREFIX = "${";
   private static final String DEFAULT_PLACEHOLDER_SUFFIX = "}";
   private static final String DEFAULT_SQL_MIGRATION_PREFIX = "V";

--- a/src/main/java/marquez/db/FlywayFactory.java
+++ b/src/main/java/marquez/db/FlywayFactory.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package marquez.db;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import javax.sql.DataSource;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import org.flywaydb.core.Flyway;
+
+@NoArgsConstructor
+public final class FlywayFactory {
+  private static final int DEFAULT_CONNECT_RETRIES = 0;
+  private static final boolean DEFAULT_GROUP = false;
+  private static final boolean DEFAULT_MIX = false;
+  private static final boolean DEFAULT_IGNORE_MISSING_MIGRATIONS = false;
+  private static final boolean DEFAULT_IGNORE_IGNORED_MIGRATIONS = false;
+  private static final boolean DEFAULT_IGNORE_PENDING_MIGRATIONS = false;
+  private static final boolean DEFAULT_IGNORE_FUTURE_MIGRATIONS = false;
+  private static final boolean DEFAULT_VALIDATE_ON_MIGRATE = false;
+  private static final boolean DEFAULT_CLEAN_ON_VALIDATION_ERROR = false;
+  private static final boolean DEFAULT_CLEAN_DISABLED = false;
+  private static final String DEFAULT_LOCATION = "db/migration";
+  private static final List<String> DEFAULT_LOCATIONS = ImmutableList.of(DEFAULT_LOCATION);
+  private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
+  private static final String DEFAULT_TABLE = "flyway_schema_history";
+  private static final boolean DEFAULT_PLACEHOLDER_REPLACEMENT = false;
+  private static final Map DEFAULT_PLACEHOLDERS = ImmutableMap.of();
+  private static final String DEFAULT_PLACEHOLDER_PREFIX = "${";
+  private static final String DEFAULT_PLACEHOLDER_SUFFIX = "}";
+  private static final String DEFAULT_SQL_MIGRATION_PREFIX = "V";
+  private static final String DEFAULT_REPEATABLE_SQL_MIGRATION_PREFIX = "R";
+
+  @Getter @Setter private int connectRetries = DEFAULT_CONNECT_RETRIES;
+  @Setter @Nullable private String initSql;
+  @Getter @Setter private boolean group = DEFAULT_GROUP;
+  @Setter @Nullable private String installedBy;
+  @Getter @Setter private boolean mixed = DEFAULT_MIX;
+  @Getter @Setter private boolean ignoreMissingMigrations = DEFAULT_IGNORE_MISSING_MIGRATIONS;
+  @Getter @Setter private boolean ignoreIgnoredMigrations = DEFAULT_IGNORE_IGNORED_MIGRATIONS;
+  @Getter @Setter private boolean ignorePendingMigrations = DEFAULT_IGNORE_PENDING_MIGRATIONS;
+  @Getter @Setter private boolean ignoreFutureMigrations = DEFAULT_IGNORE_FUTURE_MIGRATIONS;
+  @Getter @Setter private boolean validateOnMigrate = DEFAULT_VALIDATE_ON_MIGRATE;
+  @Getter @Setter private boolean cleanOnValidationError = DEFAULT_CLEAN_ON_VALIDATION_ERROR;
+  @Getter @Setter private boolean cleanDisabled = DEFAULT_CLEAN_DISABLED;
+  @Getter @Setter private List<String> locations = DEFAULT_LOCATIONS;
+  @Getter @Setter private String encoding = DEFAULT_ENCODING;
+  @Getter @Setter private String table = DEFAULT_TABLE;
+  @Setter @Nullable private String tablespace;
+  @Getter @Setter private boolean placeholderReplacement = DEFAULT_PLACEHOLDER_REPLACEMENT;
+  @Getter @Setter private Map<String, String> placeholders = DEFAULT_PLACEHOLDERS;
+  @Getter @Setter private String placeholderPrefix = DEFAULT_PLACEHOLDER_PREFIX;
+  @Getter @Setter private String placeholderSuffix = DEFAULT_PLACEHOLDER_SUFFIX;
+  @Getter @Setter private String sqlMigrationPrefix = DEFAULT_SQL_MIGRATION_PREFIX;
+
+  @Getter @Setter
+  private String repeatableSqlMigrationPrefix = DEFAULT_REPEATABLE_SQL_MIGRATION_PREFIX;
+
+  public Optional<String> getInitSql() {
+    return Optional.ofNullable(initSql);
+  }
+
+  public Optional<String> getInstalledBy() {
+    return Optional.ofNullable(installedBy);
+  }
+
+  public Optional<String> getTablespace() {
+    return Optional.ofNullable(tablespace);
+  }
+
+  public Flyway build(@NonNull DataSource source) {
+    return Flyway.configure()
+        .dataSource(source)
+        .connectRetries(connectRetries)
+        .initSql(initSql)
+        .group(group)
+        .installedBy(installedBy)
+        .mixed(mixed)
+        .ignoreMissingMigrations(ignoreMissingMigrations)
+        .ignoreIgnoredMigrations(ignoreIgnoredMigrations)
+        .ignorePendingMigrations(ignorePendingMigrations)
+        .ignoreFutureMigrations(ignoreFutureMigrations)
+        .validateOnMigrate(validateOnMigrate)
+        .cleanOnValidationError(cleanOnValidationError)
+        .cleanDisabled(cleanDisabled)
+        .locations(locations.stream().toArray(String[]::new))
+        .encoding(encoding)
+        .table(table)
+        .tablespace(tablespace)
+        .placeholderReplacement(placeholderReplacement)
+        .placeholders(placeholders)
+        .placeholderPrefix(placeholderPrefix)
+        .placeholderSuffix(placeholderSuffix)
+        .sqlMigrationPrefix(sqlMigrationPrefix)
+        .repeatableSqlMigrationPrefix(repeatableSqlMigrationPrefix)
+        .load();
+  }
+}

--- a/src/main/java/marquez/db/FlywayFactory.java
+++ b/src/main/java/marquez/db/FlywayFactory.java
@@ -32,7 +32,7 @@ import org.flywaydb.core.Flyway;
 public final class FlywayFactory {
   private static final int DEFAULT_CONNECT_RETRIES = 0;
   private static final boolean DEFAULT_GROUP = false;
-  private static final boolean DEFAULT_MIX = false;
+  private static final boolean DEFAULT_MIXED = false;
   private static final boolean DEFAULT_IGNORE_MISSING_MIGRATIONS = false;
   private static final boolean DEFAULT_IGNORE_IGNORED_MIGRATIONS = false;
   private static final boolean DEFAULT_IGNORE_PENDING_MIGRATIONS = false;
@@ -55,7 +55,7 @@ public final class FlywayFactory {
   @Setter @Nullable private String initSql;
   @Getter @Setter private boolean group = DEFAULT_GROUP;
   @Setter @Nullable private String installedBy;
-  @Getter @Setter private boolean mixed = DEFAULT_MIX;
+  @Getter @Setter private boolean mixed = DEFAULT_MIXED;
   @Getter @Setter private boolean ignoreMissingMigrations = DEFAULT_IGNORE_MISSING_MIGRATIONS;
   @Getter @Setter private boolean ignoreIgnoredMigrations = DEFAULT_IGNORE_IGNORED_MIGRATIONS;
   @Getter @Setter private boolean ignorePendingMigrations = DEFAULT_IGNORE_PENDING_MIGRATIONS;

--- a/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/src/main/resources/db/migration/V1__initial_schema.sql
@@ -23,13 +23,13 @@ CREATE TABLE namespace_ownerships (
 );
 
 CREATE TABLE sources (
-  uuid            UUID PRIMARY KEY,
-  type            VARCHAR(64) NOT NULL,
-  created_at      TIMESTAMP NOT NULL,
-  updated_at      TIMESTAMP NOT NULL,
-  name            VARCHAR(64) UNIQUE NOT NULL,
-  connection_url  VARCHAR(255) NOT NULL,
-  description     TEXT,
+  uuid           UUID PRIMARY KEY,
+  type           VARCHAR(64) NOT NULL,
+  created_at     TIMESTAMP NOT NULL,
+  updated_at     TIMESTAMP NOT NULL,
+  name           VARCHAR(64) UNIQUE NOT NULL,
+  connection_url VARCHAR(255) NOT NULL,
+  description    TEXT,
   UNIQUE (name, connection_url)
 );
 
@@ -85,14 +85,14 @@ CREATE TABLE run_args (
 );
 
 CREATE TABLE runs (
-  uuid                UUID PRIMARY KEY,
-  created_at          TIMESTAMP NOT NULL,
-  updated_at          TIMESTAMP NOT NULL,
-  job_version_uuid    UUID REFERENCES job_versions(uuid),
-  run_args_uuid       UUID REFERENCES run_args(uuid),
-  nominal_start_time  TIMESTAMP,
-  nominal_end_time    TIMESTAMP,
-  current_run_state   VARCHAR(64)
+  uuid               UUID PRIMARY KEY,
+  created_at         TIMESTAMP NOT NULL,
+  updated_at         TIMESTAMP NOT NULL,
+  job_version_uuid   UUID REFERENCES job_versions(uuid),
+  run_args_uuid      UUID REFERENCES run_args(uuid),
+  nominal_start_time TIMESTAMP,
+  nominal_end_time   TIMESTAMP,
+  current_run_state  VARCHAR(64)
 );
 
 CREATE TABLE run_states (

--- a/src/test/java/marquez/db/FlywayFactoryTest.java
+++ b/src/test/java/marquez/db/FlywayFactoryTest.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package marquez.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import marquez.UnitTests;
+import org.flywaydb.core.Flyway;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@Category(UnitTests.class)
+public class FlywayFactoryTest {
+  @Rule public MockitoRule rule = MockitoJUnit.rule();
+
+  @Mock private DataSource source;
+
+  @Test
+  public void testBuild_overrideConnectRetries() {
+    final int override = 2;
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setConnectRetries(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideInitSql() {
+    final String override = "SET ROLE buendia;";
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setInitSql(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideGroup() {
+    final boolean override = true;
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setGroup(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideInstalledBy() {
+    final String override = "marquez";
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setInstalledBy(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideMixed() {
+    final boolean override = true;
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setMixed(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideIgnoreMissingMigrations() {
+    final boolean override = true;
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setIgnoreMissingMigrations(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideIgnoreIgnoredMigrations() {
+    final boolean override = true;
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setIgnoreIgnoredMigrations(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideIgnorePendingMigrations() {
+    final boolean override = true;
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setIgnorePendingMigrations(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideIgnoreFutureMigrations() {
+    final boolean override = true;
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setIgnoreFutureMigrations(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideValidateOnMigrate() {
+    final boolean override = true;
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setValidateOnMigrate(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideCleanOnValidationError() {
+    final boolean override = true;
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setCleanOnValidationError(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideCleanDisabled() {
+    final boolean override = true;
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setCleanDisabled(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideLocations() {
+    final List<String> override = ImmutableList.of("override/migration");
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setLocations(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideEncoding() {
+    final String override = StandardCharsets.UTF_16.name();
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setEncoding(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideTable() {
+    final String override = "override_flyway_schema_history";
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setTable(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideTablespace() {
+    final String override = "override_tablespace";
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setTablespace(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overridePlaceholderReplacement() {
+    final boolean override = true;
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setPlaceholderReplacement(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overridePlaceholders() {
+    final Map<String, String> override = ImmutableMap.of("${placeholder}", "override");
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setPlaceholders(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overridePlaceholderPrefix() {
+    final String override = "<";
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setPlaceholderPrefix(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overridePlaceholderSuffix() {
+    final String override = ">";
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setPlaceholderSuffix(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideSqlMigrationPrefix() {
+    final String override = "M";
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setSqlMigrationPrefix(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+
+  @Test
+  public void testBuild_overrideRepeatableSqlMigrationPrefix() {
+    final String override = "W";
+    final FlywayFactory factory = new FlywayFactory();
+    factory.setRepeatableSqlMigrationPrefix(override);
+
+    final Flyway flyway = factory.build(source);
+    assertThat(flyway).isNotNull();
+  }
+}

--- a/src/test/resources/config.test.yml
+++ b/src/test/resources/config.test.yml
@@ -11,3 +11,7 @@ db:
   url: jdbc:postgresql://${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}/${POSTGRES_DB}
   user: ${POSTGRES_USER}
   password: ${POSTGRES_PASSWORD}
+
+flyway:
+  connectRetries: 3
+  cleanDisabled: true


### PR DESCRIPTION
This PR makes changes to how Marquez manages DB connections and applies schema migrations to the underlying postgres instance. The changes include:

- Bump `jdbi3` to [`3.12.0`](https://github.com/jdbi/jdbi/releases/tag/v3.12.0)
- Use shared [`ManagedPooledDataSource`](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-db/src/main/java/io/dropwizard/db/ManagedPooledDataSource.java) for DB connections and migrations
- Add new **class** `FlywayFactory` (inspired by [`dropwizard/dropwizard-flyway`](https://github.com/dropwizard/dropwizard-flyway)) with example configuration in `config.yml`