### PR TITLE
Bumping the shadow plugin version to 6.0.0. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
   id 'com.adarshr.test-logger' version '2.0.0'
   id 'com.diffplug.gradle.spotless' version '3.27.0'
   id 'com.github.jk1.dependency-license-report' version '1.11'
-  id 'com.github.johnrengelman.shadow' version '5.2.0'
+  id 'com.github.johnrengelman.shadow' version '6.0.0'
   id 'net.researchgate.release' version '2.8.0'
 }
 


### PR DESCRIPTION
Fixes the ./gradlew runShadow error: "Execution failed for task ':runShadow'. > The value for task ':runShadow' property 'mainClass' is final and cannot be changed any further."

Signed-off-by: Michal Januszewski <michal.januszewski@gmail.com>