### PR TITLE
Allow override of marquez port in webpack.dev.js

### DIFF
--- a/web/webpack.dev.js
+++ b/web/webpack.dev.js
@@ -14,7 +14,7 @@ const webpackDev = {
     },
     proxy: {
       '/api': {
-        target: `http://localhost:5000/`,
+        target: `http://localhost:${process.env.MARQUEZ_PORT || 8080}/`,
         secure: false,
         logLevel: 'debug',
         headers: {

--- a/web/webpack.dev.js
+++ b/web/webpack.dev.js
@@ -14,7 +14,7 @@ const webpackDev = {
     },
     proxy: {
       '/api': {
-        target: `http://localhost:${process.env.MARQUEZ_PORT || 8080}/`,
+        target: `http://${process.env.MARQUEZ_HOST || 'localhost'}:${process.env.MARQUEZ_PORT || 8080}/`,
         secure: false,
         logLevel: 'debug',
         headers: {


### PR DESCRIPTION
This PR defaults the marquez API port to `8080` in `webpack.dev.js` and adds supports for overriding the port. For example,

```bash
$  MARQUEZ_PORT=5000 npm run dev
```