### PR TITLE
Add optional token to spark args

### DIFF
--- a/experimental/integrations/prototype-spark/marquez-spark-agent/src/main/java/marquez/spark/agent/ArgumentParser.java
+++ b/experimental/integrations/prototype-spark/marquez-spark-agent/src/main/java/marquez/spark/agent/ArgumentParser.java
@@ -20,7 +20,7 @@ public class ArgumentParser {
   private final String namespace;
   private final String jobName;
   private final String runId;
-  private final Optional<String> token;
+  private final Optional<String> apiKey;
 
   public static ArgumentParser parse(String agentArgs) {
     URI uri = URI.create(agentArgs);
@@ -34,18 +34,19 @@ public class ArgumentParser {
     String runId = get(elements, "runs", 7);
 
     List<NameValuePair> nameValuePairList = URLEncodedUtils.parse(uri, StandardCharsets.UTF_8);
-    String token = getToken(nameValuePairList);
+    String apiKey = getApiKey(nameValuePairList);
 
     log.info(
         String.format("/api/%s/namespaces/%s/jobs/%s/runs/%s", version, namespace, jobName, runId));
 
-    return new ArgumentParser(host, version, namespace, jobName, runId, Optional.ofNullable(token));
+    return new ArgumentParser(
+        host, version, namespace, jobName, runId, Optional.ofNullable(apiKey));
   }
 
-  private static String getToken(List<NameValuePair> nameValuePairList) {
-    String token;
-    if ((token = getNamedParameter(nameValuePairList, "token")) != null) {
-      return token;
+  private static String getApiKey(List<NameValuePair> nameValuePairList) {
+    String apiKey;
+    if ((apiKey = getNamedParameter(nameValuePairList, "api_key")) != null) {
+      return apiKey;
     }
     return null;
   }

--- a/experimental/integrations/prototype-spark/marquez-spark-agent/src/main/java/marquez/spark/agent/ArgumentParser.java
+++ b/experimental/integrations/prototype-spark/marquez-spark-agent/src/main/java/marquez/spark/agent/ArgumentParser.java
@@ -1,0 +1,71 @@
+package marquez.spark.agent;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.net.URLEncodedUtils;
+
+@AllArgsConstructor
+@Slf4j
+@Getter
+public class ArgumentParser {
+  private final String host;
+  private final String version;
+  private final String namespace;
+  private final String jobName;
+  private final String runId;
+  private final Optional<String> token;
+
+  public static ArgumentParser parse(String agentArgs) {
+    URI uri = URI.create(agentArgs);
+    String host = uri.getScheme() + "://" + uri.getAuthority();
+
+    String path = uri.getPath();
+    String[] elements = path.split("/");
+    String version = get(elements, "api", 1);
+    String namespace = get(elements, "namespaces", 3);
+    String jobName = get(elements, "jobs", 5);
+    String runId = get(elements, "runs", 7);
+
+    List<NameValuePair> nameValuePairList = URLEncodedUtils.parse(uri, StandardCharsets.UTF_8);
+    String token = getToken(nameValuePairList);
+
+    log.info(
+        String.format("/api/%s/namespaces/%s/jobs/%s/runs/%s", version, namespace, jobName, runId));
+
+    return new ArgumentParser(host, version, namespace, jobName, runId, Optional.ofNullable(token));
+  }
+
+  private static String getToken(List<NameValuePair> nameValuePairList) {
+    String token;
+    if ((token = getNamedParameter(nameValuePairList, "token")) != null) {
+      return token;
+    }
+    return null;
+  }
+
+  protected static String getNamedParameter(List<NameValuePair> nameValuePairList, String param) {
+    for (NameValuePair nameValuePair : nameValuePairList) {
+      if (nameValuePair.getName().equalsIgnoreCase(param)) {
+        return nameValuePair.getValue();
+      }
+    }
+    return null;
+  }
+
+  private static String get(String[] elements, String name, int index) {
+    boolean check = elements.length > index + 1 && name.equals(elements[index]);
+    if (check) {
+      return elements[index + 1];
+    } else {
+      log.warn("missing " + name + " in " + Arrays.toString(elements) + " at " + index);
+      return "default";
+    }
+  }
+}

--- a/experimental/integrations/prototype-spark/marquez-spark-agent/src/main/java/marquez/spark/agent/MarquezAgent.java
+++ b/experimental/integrations/prototype-spark/marquez-spark-agent/src/main/java/marquez/spark/agent/MarquezAgent.java
@@ -13,7 +13,7 @@ public class MarquezAgent {
   @SuppressWarnings("unused")
   public static void premain(String agentArgs, Instrumentation inst) {
     try {
-      premain(agentArgs, inst, new MarquezContext(agentArgs));
+      premain(agentArgs, inst, new MarquezContext(ArgumentParser.parse(agentArgs)));
     } catch (URISyntaxException e) {
       log.error("Could not find marquez client url", e);
     }

--- a/experimental/integrations/prototype-spark/marquez-spark-agent/src/main/java/marquez/spark/agent/MarquezContext.java
+++ b/experimental/integrations/prototype-spark/marquez-spark-agent/src/main/java/marquez/spark/agent/MarquezContext.java
@@ -18,7 +18,7 @@ public class MarquezContext {
 
   public MarquezContext(ArgumentParser argument) throws URISyntaxException {
     log.info("Init MarquezContext: " + argument);
-    this.client = OpenLineageClient.create(argument.getToken());
+    this.client = OpenLineageClient.create(argument.getApiKey());
     this.lineageURI =
         new URI(String.format("%s/api/%s/lineage", argument.getHost(), argument.getVersion()));
     this.jobNamespace = argument.getNamespace();

--- a/experimental/integrations/prototype-spark/marquez-spark-agent/src/main/java/marquez/spark/agent/MarquezContext.java
+++ b/experimental/integrations/prototype-spark/marquez-spark-agent/src/main/java/marquez/spark/agent/MarquezContext.java
@@ -2,8 +2,6 @@ package marquez.spark.agent;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.Map;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import marquez.spark.agent.client.LineageEvent;
@@ -12,43 +10,20 @@ import marquez.spark.agent.client.OpenLineageClient;
 
 @Slf4j
 public class MarquezContext {
-  private final OpenLineageClient client;
-  private final URI lineageURI;
+  @Getter private OpenLineageClient client;
+  @Getter private URI lineageURI;
   @Getter private String jobNamespace;
   @Getter private String jobName;
   @Getter private String parentRunId;
 
-  public MarquezContext(String argument) throws URISyntaxException {
+  public MarquezContext(ArgumentParser argument) throws URISyntaxException {
     log.info("Init MarquezContext: " + argument);
-    String[] elements = argument.split("\\/");
-    String version = get(elements, "api", 1);
-    if (version.equals("v1")) {
-      log.info("marquez api v1");
-    }
-    this.jobNamespace = get(elements, "namespaces", 3);
-    this.jobName = get(elements, "jobs", 5);
-    this.parentRunId = get(elements, "runs", 7);
-    log.info(
-        String.format(
-            "/api/%s/namespaces/%s/jobs/%s/runs/%s", version, jobNamespace, jobName, parentRunId));
-    Map<String, String> env = System.getenv();
-    String url = env.get("MARQUEZ_URL");
-    if (url == null || url.trim().equals("")) {
-      url = "http://localhost:5000";
-    }
-    this.lineageURI = new URI(url + "/api/v1/lineage");
-    final String apiKey = env.get("MARQUEZ_API_KEY");
-    this.client = OpenLineageClient.create(apiKey);
-  }
-
-  private String get(String[] elements, String name, int index) {
-    boolean check = elements.length > index + 1 && name.equals(elements[index]);
-    if (check) {
-      return elements[index + 1];
-    } else {
-      log.warn("missing " + name + " in " + Arrays.toString(elements) + " at " + index);
-      return "default";
-    }
+    this.client = OpenLineageClient.create(argument.getToken());
+    this.lineageURI =
+        new URI(String.format("%s/api/%s/lineage", argument.getHost(), argument.getVersion()));
+    this.jobNamespace = argument.getNamespace();
+    this.jobName = argument.getJobName();
+    this.parentRunId = argument.getRunId();
   }
 
   public void emit(LineageEvent event) {

--- a/experimental/integrations/prototype-spark/marquez-spark-agent/src/main/java/marquez/spark/agent/client/OpenLineageClient.java
+++ b/experimental/integrations/prototype-spark/marquez-spark-agent/src/main/java/marquez/spark/agent/client/OpenLineageClient.java
@@ -14,6 +14,7 @@ import com.ok2c.hc5.json.http.JsonResponseConsumers;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -36,16 +37,16 @@ import org.apache.hc.core5.util.Timeout;
 @Slf4j
 public class OpenLineageClient {
   private final CloseableHttpAsyncClient http;
-  private final String apiKey;
+  private final Optional<String> apiKey;
   @Getter protected static final ObjectMapper objectMapper = createMapper();
 
-  public OpenLineageClient(CloseableHttpAsyncClient http, String apiKey) {
+  public OpenLineageClient(CloseableHttpAsyncClient http, Optional<String> apiKey) {
     this.http = http;
     this.http.start();
     this.apiKey = apiKey;
   }
 
-  public static OpenLineageClient create(final String apiKey) {
+  public static OpenLineageClient create(final Optional<String> apiKey) {
     final CloseableHttpAsyncClient http =
         HttpAsyncClients.customHttp2()
             .setTlsStrategy(
@@ -156,8 +157,8 @@ public class OpenLineageClient {
   }
 
   private void addAuthToReqIfKeyPresent(final HttpRequest request) {
-    if (apiKey != null) {
-      request.addHeader(AUTHORIZATION, "Bearer " + apiKey);
+    if (apiKey.isPresent()) {
+      request.addHeader(AUTHORIZATION, "Bearer " + apiKey.get());
     }
   }
 

--- a/experimental/integrations/prototype-spark/marquez-spark-agent/src/test/java/marquez/spark/LibraryTest.java
+++ b/experimental/integrations/prototype-spark/marquez-spark-agent/src/test/java/marquez/spark/LibraryTest.java
@@ -36,10 +36,7 @@ public class LibraryTest {
   public static void setUp() throws Exception {
     marquezContext = mock(MarquezContext.class);
     ByteBuddyAgent.install();
-    MarquezAgent.premain(
-        "/api/v1/namespaces/ns_name/jobs/job_name/runs/ea445b5c-22eb-457a-8007-01c7c52b6e54",
-        ByteBuddyAgent.getInstrumentation(),
-        marquezContext);
+    MarquezAgent.premain("", ByteBuddyAgent.getInstrumentation(), marquezContext);
   }
 
   @Test

--- a/experimental/integrations/prototype-spark/marquez-spark-agent/src/test/java/marquez/spark/agent/MarquezContextTest.java
+++ b/experimental/integrations/prototype-spark/marquez-spark-agent/src/test/java/marquez/spark/agent/MarquezContextTest.java
@@ -1,0 +1,20 @@
+package marquez.spark.agent;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.junit.Test;
+
+public class MarquezContextTest {
+
+  @Test
+  public void testLineageUri() throws URISyntaxException {
+    MarquezContext ctx =
+        new MarquezContext(
+            ArgumentParser.parse(
+                "https://localhost:5000/api/v1/namespaces/ns_name/jobs/job_name/runs/"
+                    + "ea445b5c-22eb-457a-8007-01c7c52b6e54?token=abc"));
+    assertEquals(URI.create("https://localhost:5000/api/v1/lineage"), ctx.getLineageURI());
+  }
+}

--- a/experimental/integrations/prototype-spark/marquez-spark-agent/src/test/java/marquez/spark/agent/MarquezContextTest.java
+++ b/experimental/integrations/prototype-spark/marquez-spark-agent/src/test/java/marquez/spark/agent/MarquezContextTest.java
@@ -14,7 +14,7 @@ public class MarquezContextTest {
         new MarquezContext(
             ArgumentParser.parse(
                 "https://localhost:5000/api/v1/namespaces/ns_name/jobs/job_name/runs/"
-                    + "ea445b5c-22eb-457a-8007-01c7c52b6e54?token=abc"));
+                    + "ea445b5c-22eb-457a-8007-01c7c52b6e54?api_key=abc"));
     assertEquals(URI.create("https://localhost:5000/api/v1/lineage"), ctx.getLineageURI());
   }
 }

--- a/experimental/integrations/prototype-spark/marquez-spark-agent/src/test/java/marquez/spark/agent/PassingArgumentParserTest.java
+++ b/experimental/integrations/prototype-spark/marquez-spark-agent/src/test/java/marquez/spark/agent/PassingArgumentParserTest.java
@@ -1,0 +1,74 @@
+package marquez.spark.agent;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class PassingArgumentParserTest {
+  @Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    List<Object[]> pass = new ArrayList<>();
+    pass.add(
+        new Object[] {
+          "http://localhost:5000/api/v1/namespaces/ns_name/jobs/job_name/runs/ea445b5c-22eb-457a-8007-01c7c52b6e54?token=abc",
+          "http://localhost:5000",
+          "v1",
+          "ns_name",
+          "job_name",
+          "ea445b5c-22eb-457a-8007-01c7c52b6e54",
+          Optional.of("abc")
+        });
+    pass.add(
+        new Object[] {
+          "http://localhost:5000/api/v1/namespaces/ns_name/jobs/job_name/runs/ea445b5c-22eb-457a-8007-01c7c52b6e54",
+          "http://localhost:5000",
+          "v1",
+          "ns_name",
+          "job_name",
+          "ea445b5c-22eb-457a-8007-01c7c52b6e54",
+          Optional.empty()
+        });
+    return pass;
+  }
+
+  @Parameter(value = 0)
+  public String input;
+
+  @Parameter(value = 1)
+  public String host;
+
+  @Parameter(value = 2)
+  public String version;
+
+  @Parameter(value = 3)
+  public String namespace;
+
+  @Parameter(value = 4)
+  public String jobName;
+
+  @Parameter(value = 5)
+  public String runId;
+
+  @Parameter(value = 6)
+  public Optional<String> token;
+
+  @Test
+  public void testArgument() {
+    ArgumentParser parser = ArgumentParser.parse(input);
+    assertEquals(host, parser.getHost());
+    assertEquals(version, parser.getVersion());
+    assertEquals(namespace, parser.getNamespace());
+    assertEquals(jobName, parser.getJobName());
+    assertEquals(runId, parser.getRunId());
+    assertEquals(token, parser.getToken());
+  }
+}

--- a/experimental/integrations/prototype-spark/marquez-spark-agent/src/test/java/marquez/spark/agent/PassingArgumentParserTest.java
+++ b/experimental/integrations/prototype-spark/marquez-spark-agent/src/test/java/marquez/spark/agent/PassingArgumentParserTest.java
@@ -19,7 +19,7 @@ public class PassingArgumentParserTest {
     List<Object[]> pass = new ArrayList<>();
     pass.add(
         new Object[] {
-          "http://localhost:5000/api/v1/namespaces/ns_name/jobs/job_name/runs/ea445b5c-22eb-457a-8007-01c7c52b6e54?token=abc",
+          "http://localhost:5000/api/v1/namespaces/ns_name/jobs/job_name/runs/ea445b5c-22eb-457a-8007-01c7c52b6e54?api_key=abc",
           "http://localhost:5000",
           "v1",
           "ns_name",
@@ -59,7 +59,7 @@ public class PassingArgumentParserTest {
   public String runId;
 
   @Parameter(value = 6)
-  public Optional<String> token;
+  public Optional<String> apiKey;
 
   @Test
   public void testArgument() {
@@ -69,6 +69,6 @@ public class PassingArgumentParserTest {
     assertEquals(namespace, parser.getNamespace());
     assertEquals(jobName, parser.getJobName());
     assertEquals(runId, parser.getRunId());
-    assertEquals(token, parser.getToken());
+    assertEquals(apiKey, parser.getApiKey());
   }
 }


### PR DESCRIPTION
Airflow Dataproc operator doesn't have access to env variables so this removes them completely. Token is pass as a pseudo uri in the form of 'http://localhost:5000/api/v1/namespaces/ns_name/jobs/job_name/runs/ea445b5c-22eb-457a-8007-01c7c52b6e54?token=abc`.

The spark docs can be updated after that PR lands.

Signed-off-by: henneberger <git@danielhenneberger.com>