### PR TITLE
Rename functions to original names to reduce breaking changes

### DIFF
--- a/src/main/java/marquez/api/JobResource.java
+++ b/src/main/java/marquez/api/JobResource.java
@@ -103,7 +103,7 @@ public class JobResource {
 
     final Job job =
         jobService
-            .getJob(namespaceName, jobName)
+            .get(namespaceName, jobName)
             .orElseThrow(() -> new JobNotFoundException(jobName));
     return Response.ok(job).build();
   }

--- a/src/main/java/marquez/api/JobResource.java
+++ b/src/main/java/marquez/api/JobResource.java
@@ -102,9 +102,7 @@ public class JobResource {
     throwIfNotExists(namespaceName);
 
     final Job job =
-        jobService
-            .get(namespaceName, jobName)
-            .orElseThrow(() -> new JobNotFoundException(jobName));
+        jobService.get(namespaceName, jobName).orElseThrow(() -> new JobNotFoundException(jobName));
     return Response.ok(job).build();
   }
 

--- a/src/main/java/marquez/service/JobService.java
+++ b/src/main/java/marquez/service/JobService.java
@@ -248,8 +248,7 @@ public class JobService {
     return jobDao.find(namespaceName.getValue(), jobName.getValue()).map(this::toJob);
   }
 
-  public Optional<Job> getBy(@NonNull JobVersionId jobVersionId)
-      throws MarquezServiceException {
+  public Optional<Job> getBy(@NonNull JobVersionId jobVersionId) throws MarquezServiceException {
     return jobDao
         .find(jobVersionId.getNamespace().getValue(), jobVersionId.getName().getValue())
         .map(jobRow -> toJob(jobRow, jobVersionId.getVersionUuid()));

--- a/src/main/java/marquez/service/JobService.java
+++ b/src/main/java/marquez/service/JobService.java
@@ -92,7 +92,7 @@ public class JobService {
     if (!jobVersionDao.exists(jobVersion.getValue())) {
       createJobVersion(job.getUuid(), jobVersion, namespaceName, jobName, jobMeta);
       // Get a new job as versions have been attached
-      return getJob(namespaceName, jobName).get();
+      return get(namespaceName, jobName).get();
     }
     return toJob(job);
   }
@@ -243,12 +243,12 @@ public class JobService {
     return jobDao.exists(namespaceName.getValue(), jobName.getValue());
   }
 
-  public Optional<Job> getJob(@NonNull NamespaceName namespaceName, @NonNull JobName jobName)
+  public Optional<Job> get(@NonNull NamespaceName namespaceName, @NonNull JobName jobName)
       throws MarquezServiceException {
     return jobDao.find(namespaceName.getValue(), jobName.getValue()).map(this::toJob);
   }
 
-  public Optional<Job> getByJobVersion(@NonNull JobVersionId jobVersionId)
+  public Optional<Job> getBy(@NonNull JobVersionId jobVersionId)
       throws MarquezServiceException {
     return jobDao
         .find(jobVersionId.getNamespace().getValue(), jobVersionId.getName().getValue())

--- a/src/test/java/marquez/api/JobResourceTest.java
+++ b/src/test/java/marquez/api/JobResourceTest.java
@@ -107,7 +107,7 @@ public class JobResourceTest {
     final Job job = newJobWith(JOB_ID);
 
     when(namespaceService.exists(NAMESPACE_NAME)).thenReturn(true);
-    when(jobService.getJob(NAMESPACE_NAME, JOB_NAME)).thenReturn(Optional.of(job));
+    when(jobService.get(NAMESPACE_NAME, JOB_NAME)).thenReturn(Optional.of(job));
 
     final Response response = jobResource.get(NAMESPACE_NAME, JOB_NAME);
     assertThat(response.getStatus()).isEqualTo(200);
@@ -126,7 +126,7 @@ public class JobResourceTest {
   @Test
   public void testGet_notFound() throws MarquezServiceException {
     when(namespaceService.exists(NAMESPACE_NAME)).thenReturn(true);
-    when(jobService.getJob(NAMESPACE_NAME, JOB_NAME)).thenReturn(Optional.empty());
+    when(jobService.get(NAMESPACE_NAME, JOB_NAME)).thenReturn(Optional.empty());
 
     assertThatExceptionOfType(JobNotFoundException.class)
         .isThrownBy(() -> jobResource.get(NAMESPACE_NAME, JOB_NAME))

--- a/src/test/java/marquez/service/JobServiceTest.java
+++ b/src/test/java/marquez/service/JobServiceTest.java
@@ -242,7 +242,7 @@ public class JobServiceTest {
         .thenReturn(Optional.of(JOB_ROW));
     when(jobVersionDao.findBy(JOB_VERSION_ROW.getUuid())).thenReturn(Optional.of(JOB_VERSION_ROW));
 
-    final Optional<Job> job = jobService.getJob(NAMESPACE_NAME, JOB_NAME);
+    final Optional<Job> job = jobService.get(NAMESPACE_NAME, JOB_NAME);
     assertThat(job).contains(JOB);
 
     verify(jobDao, times(1)).find(NAMESPACE_NAME.getValue(), JOB_NAME.getValue());
@@ -255,7 +255,7 @@ public class JobServiceTest {
         .thenReturn(Optional.of(JOB_ROW));
     when(jobVersionDao.findBy(JOB_VERSION_ROW.getUuid())).thenReturn(Optional.of(JOB_VERSION_ROW));
 
-    final Optional<Job> job = jobService.getByJobVersion(JOB_VERSION_ID);
+    final Optional<Job> job = jobService.getBy(JOB_VERSION_ID);
     assertThat(job).contains(JOB);
 
     verify(jobDao, times(1)).find(NAMESPACE_NAME.getValue(), JOB_NAME.getValue());


### PR DESCRIPTION
Fixes functions renamed in 2bb32a28e44b9985eab70fad663df1ec8c306e17
Signed-off-by: henneberger <git@danielhenneberger.com>