### PR TITLE
helm chart: fix replicaCount

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.marquez.replicaCount }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "marquez.name" . }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,13 +12,6 @@ marquez:
     password: macondo
   migrateOnStartup: true
 
-web:
-  replicaCount: 1
-  image:
-    repository: marquezproject/marquez-web
-    tag: 0.5.3
-    pullPolicy: IfNotPresent
-
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
This fixes two issues:
* `values.yaml` contains an unused set of values `web:` . This is misleading. 
* The default `marquez.replicaCount: 1` was ignored (not used in deployment.yaml)