### PR TITLE
helm chart: fix configmap name mismatch

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
       volumes:
         - name: marquez-volume
           configMap:
-            name: marquez-config
+            name: {{ template "marquez.fullname" . }}-config
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Current helm chart will only deploy correctly if the release name is exactly `marquez`. 

For example, if release is `marquez-test` the `ConfigMap` will be named `marquez-test-config`  and the `Deployment` still looks for `marquez-config`. 