### PR TITLE
Remove field unioning behavior during dataset field creation #1022

### DIFF
--- a/api/src/main/java/marquez/api/DatasetResource.java
+++ b/api/src/main/java/marquez/api/DatasetResource.java
@@ -83,8 +83,7 @@ public class DatasetResource {
   public Response createOrUpdate(
       @PathParam("namespace") NamespaceName namespaceName,
       @PathParam("dataset") DatasetName datasetName,
-      @Valid DatasetMeta datasetMeta)
-      throws MarquezServiceException {
+      @Valid DatasetMeta datasetMeta) {
     throwIfNotExists(namespaceName);
     datasetMeta.getRunId().ifPresent(this::throwIfNotExists);
 

--- a/api/src/main/java/marquez/db/DatasetDao.java
+++ b/api/src/main/java/marquez/db/DatasetDao.java
@@ -14,28 +14,38 @@
 
 package marquez.db;
 
+import static marquez.db.OpenLineageDao.DEFAULT_NAMESPACE_OWNER;
 import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.NULL_STRING;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.Value;
 import marquez.common.models.DatasetType;
+import marquez.common.models.TagName;
 import marquez.db.mappers.DatasetRowMapper;
 import marquez.db.mappers.ExtendedDatasetRowMapper;
 import marquez.db.models.DatasetRow;
 import marquez.db.models.ExtendedDatasetRow;
-import org.jdbi.v3.sqlobject.SqlObject;
+import marquez.db.models.NamespaceRow;
+import marquez.db.models.SourceRow;
+import marquez.db.models.TagRow;
+import marquez.service.DatasetService;
+import marquez.service.models.DatasetMeta;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.customizer.BindList;
+import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 
 @RegisterRowMapper(ExtendedDatasetRowMapper.class)
 @RegisterRowMapper(DatasetRowMapper.class)
-public interface DatasetDao extends SqlObject {
+public interface DatasetDao extends MarquezDao {
   @Transaction
   default void insert(DatasetRow row) {
     withHandle(
@@ -82,6 +92,12 @@ public interface DatasetDao extends SqlObject {
           + "VALUES (:rowUuid, :tagUuid, :taggedAt) "
           + "ON CONFLICT DO NOTHING")
   void updateTags(UUID rowUuid, UUID tagUuid, Instant taggedAt);
+
+  @SqlBatch(
+      "INSERT INTO datasets_tag_mapping (dataset_uuid, tag_uuid, tagged_at) "
+          + "VALUES (:rowUuid, :tagUuid, :taggedAt) "
+          + "ON CONFLICT DO NOTHING")
+  void updateTagMapping(@BindBean List<DatasetTagMapping> datasetTagMappings);
 
   @SqlUpdate(
       "UPDATE datasets "
@@ -186,4 +202,54 @@ public interface DatasetDao extends SqlObject {
       String name,
       String physicalName,
       String description);
+
+  @Transaction
+  default void upsertDatasetMeta(
+      String namespaceName, String datasetName, DatasetMeta datasetMeta) {
+    Instant now = Instant.now();
+    NamespaceRow namespaceRow =
+        createNamespaceDao().upsert(UUID.randomUUID(), now, namespaceName, DEFAULT_NAMESPACE_OWNER);
+    SourceRow sourceRow =
+        createSourceDao()
+            .upsertOrDefault(
+                UUID.randomUUID(), "POSTGRES", now, datasetMeta.getSourceName().getValue(), "");
+    UUID newDatasetUuid = UUID.randomUUID();
+    DatasetRow datasetRow =
+        upsert(
+            newDatasetUuid,
+            datasetMeta.getType(),
+            now,
+            namespaceRow.getUuid(),
+            sourceRow.getUuid(),
+            datasetName,
+            datasetMeta.getPhysicalName().getValue(),
+            datasetMeta.getDescription().orElse(null));
+    updateDatasetMetric(
+        namespaceName, datasetMeta.getType().toString(), newDatasetUuid, datasetRow.getUuid());
+
+    TagDao tagDao = createTagDao();
+    List<DatasetTagMapping> datasetTagMappings = new ArrayList<>();
+    for (TagName tagName : datasetMeta.getTags()) {
+      TagRow tag = tagDao.upsert(UUID.randomUUID(), now, tagName.getValue());
+      datasetTagMappings.add(new DatasetTagMapping(datasetRow.getUuid(), tag.getUuid(), now));
+    }
+    updateTagMapping(datasetTagMappings);
+
+    createDatasetVersionDao()
+        .upsertDatasetVersion(datasetRow.getUuid(), now, namespaceName, datasetName, datasetMeta);
+  }
+
+  default void updateDatasetMetric(
+      String namespaceName, String type, UUID newDatasetUuid, UUID datasetUuid) {
+    if (newDatasetUuid != datasetUuid) {
+      DatasetService.datasets.labels(namespaceName, type).inc();
+    }
+  }
+
+  @Value
+  class DatasetTagMapping {
+    UUID rowUuid;
+    UUID tagUuid;
+    Instant taggedAt;
+  }
 }

--- a/api/src/main/java/marquez/db/DatasetVersionDao.java
+++ b/api/src/main/java/marquez/db/DatasetVersionDao.java
@@ -15,64 +15,108 @@
 package marquez.db;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import lombok.NonNull;
+import marquez.common.models.DatasetName;
 import marquez.common.models.DatasetType;
+import marquez.common.models.Field;
+import marquez.common.models.NamespaceName;
+import marquez.common.models.RunId;
+import marquez.common.models.TagName;
+import marquez.common.models.Version;
+import marquez.db.DatasetFieldDao.DatasetFieldMapping;
+import marquez.db.DatasetFieldDao.DatasetFieldTag;
 import marquez.db.mappers.DatasetVersionRowMapper;
 import marquez.db.mappers.ExtendedDatasetVersionRowMapper;
 import marquez.db.models.DatasetFieldRow;
 import marquez.db.models.DatasetVersionRow;
 import marquez.db.models.ExtendedDatasetVersionRow;
-import marquez.db.models.StreamVersionRow;
-import org.jdbi.v3.sqlobject.CreateSqlObject;
+import marquez.db.models.TagRow;
+import marquez.service.DatasetService;
+import marquez.service.models.DatasetMeta;
+import marquez.service.models.StreamMeta;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
-import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
-import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 
 @RegisterRowMapper(DatasetVersionRowMapper.class)
 @RegisterRowMapper(ExtendedDatasetVersionRowMapper.class)
-public interface DatasetVersionDao {
-  @CreateSqlObject
-  DatasetDao createDatasetDao();
-
-  @CreateSqlObject
-  DatasetFieldDao createDatasetFieldDao();
-
-  @CreateSqlObject
-  StreamVersionDao createStreamVersionDao();
+public interface DatasetVersionDao extends MarquezDao {
 
   @Transaction
-  default void insertWith(DatasetVersionRow row, List<DatasetFieldRow> fieldRows) {
-    // Fields
-    createDatasetFieldDao().insertAll(fieldRows);
-    insert(row);
-    // Version
-    if (row instanceof StreamVersionRow) {
-      createStreamVersionDao().insert((StreamVersionRow) row);
+  default void upsertDatasetVersion(
+      UUID datasetUuid,
+      Instant now,
+      String namespaceName,
+      String datasetName,
+      DatasetMeta datasetMeta) {
+    TagDao tagDao = createTagDao();
+    DatasetFieldDao datasetFieldDao = createDatasetFieldDao();
+
+    final Version version =
+        datasetMeta.version(NamespaceName.of(namespaceName), DatasetName.of(datasetName));
+    UUID newDatasetVersionUuid = UUID.randomUUID();
+    DatasetVersionRow datasetVersionRow =
+        upsert(
+            newDatasetVersionUuid,
+            now,
+            datasetUuid,
+            version.getValue(),
+            datasetMeta.getRunId().map(RunId::getValue).orElse(null));
+    updateDatasetVersionMetric(
+        namespaceName,
+        datasetMeta.getType().toString(),
+        datasetName,
+        newDatasetVersionUuid,
+        datasetVersionRow.getUuid());
+
+    if (datasetMeta instanceof StreamMeta) {
+      createStreamVersionDao()
+          .insert(
+              datasetVersionRow.getUuid(),
+              ((StreamMeta) datasetMeta).getSchemaLocation().toString());
     }
-    row.getFieldUuids().forEach(fieldUuid -> updateFields(row.getUuid(), fieldUuid));
-    // Current
-    final Instant updatedAt = row.getCreatedAt();
-    createDatasetDao().updateVersion(row.getDatasetUuid(), updatedAt, row.getUuid());
+
+    List<DatasetFieldMapping> datasetFieldMappings = new ArrayList<>();
+    List<DatasetFieldTag> datasetFieldTag = new ArrayList<>();
+
+    for (Field field : datasetMeta.getFields()) {
+      DatasetFieldRow datasetFieldRow =
+          datasetFieldDao.upsert(
+              UUID.randomUUID(),
+              now,
+              field.getName().getValue(),
+              field.getType().name(),
+              field.getDescription().orElse(null),
+              datasetUuid);
+      for (TagName tagName : field.getTags()) {
+        TagRow tag = tagDao.upsert(UUID.randomUUID(), now, tagName.getValue());
+        datasetFieldTag.add(new DatasetFieldTag(datasetFieldRow.getUuid(), tag.getUuid(), now));
+      }
+      datasetFieldMappings.add(
+          new DatasetFieldMapping(datasetVersionRow.getUuid(), datasetFieldRow.getUuid()));
+    }
+
+    datasetFieldDao.updateFieldMapping(datasetFieldMappings);
+    datasetFieldDao.updateTags(datasetFieldTag);
+
+    createDatasetDao().updateVersion(datasetUuid, now, datasetVersionRow.getUuid());
   }
 
-  @SqlUpdate(
-      "INSERT INTO dataset_versions (uuid, created_at, dataset_uuid, version, run_uuid) "
-          + "VALUES (:uuid, :createdAt, :datasetUuid, :version, :runUuid)")
-  void insert(@BindBean DatasetVersionRow row);
-
-  @SqlQuery("SELECT EXISTS (SELECT 1 FROM dataset_versions WHERE version = :version)")
-  boolean exists(UUID version);
-
-  @SqlUpdate(
-      "INSERT INTO dataset_versions_field_mapping (dataset_version_uuid, dataset_field_uuid) "
-          + "VALUES (:datasetVersionUuid, :datasetFieldUuid)")
-  void updateFields(UUID datasetVersionUuid, UUID datasetFieldUuid);
+  default void updateDatasetVersionMetric(
+      String namespaceName,
+      String type,
+      String datasetName,
+      UUID newDatasetVersionUuid,
+      UUID datasetVersionUuid) {
+    if (newDatasetVersionUuid != datasetVersionUuid) {
+      DatasetService.versions.labels(namespaceName, type, datasetName).inc();
+    }
+  }
 
   String SELECT =
       "SELECT dv.*, "
@@ -93,9 +137,6 @@ public interface DatasetVersionDao {
   @SqlQuery(SELECT + "WHERE uuid = :uuid")
   Optional<DatasetVersionRow> findBy(UUID uuid);
 
-  @SqlQuery(SELECT + "WHERE uuid = :uuid")
-  Optional<DatasetVersionRow> findAllBy(UUID uuid);
-
   @SqlQuery(
       SELECT
           + "INNER JOIN datasets AS d ON d.uuid = dv.dataset_uuid AND d.current_version_uuid = dv.uuid "
@@ -115,9 +156,6 @@ public interface DatasetVersionDao {
         return findBy(uuid);
     }
   }
-
-  @SqlQuery("SELECT COUNT(*) FROM dataset_versions")
-  int count();
 
   /**
    * returns all Dataset Versions created by this run id

--- a/api/src/main/java/marquez/db/MarquezDao.java
+++ b/api/src/main/java/marquez/db/MarquezDao.java
@@ -39,4 +39,7 @@ public interface MarquezDao extends SqlObject {
 
   @CreateSqlObject
   TagDao createTagDao();
+
+  @CreateSqlObject
+  StreamVersionDao createStreamVersionDao();
 }

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -304,7 +304,9 @@ public interface OpenLineageDao extends MarquezDao {
               ds.getFacets().getDataSource().getName(),
               getUrlOrPlaceholder(ds.getFacets().getDataSource().getUri()));
     } else {
-      source = sourceDao.upsert(UUID.randomUUID(), getSourceType(ds), now, DEFAULT_SOURCE_NAME, "");
+      source =
+          sourceDao.upsertOrDefault(
+              UUID.randomUUID(), getSourceType(ds), now, DEFAULT_SOURCE_NAME, "");
     }
 
     String dsDescription = null;

--- a/api/src/main/java/marquez/db/SourceDao.java
+++ b/api/src/main/java/marquez/db/SourceDao.java
@@ -83,4 +83,24 @@ public interface SourceDao {
           + "connection_url = EXCLUDED.connection_url "
           + "RETURNING *")
   SourceRow upsert(UUID uuid, String type, Instant now, String name, String connectionUrl);
+
+  @SqlQuery(
+      "INSERT INTO sources ("
+          + "uuid, "
+          + "type, "
+          + "created_at, "
+          + "updated_at, "
+          + "name, "
+          + "connection_url "
+          + ") VALUES ("
+          + ":uuid, "
+          + ":defaultType, "
+          + ":now, "
+          + ":now, "
+          + ":defaultName, "
+          + ":defaultConnectionUrl"
+          + ") ON CONFLICT(name) DO UPDATE SET updated_at = EXCLUDED.updated_at "
+          + "RETURNING *")
+  SourceRow upsertOrDefault(
+      UUID uuid, String defaultType, Instant now, String defaultName, String defaultConnectionUrl);
 }

--- a/api/src/main/java/marquez/db/StreamVersionDao.java
+++ b/api/src/main/java/marquez/db/StreamVersionDao.java
@@ -19,7 +19,6 @@ import java.util.UUID;
 import marquez.db.mappers.StreamVersionRowMapper;
 import marquez.db.models.StreamVersionRow;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
-import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
@@ -27,8 +26,8 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 public interface StreamVersionDao {
   @SqlUpdate(
       "INSERT INTO stream_versions (dataset_version_uuid, schema_location) "
-          + "VALUES (:uuid, :schemaLocation)")
-  void insert(@BindBean StreamVersionRow row);
+          + "VALUES (:datasetVersionUuid, :schemaLocation)")
+  void insert(UUID datasetVersionUuid, String schemaLocation);
 
   @SqlQuery(
       "SELECT dv.*, sv.*, "

--- a/api/src/main/java/marquez/db/TagDao.java
+++ b/api/src/main/java/marquez/db/TagDao.java
@@ -16,6 +16,7 @@ package marquez.db;
 
 import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.NULL_STRING;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -33,6 +34,13 @@ public interface TagDao {
       "INSERT INTO tags (uuid, created_at, updated_at, name, description) "
           + "VALUES (:uuid, :createdAt, :updatedAt, :name, :description)")
   void insert(@BindBean TagRow row);
+
+  @SqlQuery(
+      "INSERT INTO tags (uuid, created_at, updated_at, name) "
+          + "VALUES (:uuid, :updatedAt, :updatedAt, :name) "
+          + "ON CONFLICT(name) DO UPDATE SET updated_at = EXCLUDED.updated_at "
+          + "RETURNING *")
+  TagRow upsert(UUID uuid, Instant updatedAt, String name);
 
   @SqlQuery("SELECT EXISTS (SELECT 1 FROM tags WHERE name = :name)")
   boolean exists(String name);

--- a/api/src/main/java/marquez/service/DatasetService.java
+++ b/api/src/main/java/marquez/service/DatasetService.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -48,12 +47,9 @@ import marquez.db.NamespaceDao;
 import marquez.db.SourceDao;
 import marquez.db.TagDao;
 import marquez.db.models.DatasetFieldRow;
-import marquez.db.models.DatasetRow;
 import marquez.db.models.DatasetVersionRow;
 import marquez.db.models.ExtendedDatasetRow;
 import marquez.db.models.ExtendedDatasetVersionRow;
-import marquez.db.models.NamespaceRow;
-import marquez.db.models.SourceRow;
 import marquez.db.models.StreamVersionRow;
 import marquez.db.models.TagRow;
 import marquez.service.exceptions.MarquezServiceException;
@@ -66,14 +62,14 @@ import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 
 @Slf4j
 public class DatasetService {
-  private static final Counter datasets =
+  public static final Counter datasets =
       Counter.build()
           .namespace("marquez")
           .name("dataset_total")
           .labelNames("namespace_name", "dataset_type")
           .help("Total number of datasets.")
           .register();
-  private static final Counter versions =
+  public static final Counter versions =
       Counter.build()
           .namespace("marquez")
           .name("dataset_versions_total")
@@ -121,113 +117,16 @@ public class DatasetService {
   public Dataset createOrUpdate(
       @NonNull NamespaceName namespaceName,
       @NonNull DatasetName datasetName,
-      @NonNull DatasetMeta datasetMeta)
-      throws MarquezServiceException {
-    try {
-      if (!exists(namespaceName, datasetName)) {
-        log.info(
-            "No dataset with name '{}' for namespace '{}' found, creating...",
-            datasetName.getValue(),
-            namespaceName.getValue());
-        final NamespaceRow namespaceRow = namespaceDao.findBy(namespaceName.getValue()).get();
-        final SourceRow sourceRow = sourceDao.findBy(datasetMeta.getSourceName().getValue()).get();
-        final List<UUID> tagUuids =
-            tagDao
-                .findAllIn(
-                    toArray(
-                        datasetMeta.getTags().stream()
-                            .map(TagName::getValue)
-                            .collect(toImmutableList()),
-                        String.class))
-                .stream()
-                .map(TagRow::getUuid)
-                .collect(toImmutableList());
-        final DatasetRow newDatasetRow =
-            Mapper.toDatasetRow(
-                namespaceRow.getUuid(), sourceRow.getUuid(), datasetName, datasetMeta, tagUuids);
-        datasetDao.insert(newDatasetRow);
-        log.info(
-            "Successfully created dataset '{}' for namespace '{}' with meta: {}",
-            datasetName.getValue(),
-            namespaceName.getValue(),
-            datasetMeta);
-        datasets.labels(namespaceName.getValue(), datasetMeta.getType().toString()).inc();
-      }
-      final Version version = datasetMeta.version(namespaceName, datasetName);
-      if (!datasetVersionDao.exists(version.getValue())) {
-        log.info(
-            "Creating version '{}' for dataset '{}'...",
-            version.getValue(),
-            datasetName.getValue());
-        final ExtendedDatasetRow datasetRow =
-            datasetDao.find(namespaceName.getValue(), datasetName.getValue()).get();
-        final List<DatasetFieldRow> fieldRows = datasetFieldDao.findAll(datasetRow.getUuid());
-        final List<DatasetFieldRow> newFieldRows =
-            datasetMeta.getFields().stream()
-                .map(field -> toDatasetFieldRow(datasetRow.getUuid(), field))
-                .collect(toImmutableList());
-        final List<DatasetFieldRow> newFieldRowsForVersion =
-            newFieldRows.stream()
-                .filter(
-                    newFieldRow ->
-                        fieldRows.stream()
-                            .noneMatch(
-                                fieldRow ->
-                                    newFieldRow.getName().equals(fieldRow.getName())
-                                        && newFieldRow.getType().equals(fieldRow.getType())))
-                .collect(toImmutableList());
-        final List<DatasetFieldRow> fieldRowsForVersion =
-            Stream.concat(
-                    fieldRows.stream()
-                        .filter(
-                            fieldRow ->
-                                newFieldRows.stream()
-                                    .noneMatch(
-                                        newFieldRow ->
-                                            newFieldRow.getName().equals(fieldRow.getName())
-                                                && !newFieldRow
-                                                    .getType()
-                                                    .equals(fieldRow.getType()))),
-                    newFieldRowsForVersion.stream())
-                .collect(toImmutableList());
-        final List<UUID> fieldUuids =
-            fieldRowsForVersion.stream().map(DatasetFieldRow::getUuid).collect(toImmutableList());
-        final DatasetVersionRow newVersionRow =
-            Mapper.toDatasetVersionRow(datasetRow.getUuid(), version, fieldUuids, datasetMeta);
-        datasetVersionDao.insertWith(newVersionRow, newFieldRowsForVersion);
-        log.info(
-            "Successfully created version '{}' for dataset '{}'.",
-            version.getValue(),
-            datasetName.getValue());
-        versions
-            .labels(
-                namespaceName.getValue(), datasetMeta.getType().toString(), datasetName.getValue())
-            .inc();
-      }
-      return get(namespaceName, datasetName).get();
-    } catch (UnableToExecuteStatementException e) {
-      log.error(
-          "Failed to create or update dataset '{}' for namespace '{}' with meta: {}",
-          datasetName.getValue(),
-          namespaceName.getValue(),
-          datasetMeta,
-          e);
-      throw new MarquezServiceException();
-    }
-  }
+      @NonNull DatasetMeta datasetMeta) {
+    log.info(
+        "Creating or updating dataset '{}' for namespace '{}' with meta: {}",
+        datasetName.getValue(),
+        namespaceName.getValue(),
+        datasetMeta);
 
-  /** Creates a {@link DatasetFieldRow} instance from the given {@link Field}. */
-  private DatasetFieldRow toDatasetFieldRow(@NonNull UUID datasetUuid, @NonNull Field field) {
-    final List<UUID> tagUuids =
-        tagDao
-            .findAllIn(
-                toArray(
-                    field.getTags().stream().map(TagName::getValue).collect(toImmutableList()),
-                    String.class))
-            .stream()
-            .map(TagRow::getUuid)
-            .collect(toImmutableList());
-    return Mapper.toDatasetFieldRow(datasetUuid, field, tagUuids);
+    datasetDao.upsertDatasetMeta(namespaceName.getValue(), datasetName.getValue(), datasetMeta);
+
+    return get(namespaceName, datasetName).get();
   }
 
   public boolean exists(@NonNull NamespaceName namespaceName, @NonNull DatasetName datasetName)

--- a/api/src/main/java/marquez/service/mappers/Mapper.java
+++ b/api/src/main/java/marquez/service/mappers/Mapper.java
@@ -49,7 +49,6 @@ import marquez.common.models.SourceType;
 import marquez.common.models.TagName;
 import marquez.common.models.Version;
 import marquez.db.models.DatasetFieldRow;
-import marquez.db.models.DatasetRow;
 import marquez.db.models.DatasetVersionRow;
 import marquez.db.models.ExtendedDatasetRow;
 import marquez.db.models.ExtendedRunRow;
@@ -64,7 +63,6 @@ import marquez.db.models.RunRow;
 import marquez.db.models.RunStateRow;
 import marquez.db.models.SourceRow;
 import marquez.db.models.StreamVersionRow;
-import marquez.db.models.TagRow;
 import marquez.service.models.Dataset;
 import marquez.service.models.DatasetMeta;
 import marquez.service.models.DatasetVersion;
@@ -82,7 +80,6 @@ import marquez.service.models.SourceMeta;
 import marquez.service.models.Stream;
 import marquez.service.models.StreamMeta;
 import marquez.service.models.StreamVersion;
-import marquez.service.models.Tag;
 
 public final class Mapper {
   private Mapper() {}
@@ -267,28 +264,6 @@ public final class Mapper {
         createdByRun);
   }
 
-  public static DatasetRow toDatasetRow(
-      @NonNull final UUID namespaceRowUuid,
-      @NonNull final UUID sourceRowUuid,
-      @NonNull final DatasetName name,
-      @NonNull final DatasetMeta meta,
-      @NonNull final List<UUID> tagUuids) {
-    final Instant now = newTimestamp();
-    return new DatasetRow(
-        newRowUuid(),
-        toDatasetType(meta).toString(),
-        now,
-        now,
-        namespaceRowUuid,
-        sourceRowUuid,
-        name.getValue(),
-        meta.getPhysicalName().getValue(),
-        tagUuids,
-        null,
-        meta.getDescription().orElse(null),
-        null);
-  }
-
   private static DatasetType toDatasetType(@NonNull final DatasetMeta meta) {
     if (meta instanceof DbTableMeta) {
       return DatasetType.DB_TABLE;
@@ -305,60 +280,6 @@ public final class Mapper {
         FieldType.valueOf(row.getType()),
         tags,
         row.getDescription().orElse(null));
-  }
-
-  public static DatasetFieldRow toDatasetFieldRow(
-      @NonNull final UUID datasetUuid, @NonNull final Field field, @NonNull List<UUID> tagUuids) {
-    final Instant now = Instant.now();
-    return new DatasetFieldRow(
-        newRowUuid(),
-        field.getType().toString(),
-        now,
-        now,
-        datasetUuid,
-        field.getName().getValue(),
-        tagUuids,
-        field.getDescription().orElse(null));
-  }
-
-  public static DatasetVersionRow toDatasetVersionRow(
-      @NonNull final UUID datasetUuid,
-      @NonNull final Version version,
-      @NonNull final List<UUID> fieldUuids,
-      @NonNull final DatasetMeta meta) {
-    if (meta instanceof StreamMeta) {
-      return toStreamVersionRow(datasetUuid, version, fieldUuids, meta);
-    }
-    return new DatasetVersionRow(
-        newRowUuid(),
-        newTimestamp(),
-        datasetUuid,
-        version.getValue(),
-        fieldUuids,
-        meta.getRunId().map(RunId::getValue).orElse(null));
-  }
-
-  private static DatasetVersionRow toStreamVersionRow(
-      @NonNull final UUID datasetUuid,
-      @NonNull final Version version,
-      @NonNull final List<UUID> fieldUuids,
-      @NonNull final DatasetMeta meta) {
-    return new StreamVersionRow(
-        newRowUuid(),
-        newTimestamp(),
-        datasetUuid,
-        version.getValue(),
-        fieldUuids,
-        meta.getRunId().map(RunId::getValue).orElse(null),
-        ((StreamMeta) meta).getSchemaLocation().toString());
-  }
-
-  public static Tag toTag(@NonNull final TagRow row) {
-    return new Tag(TagName.of(row.getName()), row.getDescription().orElse(null));
-  }
-
-  public static List<Tag> toTags(@NonNull final List<TagRow> rows) {
-    return rows.stream().map(Mapper::toTag).collect(toImmutableList());
   }
 
   public static Job toJob(

--- a/api/src/test/java/marquez/api/DatasetResourceTest.java
+++ b/api/src/test/java/marquez/api/DatasetResourceTest.java
@@ -81,7 +81,7 @@ public class DatasetResourceTest {
   }
 
   @Test
-  public void testCreateOrUpdate() throws MarquezServiceException {
+  public void testCreateOrUpdate() {
     final DbTableMeta dbTableMeta = newDbTableMeta();
     final DbTable dbTable = toDbTable(DB_TABLE_ID, dbTableMeta);
 
@@ -96,7 +96,7 @@ public class DatasetResourceTest {
   }
 
   @Test
-  public void testCreateOrUpdateWithRun() throws MarquezServiceException {
+  public void testCreateOrUpdateWithRun() {
     final DbTableMeta dbTableMeta = newDbTableMetaWith(RUN_ID);
     final DbTable dbTable = toDbTable(DB_TABLE_ID, dbTableMeta);
 

--- a/api/src/test/java/marquez/db/DatasetDaoTest.java
+++ b/api/src/test/java/marquez/db/DatasetDaoTest.java
@@ -22,17 +22,13 @@ import static marquez.common.models.ModelGenerator.newNamespaceName;
 import static marquez.db.models.ModelGenerator.newDatasetRow;
 import static marquez.db.models.ModelGenerator.newDatasetRowWith;
 import static marquez.db.models.ModelGenerator.newDatasetRowsWith;
-import static marquez.db.models.ModelGenerator.newDatasetVersionRowWith;
 import static marquez.db.models.ModelGenerator.newNamespaceRowWith;
-import static marquez.db.models.ModelGenerator.newRowUuid;
 import static marquez.db.models.ModelGenerator.newSourceRow;
 import static marquez.db.models.ModelGenerator.newTagRow;
 import static marquez.db.models.ModelGenerator.newTagRows;
 import static marquez.db.models.ModelGenerator.toTagUuids;
-import static marquez.service.models.ModelGenerator.newVersion;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.time.Instant;
 import java.util.List;
@@ -45,9 +41,7 @@ import marquez.JdbiRuleInit;
 import marquez.common.models.DatasetName;
 import marquez.common.models.NamespaceName;
 import marquez.db.models.DatasetRow;
-import marquez.db.models.DatasetVersionRow;
 import marquez.db.models.ExtendedDatasetRow;
-import marquez.db.models.ExtendedDatasetVersionRow;
 import marquez.db.models.NamespaceRow;
 import marquez.db.models.SourceRow;
 import marquez.db.models.TagRow;
@@ -260,21 +254,5 @@ public class DatasetDaoTest {
 
     final List<ExtendedDatasetRow> rows = datasetDao.findAll(NAMESPACE_NAME.getValue(), 4, 0);
     assertThat(rows).isNotNull().hasSize(4);
-  }
-
-  @Test
-  public void testDatasetVersions() {
-    final DatasetRow ds =
-        newDatasetRowWith(namespaceRow.getUuid(), sourceRow.getUuid(), toTagUuids(tagRows));
-    datasetDao.insert(ds);
-
-    DatasetVersionRow dsv =
-        newDatasetVersionRowWith(ds.getUuid(), newVersion(), ImmutableList.of(), newRowUuid());
-
-    datasetVersionDao.insert(dsv);
-
-    final List<ExtendedDatasetVersionRow> rows =
-        datasetVersionDao.findByRunId(dsv.getRunUuid().get());
-    assertThat(rows).isNotNull().hasSize(1);
   }
 }

--- a/api/src/test/java/marquez/service/DatasetServiceTest.java
+++ b/api/src/test/java/marquez/service/DatasetServiceTest.java
@@ -155,7 +155,6 @@ public class DatasetServiceTest {
 
     // Version
     final Version version = dbTableMeta.version(NAMESPACE_NAME, DB_TABLE_NAME);
-    when(datasetVersionDao.exists(version.getValue())).thenReturn(false);
 
     final DatasetVersionRow datasetVersionRow =
         newDatasetVersionRowWith(DATASET_ROW.getUuid(), version, NO_TAG_UUIDS, null);
@@ -178,17 +177,6 @@ public class DatasetServiceTest {
     assertThat(dbTable.getTags()).isEmpty();
     assertThat(dbTable.getLastModifiedAt()).isEmpty();
     assertThat(dbTable.getDescription()).isEqualTo(Optional.of(DB_TABLE_DESCRIPTION));
-
-    verify(namespaceDao, times(1)).findBy(NAMESPACE_NAME.getValue());
-    verify(sourceDao, times(1)).findBy(DB_TABLE_SOURCE_NAME.getValue());
-    verify(datasetDao, times(1)).exists(NAMESPACE_NAME.getValue(), DB_TABLE_NAME.getValue());
-    verify(datasetDao, times(2)).find(NAMESPACE_NAME.getValue(), DB_TABLE_NAME.getValue());
-    verify(datasetFieldDao, times(1))
-        .findAllIn(toArray(datasetVersionRow.getFieldUuids(), UUID.class));
-    verify(datasetVersionDao, times(1)).exists(version.getValue());
-    verify(datasetVersionDao, times(1))
-        .find(DATASET_ROW.getType(), DATASET_ROW.getCurrentVersionUuid().orElse(null));
-    verify(tagDao, times(1)).findAllIn(toArray(DATASET_ROW.getTagUuids(), UUID.class));
   }
 
   @Test


### PR DESCRIPTION
This changes the dataset creation behavior to use the user-provided dataset fields rather than doing a field union of previous datasets. #1022 

Signed-off-by: henneberger <gpg@danielhenneberger.com>