### PR TITLE
Throw RunAlreadyExistsException on run ID already exists

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.internal.http.connectionTimeout=60000
 org.gradle.internal.http.socketTimeout=60000
 
-version=0.11.3-rc.1
+version=0.11.3-rc.2

--- a/src/main/java/marquez/api/exceptions/RunAlreadyExistsException.java
+++ b/src/main/java/marquez/api/exceptions/RunAlreadyExistsException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package marquez.api.exceptions;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.ws.rs.BadRequestException;
+import marquez.common.models.JobName;
+import marquez.common.models.NamespaceName;
+import marquez.common.models.RunId;
+
+public final class RunAlreadyExistsException extends BadRequestException {
+  private static final long serialVersionUID = 1L;
+
+  public RunAlreadyExistsException(
+      final NamespaceName namespaceName, final JobName jobName, final RunId id) {
+    super(
+        String.format(
+            "Run '%s' already exists for '%s' under namespace '%s'.",
+            checkNotNull(id).getValue(),
+            checkNotNull(jobName).getValue(),
+            checkNotNull(namespaceName).getValue()));
+  }
+}


### PR DESCRIPTION
With the option to pass in an external ID via [`JobMeta`](https://github.com/MarquezProject/marquez/blob/main/src/main/java/marquez/service/models/JobMeta.java), we also need to add a check if the run ID already exists to fix a unique constraint in the `runs` table:

```
Causing: org.jdbi.v3.core.statement.UnableToExecuteStatementException: org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "runs_pkey"
   Detail: Key (uuid)=(c2e6c59c-1255-40f8-82fa-d1fc6a271861) already exists. [statement:"/* RunDao.insert */ INSERT INTO runs (uuid, created_at, updated_at, job_version_uuid, run_args_uuid, nominal_start_time, nominal_end_time) VALUES (:uuid, :createdAt, :updatedAt, :jobVersionUuid, :runArgsUuid, :nominalStartTime, :nominalEndTime)", arguments:{positional:{}, named:{}, finder:[{lazy bean property arguments "RunRow(uuid=c2e6c59c-1255-40f8-82fa-d1fc6a271861, createdAt=2020-09-03T23:38:12.344797Z, updatedAt=2020-09-03T23:38:12.344797Z, jobVersionUuid=5e5d3e77-cd71-4f9a-a820-edde44bb1c3a, runArgsUuid=0ee65287-6c5f-4d1c-bcf9-a302440426e3, inputVersionUuids=[], nominalStartTime=Optional[2020-08-27T00:00:00Z], nominalEndTime=Optional.empty, currentRunState=Optional.empty, startedAt=Optional.empty, endedAt=Optional.empty)"}]}]
     at org.jdbi.v3.core.statement.SqlStatement.internalExecute(SqlStatement.java:1676)
     at org.jdbi.v3.core.result.ResultProducers.lambda$returningUpdateCount$0(ResultProducers.java:46)
     at org.jdbi.v3.core.statement.Update.execute(Update.java:60)
     at org.jdbi.v3.core.statement.Update.execute(Update.java:48)
     at marquez.db.RunDao.insert(RunDao.java:64)
     .
     .
```

This PR ensures the a run ID for a given job is not already associated with a run. If true, a `400` is returned instead of a `500`.