### PR TITLE
Updates openapi to show correct key

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -573,7 +573,7 @@ components:
         inputs: ["wedata.room_bookings", "analytics.scheduled_events"]
         outputs: ["wedata.room_bookings_7_days"]
         location: https://github.com/wework/jobs/commit/124f6089ad4c5fcbb1d7b33cbb5d3a9521c5d32c
-        context: {'sql': "SELECT * FROM room_bookings WHERE room_num = '2H';"}
+        context: {'SQL': "SELECT * FROM room_bookings WHERE room_num = '2H';"}
         description: Determine weekly room booking occupancy patterns.
         latestRun: null
 
@@ -655,7 +655,7 @@ components:
         inputs: ["wedata.room_bookings", "analytics.scheduled_events"]
         outputs: ["wedata.room_bookings_7_days"]
         location: https://github.com/wework/jobs/commit/124f6089ad4c5fcbb1d7b33cbb5d3a9521c5d32c
-        context: {'sql': "SELECT * FROM room_bookings WHERE room_num = '2H';"}
+        context: {'SQL': "SELECT * FROM room_bookings WHERE room_num = '2H';"}
         description: Determine weekly room booking occupancy patterns.
         latestRun: null
 


### PR DESCRIPTION
Updates openapi to show correct key.  

I tried creating a along the lines of:

```bash
curl -X PUT http://localhost:5000/api/v1/namespaces/data_engineering/jobs/airflow.pim_agg \
  -H 'Content-Type: application/json' \
  -d '{
        "type": "BATCH",
        "inputs": ["frank_dev.items"],
        "outputs": ["frank_dev.items_aggregate"],
        "location": "https://github.com/...",
        "description": "thing.",
        "context": {
          "sql":"INSERT INTO frank_dev.items_aggregate..."
        }
      }'
```

Per the Docs discussion
![Screen Shot 2020-04-29 at 9 57 04 AM](https://user-images.githubusercontent.com/6012231/80604520-d3205a00-89ff-11ea-9e54-56651e52e806.png)

This results in an empty sql field when running marquez-web.  To resolve this someone needs to send 

```bash
curl -X PUT http://localhost:5000/api/v1/namespaces/data_engineering/jobs/airflow.pim_agg \
  -H 'Content-Type: application/json' \
  -d '{
        "type": "BATCH",
        "inputs": ["frank_dev.items"],
        "outputs": ["frank_dev.items_aggregate"],
        "location": "https://github.com/...",
        "description": "thing.",
        "context": {
          "SQL":"INSERT INTO frank_dev.items_aggregate..."
        }
      }'
```

Thus I felt it necessary to update the openapi examples