### PR TITLE
Add JobResource.locationFor()

### DIFF
--- a/src/main/java/marquez/api/JobResource.java
+++ b/src/main/java/marquez/api/JobResource.java
@@ -161,14 +161,7 @@ public final class JobResource {
     final Run run = jobService.createRun(namespaceName, jobName, runMeta);
     final RunResponse response = Mapper.toRunResponse(run);
     log.debug("Response: {}", response);
-    final URI runLocation =
-        uriInfo
-            .getBaseUriBuilder()
-            .clone()
-            .path(this.getClass())
-            .path(this.getClass(), "getRun")
-            .build(run.getId());
-
+    final URI runLocation = locationFor(uriInfo, run);
     return Response.created(runLocation).entity(response).build();
   }
 
@@ -291,5 +284,13 @@ public final class JobResource {
     if (!jobService.runExists(runId)) {
       throw new RunNotFoundException(runId);
     }
+  }
+
+  private URI locationFor(@NonNull UriInfo uriInfo, @NonNull Run run) {
+    return uriInfo
+        .getBaseUriBuilder()
+        .path(JobResource.class)
+        .path(JobResource.class, "getRun")
+        .build(run.getId());
   }
 }


### PR DESCRIPTION
This PR make minor changes to how we add the `Location` header on job creation by introduction the helper method **`JobResource.locationFor()`**

/cc @nkijak 