### PR TITLE
Bump postgres to 12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY build.gradle build.gradle
 RUN ./gradlew --no-daemon shadowJar
 
 FROM openjdk:8-jre
-RUN apt-get update && apt-get install -y --no-install-recommends postgresql-client-9.6
+RUN apt-get update && apt-get install -y --no-install-recommends postgresql-client
 WORKDIR /usr/src/app
 COPY --from=build /usr/src/app/build/libs/marquez-*.jar /usr/src/app
 COPY docker/config.dev.yml config.dev.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     entrypoint: ["./wait-for-it.sh", "db:5432", "--", "./entrypoint.sh"]
 
   db:
-    image: 'postgres:9.6'
+    image: 'postgres:12.1'
     ports:
       - '5432:5432'
     environment:


### PR DESCRIPTION
This PR bump the postgres version in [`docker-compose.yml`](https://github.com/MarquezProject/marquez/blob/master/docker-compose.yml) to [12.1](https://www.postgresql.org/docs/12/index.html). The PR also fixes the following error when running `docker-compose up`:

```
$ docker-compose up --build
.
.
Step 14/20 : RUN apt-get update && apt-get install -y --no-install-recommends postgresql-client-9.6
 ---> Running in 7a8ed4d27298
Get:1 http://deb.debian.org/debian buster InRelease [122 kB]
Get:2 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
Get:3 http://deb.debian.org/debian buster-updates InRelease [49.3 kB]
Get:4 http://security.debian.org/debian-security buster/updates/main amd64 Packages [176 kB]
Get:5 http://deb.debian.org/debian buster/main amd64 Packages [7908 kB]
Get:6 http://deb.debian.org/debian buster-updates/main amd64 Packages [5792 B]
Fetched 8326 kB in 2s (4070 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package postgresql-client-9.6
E: Couldn't find any package by glob 'postgresql-client-9.6'
E: Couldn't find any package by regex 'postgresql-client-9.6'
.
.

```

/cc @roaraya8 