### PR TITLE
helm: Add web deployment

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: marquez
-version: 0.1.0
+version: 0.1.1

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,20 +1,21 @@
 1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
+{{- if .Values.marquez.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range $.Values.ingress.paths }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ . }}
   {{- end }}
 {{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
+{{- else if contains "NodePort" .Values.marquez.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "marquez.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if contains "LoadBalancer" .Values.marquez.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ include "marquez.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "marquez.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
+  echo http://$SERVICE_IP:{{ .Values.marquez.service.port }}
+  
+{{- else if contains "ClusterIP" .Values.marquez.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "marquez.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:80

--- a/chart/templates/deployment-api.yaml
+++ b/chart/templates/deployment-api.yaml
@@ -1,23 +1,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "marquez.fullname" . }}
+  name: {{ include "marquez.fullname" . }}-api
   labels:
     app.kubernetes.io/name: {{ include "marquez.name" . }}
     helm.sh/chart: {{ include "marquez.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.marquez.replicaCount }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "marquez.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      component: api
   template:
     metadata:
       labels:
         app.kubernetes.io/name: {{ include "marquez.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        component: api
     spec:
       containers:
         - name: {{ .Chart.Name }}
@@ -29,10 +31,10 @@ spec:
               subPath: config.yml
           ports:
             - name: http
-              containerPort: 5000 
+              containerPort: {{ .Values.marquez.port }} 
               protocol: TCP
             - name: http-admin
-              containerPort: 5001
+              containerPort: {{ .Values.marquez.adminPort }} 
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -66,7 +68,7 @@ spec:
       volumes:
         - name: marquez-volume
           configMap:
-            name: marquez-config
+            name: {{ template "marquez.fullname" . }}-config
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -79,4 +81,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-   

--- a/chart/templates/deployment-web.yaml
+++ b/chart/templates/deployment-web.yaml
@@ -1,0 +1,62 @@
+{{ if .Values.web.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "marquez.fullname" . }}-web
+  labels:
+    app.kubernetes.io/name: {{ include "marquez.name" . }}
+    helm.sh/chart: {{ include "marquez.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.web.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "marquez.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      component: web
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "marquez.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        component: web
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+          env:
+            - name: MARQUEZ_PORT
+              value: {{ .Values.marquez.service.port | quote }}
+            - name: MARQUEZ_HOST
+              value: {{ include "marquez.fullname" . }}-api
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+   
+{{ end }}

--- a/chart/templates/ingress-api.yaml
+++ b/chart/templates/ingress-api.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.marquez.ingress.enabled -}}
+{{- $fullName := include "marquez.fullname" . -}}
+{{- $ingressPaths := .Values.marquez.ingress.paths -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-api
+  labels:
+    app.kubernetes.io/name: {{ include "marquez.name" . }}
+    helm.sh/chart: {{ include "marquez.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.marquez.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.marquez.ingress.tls }}
+  tls:
+  {{- range .Values.marquez.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.marquez.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+	{{- range $ingressPaths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}-api
+              servicePort: http
+	{{- end }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/ingress-web.yaml
+++ b/chart/templates/ingress-web.yaml
@@ -1,23 +1,23 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.web.ingress.enabled -}}
 {{- $fullName := include "marquez.fullname" . -}}
-{{- $ingressPaths := .Values.ingress.paths -}}
+{{- $ingressPaths := .Values.web.ingress.paths -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ $fullName }}-web
   labels:
     app.kubernetes.io/name: {{ include "marquez.name" . }}
     helm.sh/chart: {{ include "marquez.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{- with .Values.ingress.annotations }}
+  {{- with .Values.web.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
+{{- if .Values.web.ingress.tls }}
   tls:
-  {{- range .Values.ingress.tls }}
+  {{- range .Values.web.ingress.tls }}
     - hosts:
       {{- range .hosts }}
         - {{ . | quote }}
@@ -26,14 +26,14 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+  {{- range .Values.web.ingress.hosts }}
     - host: {{ . | quote }}
       http:
         paths:
 	{{- range $ingressPaths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}
+              serviceName: {{ $fullName }}-web
               servicePort: http
 	{{- end }}
   {{- end }}

--- a/chart/templates/service-api.yaml
+++ b/chart/templates/service-api.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "marquez.fullname" . }}-api
+  labels:
+    app.kubernetes.io/name: {{ include "marquez.name" . }}
+    helm.sh/chart: {{ include "marquez.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.marquez.service.type }}
+  ports:
+    - port: {{ .Values.marquez.service.port }}
+      targetPort: {{ .Values.marquez.port}}
+      protocol: TCP
+      name: http
+ 
+  selector:
+    app.kubernetes.io/name: {{ include "marquez.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    component: api

--- a/chart/templates/service-web.yaml
+++ b/chart/templates/service-web.yaml
@@ -1,20 +1,23 @@
+{{- if .Values.web.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "marquez.fullname" . }}
+  name: {{ include "marquez.fullname" . }}-web
   labels:
     app.kubernetes.io/name: {{ include "marquez.name" . }}
     helm.sh/chart: {{ include "marquez.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.web.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
+    - port: {{ .Values.web.service.port }}
+      targetPort: 3000
       protocol: TCP
       name: http
  
   selector:
     app.kubernetes.io/name: {{ include "marquez.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    component: web
+{{- end }}

--- a/chart/templates/tests/test-connection.yaml
+++ b/chart/templates/tests/test-connection.yaml
@@ -14,5 +14,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ include "marquez.fullname" . }}:{{ .Values.service.port }}']
+      args:  ['{{ include "marquez.fullname" . }}:{{ .Values.marquez.service.port }}']
   restartPolicy: Never

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,6 +4,8 @@ marquez:
     repository: marquezproject/marquez
     tag: 0.12.0
     pullPolicy: IfNotPresent
+  port: 5000
+  adminPort: 5001
   db:
     host: localhost
     port: 5432
@@ -11,30 +13,40 @@ marquez:
     user: buendia
     password: macondo
   migrateOnStartup: true
+  service:
+    type: ClusterIP
+    port: 80
+  ingress:
+    enabled: false
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    paths: ["/*"]
+    hosts:
+      - chart-example.local
+    tls: []
+
 
 web:
+  enabled: true
   replicaCount: 1
   image:
     repository: marquezproject/marquez-web
     tag: 0.5.3
     pullPolicy: IfNotPresent
-
-service:
-  type: ClusterIP
-  port: 80
-
-ingress:
-  enabled: false
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
+  service:
+    type: ClusterIP
+    port: 80
+  ingress:
+    enabled: false
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  paths: []
-  hosts:
-    - chart-example.local
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+    paths: ["/*"]
+    hosts:
+      - chart-example.local
+    tls: []
+
 
 resources: {}
 nodeSelector: {}


### PR DESCRIPTION
This PR : 
* add the web UI ( deployment, service and ingress) with `web.enabled=true`
* fixes issues with missing environment variables in the api container which leads to api starting in random ports 
* wrong configmap name 
* wrong replicaCount

closes: #1016 
closes: #1015