### PR TITLE
Add .testcontainers.properties to CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,15 @@ defaults: &defaults
 jobs:
   build:
     <<: *defaults
+    environment:
+      TESTCONTAINERS_RYUK_DISABLED: true
     steps:
       - checkout
       - restore_cache:
           keys:
             - v1-jvm-{{ .Branch }}-{{ .Revision }}
             - v1-jvm-{{ .Branch }}
+      - run: echo "checks.disable=true" > ~/.testcontainers.properties
       - run: ./gradlew --no-daemon --stacktrace build
       - run: ./gradlew --no-daemon jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This PR adds `~/.testcontainers.properties` and sets `TESTCONTAINERS_RYUK_DISABLED=true` to disable checks and speed our API tests

See:

- https://www.testcontainers.org/features/configuration
- https://github.com/testcontainers/workshop/blob/master/step-4-your-first-testcontainers-integration.md