### PR TITLE
Remove 'Add review label' step when contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,8 @@ $ ./gradlew spotlessApply
 5. Write a test for your change
 6. Make sure `.java` files are formatted: `./gradlew spotlessJavaCheck`
 7. Push change to your fork and [submit a pull request](https://github.com/MarquezProject/marquez/compare)
-8. Add the ["review"](https://github.com/MarquezProject/marquez/labels/review) label to your pull request
-9. Work with project maintainers to get your change reviewed and merged into the `master` branch
-10. Delete your branch
+8. Work with project maintainers to get your change reviewed and merged into the `master` branch
+9. Delete your branch
 
 To ensure your pull request is accepted, follow these guidelines:
 


### PR DESCRIPTION
You need write access add the `Review` label. So, removing this step. Thank @nkijak for the suggestion!