### PR TITLE
Override PR target for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     "docker:disable",
     ":gitSignOff"
   ],
+  "baseBranches": ["update-deps"],
   "lockFileMaintenance": { "enabled": true },
   "schedule": ["every weekend"]
 }


### PR DESCRIPTION
To make updating dependencies via renovate more manageable, we're setting the base branch to [`update-deps`](https://github.com/MarquezProject/marquez/tree/update-deps)