### PR TITLE
Don't set run state update time to state transition time

### DIFF
--- a/api/src/main/java/marquez/db/RunDao.java
+++ b/api/src/main/java/marquez/db/RunDao.java
@@ -104,7 +104,7 @@ public interface RunDao extends SqlObject {
           + "SET updated_at = :updatedAt, "
           + "    current_run_state = :currentRunState "
           + "WHERE uuid = :rowUuid")
-  void updateRunState(UUID rowUuid, Instant updatedAt, String currentRunState);
+  void updateCurrentRunState(UUID rowUuid, Instant updatedAt, String currentRunState);
 
   @SqlUpdate(
       "UPDATE runs "

--- a/api/src/main/java/marquez/db/RunStateDao.java
+++ b/api/src/main/java/marquez/db/RunStateDao.java
@@ -52,7 +52,7 @@ public interface RunStateDao extends SqlObject {
                 .execute());
     // State transition
     final Instant updateAt = row.getTransitionedAt();
-    createRunDao().updateRunState(row.getRunUuid(), updateAt, row.getState());
+    createRunDao().updateRunState(row.getRunUuid(), Instant.now(), row.getState());
     if (starting) {
       createRunDao().updateStartState(row.getRunUuid(), updateAt, row.getUuid());
     }

--- a/api/src/main/java/marquez/db/RunStateDao.java
+++ b/api/src/main/java/marquez/db/RunStateDao.java
@@ -52,7 +52,6 @@ public interface RunStateDao extends SqlObject {
                 .execute());
     // State transition
     final Instant updateAt = row.getTransitionedAt();
-    createRunDao().updateRunState(row.getRunUuid(), Instant.now(), row.getState());
     if (starting) {
       createRunDao().updateStartState(row.getRunUuid(), updateAt, row.getUuid());
     }
@@ -63,6 +62,8 @@ public interface RunStateDao extends SqlObject {
     if (complete && outputVersionUuids != null && outputVersionUuids.size() > 0) {
       createDatasetDao().updateLastModifedAt(outputVersionUuids, updateAt);
     }
+    // Update current run with new state
+    createRunDao().updateCurrentRunState(row.getRunUuid(), Instant.now(), row.getState());
   }
 
   @SqlQuery("SELECT * FROM run_states WHERE uuid = :rowUuid")


### PR DESCRIPTION
This PR fixes the timestamp used to set the `updatedAt` column for the table `runs`. It now uses the current time. Marquez provides the option to override the state transition time for a run by the caller. This transition time is also used to also set `runs.updatedAt`, which is incorrect. 