### PR TITLE
Add more dataset resource tests

### DIFF
--- a/src/main/java/marquez/api/DatasetResource.java
+++ b/src/main/java/marquez/api/DatasetResource.java
@@ -152,7 +152,7 @@ public class DatasetResource {
   @Path("/{dataset}/fields/{field}/tags/{tag}")
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
-  public Response tag(
+  public Response tagField(
       @PathParam("namespace") NamespaceName namespaceName,
       @PathParam("dataset") DatasetName datasetName,
       @PathParam("field") FieldName fieldName,
@@ -163,7 +163,7 @@ public class DatasetResource {
     throwIfNotExists(namespaceName, datasetName, fieldName);
     throwIfNotExists(tagName);
 
-    datasetService.tagWith(namespaceName, datasetName, fieldName, tagName);
+    datasetService.tagFieldWith(namespaceName, datasetName, fieldName, tagName);
     return get(namespaceName, datasetName);
   }
 
@@ -192,7 +192,7 @@ public class DatasetResource {
       @NonNull DatasetName datasetName,
       @NonNull FieldName fieldName)
       throws MarquezServiceException {
-    if (!datasetService.exists(namespaceName, datasetName, fieldName)) {
+    if (!datasetService.fieldExists(namespaceName, datasetName, fieldName)) {
       throw new FieldNotFoundException(datasetName, fieldName);
     }
   }

--- a/src/main/java/marquez/api/DatasetResource.java
+++ b/src/main/java/marquez/api/DatasetResource.java
@@ -141,8 +141,8 @@ public class DatasetResource {
     throwIfNotExists(namespaceName, datasetName);
     throwIfNotExists(tagName);
 
-    datasetService.tagWith(namespaceName, datasetName, tagName);
-    return get(namespaceName, datasetName);
+    final Dataset dataset = datasetService.tagWith(namespaceName, datasetName, tagName);
+    return Response.ok(dataset).build();
   }
 
   @Timed
@@ -163,8 +163,9 @@ public class DatasetResource {
     throwIfNotExists(namespaceName, datasetName, fieldName);
     throwIfNotExists(tagName);
 
-    datasetService.tagFieldWith(namespaceName, datasetName, fieldName, tagName);
-    return get(namespaceName, datasetName);
+    final Dataset dataset =
+        datasetService.tagFieldWith(namespaceName, datasetName, fieldName, tagName);
+    return Response.ok(dataset).build();
   }
 
   @Value

--- a/src/main/java/marquez/api/JobResource.java
+++ b/src/main/java/marquez/api/JobResource.java
@@ -16,6 +16,10 @@
 package marquez.api;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static marquez.common.models.RunState.ABORTED;
+import static marquez.common.models.RunState.COMPLETED;
+import static marquez.common.models.RunState.FAILED;
+import static marquez.common.models.RunState.RUNNING;
 
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.ResponseMetered;
@@ -178,7 +182,7 @@ public class JobResource {
   @Produces(APPLICATION_JSON)
   public Response markRunAsRunning(@PathParam("id") RunId runId, @QueryParam("at") String atAsIso)
       throws MarquezServiceException {
-    return markRunAs(runId, RunState.RUNNING, atAsIso);
+    return markRunAs(runId, RUNNING, atAsIso);
   }
 
   @Timed
@@ -189,7 +193,7 @@ public class JobResource {
   @Produces(APPLICATION_JSON)
   public Response markRunAsCompleted(@PathParam("id") RunId runId, @QueryParam("at") String atAsIso)
       throws MarquezServiceException {
-    return markRunAs(runId, RunState.COMPLETED, atAsIso);
+    return markRunAs(runId, COMPLETED, atAsIso);
   }
 
   @Timed
@@ -200,7 +204,7 @@ public class JobResource {
   @Produces(APPLICATION_JSON)
   public Response markRunAsFailed(@PathParam("id") RunId runId, @QueryParam("at") String atAsIso)
       throws MarquezServiceException {
-    return markRunAs(runId, RunState.FAILED, atAsIso);
+    return markRunAs(runId, FAILED, atAsIso);
   }
 
   @Timed
@@ -211,7 +215,7 @@ public class JobResource {
   @Produces(APPLICATION_JSON)
   public Response markRunAsAborted(@PathParam("id") RunId runId, @QueryParam("at") String atAsIso)
       throws MarquezServiceException {
-    return markRunAs(runId, RunState.ABORTED, atAsIso);
+    return markRunAs(runId, ABORTED, atAsIso);
   }
 
   Response markRunAs(

--- a/src/main/java/marquez/api/NamespaceResource.java
+++ b/src/main/java/marquez/api/NamespaceResource.java
@@ -56,9 +56,9 @@ public class NamespaceResource {
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
   public Response createOrUpdate(
-      @PathParam("namespace") NamespaceName namespaceName, @Valid NamespaceMeta meta)
+      @PathParam("namespace") NamespaceName name, @Valid NamespaceMeta meta)
       throws MarquezServiceException {
-    final Namespace namespace = service.createOrUpdate(namespaceName, meta);
+    final Namespace namespace = service.createOrUpdate(name, meta);
     return Response.ok(namespace).build();
   }
 
@@ -68,10 +68,9 @@ public class NamespaceResource {
   @GET
   @Path("/namespaces/{namespace}")
   @Produces(APPLICATION_JSON)
-  public Response get(@PathParam("namespace") NamespaceName namespaceName)
-      throws MarquezServiceException {
+  public Response get(@PathParam("namespace") NamespaceName name) throws MarquezServiceException {
     final Namespace namespace =
-        service.get(namespaceName).orElseThrow(() -> new NamespaceNotFoundException(namespaceName));
+        service.get(name).orElseThrow(() -> new NamespaceNotFoundException(name));
     return Response.ok(namespace).build();
   }
 

--- a/src/main/java/marquez/service/DatasetService.java
+++ b/src/main/java/marquez/service/DatasetService.java
@@ -218,7 +218,7 @@ public class DatasetService {
     }
   }
 
-  public boolean exists(
+  public boolean fieldExists(
       @NonNull NamespaceName namespaceName,
       @NonNull DatasetName datasetName,
       @NonNull FieldName fieldName)
@@ -325,7 +325,7 @@ public class DatasetService {
     }
   }
 
-  public Dataset tagWith(
+  public Dataset tagFieldWith(
       @NonNull NamespaceName namespaceName,
       @NonNull DatasetName datasetName,
       @NonNull FieldName fieldName,

--- a/src/test/java/marquez/api/DatasetResourceTest.java
+++ b/src/test/java/marquez/api/DatasetResourceTest.java
@@ -22,6 +22,7 @@ import marquez.UnitTests;
 import marquez.api.exceptions.DatasetNotFoundException;
 import marquez.api.exceptions.FieldNotFoundException;
 import marquez.api.exceptions.NamespaceNotFoundException;
+import marquez.api.exceptions.TagNotFoundException;
 import marquez.common.models.DatasetId;
 import marquez.common.models.DatasetName;
 import marquez.common.models.Field;
@@ -171,6 +172,17 @@ public class DatasetResourceTest {
   }
 
   @Test
+  public void testTag_throwOnTagNotFound() throws MarquezServiceException {
+    when(namespaceService.exists(NAMESPACE_NAME)).thenReturn(true);
+    when(datasetService.exists(NAMESPACE_NAME, DB_TABLE_NAME)).thenReturn(true);
+    when(tagService.exists(TAG_NAME)).thenReturn(false);
+
+    assertThatExceptionOfType(TagNotFoundException.class)
+        .isThrownBy(() -> datasetResource.tag(NAMESPACE_NAME, DB_TABLE_NAME, TAG_NAME))
+        .withMessageContaining(String.format("'%s' not found", TAG_NAME.getValue()));
+  }
+
+  @Test
   public void testTag_field() throws MarquezServiceException {
     when(namespaceService.exists(NAMESPACE_NAME)).thenReturn(true);
     when(datasetService.exists(NAMESPACE_NAME, DB_TABLE_NAME)).thenReturn(true);
@@ -224,6 +236,19 @@ public class DatasetResourceTest {
         .isThrownBy(
             () -> datasetResource.tagField(NAMESPACE_NAME, DB_TABLE_NAME, DB_FIELD_NAME, TAG_NAME))
         .withMessageContaining(String.format("'%s' not found", DB_FIELD_NAME.getValue()));
+  }
+
+  @Test
+  public void testTag_field_throwOnTagNotFound() throws MarquezServiceException {
+    when(namespaceService.exists(NAMESPACE_NAME)).thenReturn(true);
+    when(datasetService.exists(NAMESPACE_NAME, DB_TABLE_NAME)).thenReturn(true);
+    when(datasetService.fieldExists(NAMESPACE_NAME, DB_TABLE_NAME, DB_FIELD_NAME)).thenReturn(true);
+    when(tagService.exists(TAG_NAME)).thenReturn(false);
+
+    assertThatExceptionOfType(TagNotFoundException.class)
+        .isThrownBy(
+            () -> datasetResource.tagField(NAMESPACE_NAME, DB_TABLE_NAME, DB_FIELD_NAME, TAG_NAME))
+        .withMessageContaining(String.format("'%s' not found", TAG_NAME.getValue()));
   }
 
   static DbTable toDbTable(final DatasetId dbTableId, final DbTableMeta dbTableMeta) {

--- a/src/test/java/marquez/api/DatasetResourceTest.java
+++ b/src/test/java/marquez/api/DatasetResourceTest.java
@@ -110,7 +110,7 @@ public class DatasetResourceTest {
   }
 
   @Test
-  public void testCreateOrUpdate_throwOnRunNotFound() throws MarquezServiceException {
+  public void testCreateOrUpdateWithRun_throwOnRunNotFound() throws MarquezServiceException {
     final RunId runIdDoesNotExist = newRunId();
     final DbTableMeta dbTableMeta = newDbTableMetaWith(runIdDoesNotExist);
     final DbTable dbTable = toDbTable(DB_TABLE_ID, dbTableMeta);

--- a/src/test/java/marquez/api/DatasetResourceTest.java
+++ b/src/test/java/marquez/api/DatasetResourceTest.java
@@ -10,7 +10,6 @@ import static marquez.service.models.ModelGenerator.newDbTableMeta;
 import static marquez.service.models.ModelGenerator.newDbTableWith;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -142,7 +141,7 @@ public class DatasetResourceTest {
     when(tagService.exists(TAG_NAME)).thenReturn(true);
 
     final DbTable dbTable = tagWith(TAG_NAME, newDbTableWith(DB_TABLE_ID));
-    doReturn(Response.ok(dbTable).build()).when(datasetResource).get(NAMESPACE_NAME, DB_TABLE_NAME);
+    when(datasetService.tagWith(NAMESPACE_NAME, DB_TABLE_NAME, TAG_NAME)).thenReturn(dbTable);
 
     final Response response = datasetResource.tag(NAMESPACE_NAME, DB_TABLE_NAME, TAG_NAME);
     assertThat(response.getStatus()).isEqualTo(200);
@@ -175,12 +174,15 @@ public class DatasetResourceTest {
   public void testTag_field() throws MarquezServiceException {
     when(namespaceService.exists(NAMESPACE_NAME)).thenReturn(true);
     when(datasetService.exists(NAMESPACE_NAME, DB_TABLE_NAME)).thenReturn(true);
+    when(datasetService.fieldExists(NAMESPACE_NAME, DB_TABLE_NAME, DB_FIELD_NAME)).thenReturn(true);
     when(tagService.exists(TAG_NAME)).thenReturn(true);
 
-    final DbTable dbTable = tagAllWith(TAG_NAME, newDbTableWith(DB_TABLE_ID));
-    doReturn(Response.ok(dbTable).build()).when(datasetResource).get(NAMESPACE_NAME, DB_TABLE_NAME);
+    final DbTable dbTable = tagAllFieldsWith(TAG_NAME, newDbTableWith(DB_TABLE_ID));
+    when(datasetService.tagFieldWith(NAMESPACE_NAME, DB_TABLE_NAME, DB_FIELD_NAME, TAG_NAME))
+        .thenReturn(dbTable);
 
-    final Response response = datasetResource.tag(NAMESPACE_NAME, DB_TABLE_NAME, TAG_NAME);
+    final Response response =
+        datasetResource.tagField(NAMESPACE_NAME, DB_TABLE_NAME, DB_FIELD_NAME, TAG_NAME);
     assertThat(response.getStatus()).isEqualTo(200);
 
     final Dataset dataset = (Dataset) response.getEntity();
@@ -255,7 +257,7 @@ public class DatasetResourceTest {
         dbTable.getDescription().orElse(null));
   }
 
-  static DbTable tagAllWith(final TagName tagName, final DbTable dbTable) {
+  static DbTable tagAllFieldsWith(final TagName tagName, final DbTable dbTable) {
     final ImmutableList.Builder<Field> fields = ImmutableList.builder();
     for (final Field field : dbTable.getFields()) {
       final ImmutableSet<TagName> tags =

--- a/src/test/java/marquez/service/DatasetServiceTest.java
+++ b/src/test/java/marquez/service/DatasetServiceTest.java
@@ -211,7 +211,7 @@ public class DatasetServiceTest {
             NAMESPACE_NAME.getValue(), DB_TABLE_NAME.getValue(), fieldName.getValue()))
         .thenReturn(true);
 
-    final boolean exists = datasetService.exists(NAMESPACE_NAME, DB_TABLE_NAME, fieldName);
+    final boolean exists = datasetService.fieldExists(NAMESPACE_NAME, DB_TABLE_NAME, fieldName);
     assertThat(exists).isTrue();
 
     verify(datasetFieldDao, times(1))
@@ -225,7 +225,7 @@ public class DatasetServiceTest {
             NAMESPACE_NAME.getValue(), DB_TABLE_NAME.getValue(), fieldName.getValue()))
         .thenReturn(false);
 
-    final boolean exists = datasetService.exists(NAMESPACE_NAME, DB_TABLE_NAME, fieldName);
+    final boolean exists = datasetService.fieldExists(NAMESPACE_NAME, DB_TABLE_NAME, fieldName);
     assertThat(exists).isFalse();
 
     verify(datasetFieldDao, times(1))

--- a/src/test/java/marquez/service/models/ModelGenerator.java
+++ b/src/test/java/marquez/service/models/ModelGenerator.java
@@ -41,6 +41,7 @@ import java.time.Instant;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import marquez.Generator;
 import marquez.common.Utils;
 import marquez.common.models.DatasetId;
@@ -100,8 +101,12 @@ public final class ModelGenerator extends Generator {
   }
 
   public static DbTableMeta newDbTableMeta() {
+    return newDbTableMetaWith(null);
+  }
+
+  public static DbTableMeta newDbTableMetaWith(@Nullable final RunId runId) {
     return new DbTableMeta(
-        newDatasetName(), newSourceName(), newFields(4), newTagNames(2), newDescription(), null);
+        newDatasetName(), newSourceName(), newFields(4), newTagNames(2), newDescription(), runId);
   }
 
   public static JobMeta newJobMeta() {


### PR DESCRIPTION
This PR adds tests to ensure a `400` is thrown when tagging a dataset or field that does not exits. This PR also reduces the DB calls made on tagging by using the `Dataset` object retuned by `DatasetService.tagWith()` and `DatasetService.tagFieldWith()`. `DatasetService.fieldExist()` has also been renamed from  `DatasetService.exist()` to make it more obvious on the _field_ existence check that is being made.