### PR TITLE
Allow job updates to associate new input datasets.

### DIFF
--- a/src/main/java/marquez/common/Utils.java
+++ b/src/main/java/marquez/common/Utils.java
@@ -22,6 +22,7 @@ import static marquez.common.base.MorePreconditions.checkNotBlank;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.base.Joiner;
@@ -71,6 +72,18 @@ public final class Utils {
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
+  }
+
+  public static <T> T fromJson(@NonNull final String json, @NonNull final JavaType type) {
+    try {
+      return MAPPER.readValue(json, type);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static ObjectMapper getMapper() {
+    return MAPPER;
   }
 
   public static URL toUrl(@NonNull final String urlString) {

--- a/src/main/java/marquez/db/DatasetVersionDao.java
+++ b/src/main/java/marquez/db/DatasetVersionDao.java
@@ -74,11 +74,11 @@ public interface DatasetVersionDao {
   void updateFields(UUID datasetVersionUuid, UUID datasetFieldUuid);
 
   String SELECT =
-      "SELECT *, "
+      "SELECT dv.*, "
           + "ARRAY(SELECT dataset_field_uuid "
           + "      FROM dataset_versions_field_mapping "
-          + "      WHERE dataset_version_uuid = uuid) AS field_uuids "
-          + "FROM dataset_versions ";
+          + "      WHERE dataset_version_uuid = dv.uuid) AS field_uuids "
+          + "FROM dataset_versions dv ";
 
   String EXTENDED_SELECT =
       "SELECT dv.*, d.name as dataset_name, n.name as namespace_name, "
@@ -91,6 +91,12 @@ public interface DatasetVersionDao {
 
   @SqlQuery(SELECT + "WHERE uuid = :uuid")
   Optional<DatasetVersionRow> findBy(UUID uuid);
+
+  @SqlQuery(
+      SELECT
+          + "INNER JOIN datasets AS d ON d.uuid = dv.dataset_uuid AND d.current_version_uuid = dv.uuid "
+          + "WHERE dv.dataset_uuid = :datasetUuid")
+  Optional<DatasetVersionRow> findLatestDatasetByUuid(UUID datasetUuid);
 
   default Optional<DatasetVersionRow> find(String typeString, @Nullable UUID uuid) {
     if (uuid == null) {

--- a/src/main/java/marquez/db/RunDao.java
+++ b/src/main/java/marquez/db/RunDao.java
@@ -90,7 +90,7 @@ public interface RunDao extends SqlObject {
 
   @SqlUpdate(
       "INSERT INTO runs_input_mapping (run_uuid, dataset_version_uuid) "
-          + "VALUES (:runUuid, :datasetVersionUuid)")
+          + "VALUES (:runUuid, :datasetVersionUuid) ON CONFLICT DO NOTHING")
   void updateInputVersions(UUID runUuid, UUID datasetVersionUuid);
 
   @SqlUpdate(

--- a/src/main/java/marquez/service/JobService.java
+++ b/src/main/java/marquez/service/JobService.java
@@ -279,7 +279,7 @@ public class JobService {
                 new DatasetVersionId(
                     namespaceName, DatasetName.of(inputDataset.getName()), row.getUuid())));
       } else {
-        log.warn(
+        log.error(
             "Input dataset version could not be found during run input update. Input Dataset ID: {}",
             inputDataset.getUuid());
       }

--- a/src/main/java/marquez/service/mappers/Mapper.java
+++ b/src/main/java/marquez/service/mappers/Mapper.java
@@ -431,4 +431,15 @@ public final class Mapper {
   private static Instant newTimestamp() {
     return Instant.now();
   }
+
+  public static ImmutableMap<String, String> toRunArgs(String args) {
+    if (args == null) {
+      return null;
+    }
+    return Utils.fromJson(
+        args,
+        Utils.getMapper()
+            .getTypeFactory()
+            .constructMapType(ImmutableMap.class, String.class, String.class));
+  }
 }

--- a/src/main/resources/marquez/db/migration/V14__index_datasetversion_datasetid.sql
+++ b/src/main/resources/marquez/db/migration/V14__index_datasetversion_datasetid.sql
@@ -1,0 +1,1 @@
+CREATE INDEX datasetversion_datasetid_idx ON dataset_versions (dataset_uuid);

--- a/src/test/java/marquez/common/UtilsTest.java
+++ b/src/test/java/marquez/common/UtilsTest.java
@@ -55,7 +55,7 @@ public class UtilsTest {
 
   @Test
   public void testFromJson_throwsOnNull() {
-    assertThatNullPointerException().isThrownBy(() -> Utils.fromJson(JSON, null));
+    assertThatNullPointerException().isThrownBy(() -> Utils.fromJson(JSON, (TypeReference) null));
     assertThatNullPointerException().isThrownBy(() -> Utils.fromJson(null, TYPE));
   }
 


### PR DESCRIPTION
For workflows like big query, where the input dataset is not available during run creation, we need to associate the input datasets of a completed job. This is done via the job update resources that takes a run id as a context key.

Signed-off-by: henneberger <git@danielhenneberger.com>