### PR TITLE
Always enable graphql in marquez.dev.yml

### DIFF
--- a/marquez.dev.yml
+++ b/marquez.dev.yml
@@ -15,7 +15,7 @@ db:
 migrateOnStartup: true
 
 graphql:
-  enabled: ${GRAPHQL_ENABLED:-true}
+  enabled: true
 
 logging:
   level: INFO


### PR DESCRIPTION
This PR updates `marquez.dev.yml` to always enable graphql while using the `dev` config. 