### PR TITLE
Pin postgresql to 42.2.6

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     compile "org.jdbi:jdbi3-sqlobject:${jdbi3Version}"
     compile 'com.google.guava:guava:30.1-jre'
     compile 'org.flywaydb:flyway-core:6.5.7'
-    compile 'org.postgresql:postgresql:42.2.19'
+    compile 'org.postgresql:postgresql:42.2.6'
     compile 'com.graphql-java:graphql-java:16.2'
     compile 'com.graphql-java-kickstart:graphql-java-servlet:11.1.0'
     compileOnly "org.projectlombok:lombok:${lombokVersion}"


### PR DESCRIPTION
This PR pins `postgresql` to `42.2.6` to fix the following tests:

```
marquez.db.ColumnsTest

  Test testPgIntervalOrThrow_pgInterval FAILED

  org.junit.ComparisonFailure: expected:<...s 0 hours 5 mins 5.0[0] secs"> but was:<...s 0 hours 5 mins 5.0[] secs">
      at marquez.db.ColumnsTest.testPgIntervalOrThrow_pgInterval(ColumnsTest.java:179)
```