### PR TITLE
Use remote.origin.url on airflow integration test

### DIFF
--- a/integrations/airflow/tests/integration/docker/up.sh
+++ b/integrations/airflow/tests/integration/docker/up.sh
@@ -20,7 +20,8 @@ set -e
 project_root=$(git rev-parse --show-toplevel)
 cd "${project_root}"/integrations/airflow/tests/integration
 
-GIT_URL=$(git config --get remote.origin.url)
+GIT_URL=$(git config --get remote.origin.url \
+		          | sed 's|git@github.com:|https://github.com/|')
 GIT_REV=$(git rev-parse HEAD)
 MARQUEZ_AIRFLOW_LIB_WITH_REV="git+${GIT_URL}@${GIT_REV}#egg=marquez_airflow&subdirectory=integrations/airflow"
 

--- a/integrations/airflow/tests/integration/docker/up.sh
+++ b/integrations/airflow/tests/integration/docker/up.sh
@@ -20,8 +20,9 @@ set -e
 project_root=$(git rev-parse --show-toplevel)
 cd "${project_root}"/integrations/airflow/tests/integration
 
-REV=$(git rev-parse HEAD)
-MARQUEZ_AIRFLOW_LIB_WITH_REV="git+git://github.com/MarquezProject/marquez.git@${REV}#egg=marquez_airflow&subdirectory=integrations/airflow"
+GIT_URL=$(git config --get remote.origin.url)
+GIT_REV=$(git rev-parse HEAD)
+MARQUEZ_AIRFLOW_LIB_WITH_REV="git+${GIT_URL}@${GIT_REV}#egg=marquez_airflow&subdirectory=integrations/airflow"
 
 # Add revision to requirements.txt
 echo "${MARQUEZ_AIRFLOW_LIB_WITH_REV}" > requirements.txt


### PR DESCRIPTION
This PR (_attempts_) to fix the  failed integration tests for forked PRs. The main issue is that, for forks, the commit is not associated with the marquez repo, see [pull/894](https://github.com/MarquezProject/marquez/commit/459872eb94ee984a11eac15388e70b4e9785cf38), which causes the `git checkout` cmd to fail when installing a lib from a git url, see the failing CI job [656](https://app.circleci.com/pipelines/github/MarquezProject/marquez/656/workflows/3c376dbd-3661-467c-b2c1-9353ee809c06/jobs/5779)

We now dynamically build the url to point to `remote.origin.url` and using the rev for that repo.