### PR TITLE
Postgres Dependency Upgrade

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     compile "org.jdbi:jdbi3-sqlobject:${jdbi3Version}"
     compile 'com.google.guava:guava:30.1-jre'
     compile 'org.flywaydb:flyway-core:6.5.7'
-    compile 'org.postgresql:postgresql:42.2.6'
+    compile 'org.postgresql:postgresql:42.2.19'
     compile 'com.graphql-java:graphql-java:16.2'
     compile 'com.graphql-java-kickstart:graphql-java-servlet:11.1.0'
     compileOnly "org.projectlombok:lombok:${lombokVersion}"

--- a/api/src/test/java/marquez/db/ColumnsTest.java
+++ b/api/src/test/java/marquez/db/ColumnsTest.java
@@ -171,7 +171,7 @@ public class ColumnsTest {
   @Test
   public void testPgIntervalOrThrow_pgInterval() throws SQLException {
     final String column = "with_interval";
-    final String expected = "0 years 0 mons 0 days 0 hours 5 mins 5.00 secs";
+    final String expected = "0 years 0 mons 0 days 0 hours 5 mins 5.0 secs";
     when(results.getObject(column)).thenReturn(expected);
     when(results.getString(column)).thenReturn(expected);
 


### PR DESCRIPTION
Upgrades the Postgres dependency to 42.2.19, and alters unit test behavior to account for a change introduced in Postgres behavior around millisecond precision.

Postgres behavior change can be further seen at https://github.com/pgjdbc/pgjdbc/pull/1612/files. 

Closes #995 