### PR TITLE
Address sporadic spark integration test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,11 @@ jobs:
             - v1-integration-spark-{{ .Branch }}-{{ .Revision }}
             - v1-integration-spark-{{ .Branch }}
       - run: ./gradlew --no-daemon --stacktrace :integrations:spark:build
+      - run:
+          when: on_fail
+          command: cat integrations/spark/build/test-results/test/TEST-*.xml
+      - store_test_results:
+          path: integrations/spark/build/test-results/test
       - save_cache:
           key: v1-integration-spark-{{ .Branch }}-{{ .Revision }}
           paths:

--- a/integrations/spark/build.gradle
+++ b/integrations/spark/build.gradle
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import org.apache.tools.ant.filters.*
+import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
     id 'maven-publish'
@@ -40,9 +40,22 @@ dependencies {
     testImplementation 'org.apache.spark:spark-core_2.11:2.4.7'
     testImplementation 'org.apache.spark:spark-sql_2.11:2.4.7'
     testImplementation 'org.mockito:mockito-core:3.8.0'
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation(platform('org.junit:junit-bom:5.7.1'))
+    testImplementation('org.junit.jupiter:junit-jupiter:5.7.1')
 
     annotationProcessor "org.projectlombok:lombok:1.18.16"
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+        showStandardStreams = true
+    }
+    systemProperties = [
+            'junit.platform.output.capture.stdout': 'true',
+            'junit.platform.output.capture.stderr': 'true'
+    ]
 }
 
 publishing {

--- a/integrations/spark/src/main/java/marquez/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integrations/spark/src/main/java/marquez/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -29,6 +29,7 @@ import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
 @Slf4j
 public class SparkSQLExecutionContext implements ExecutionContext {
   private final long executionId;
+  private final QueryExecution queryExecution;
 
   private MarquezContext marquezContext;
   private final LogicalPlanFacetTraverser logicalPlanFacetTraverser;
@@ -43,6 +44,7 @@ public class SparkSQLExecutionContext implements ExecutionContext {
     this.marquezContext = marquezContext;
     this.logicalPlanFacetTraverser = logicalPlanFacetTraverser;
     this.datasetLogicalPlanTraverser = datasetLogicalPlanTraverser;
+    this.queryExecution = SQLExecution.getQueryExecution(executionId);
   }
 
   public void start(SparkListenerSQLExecutionStart startEvent) {}
@@ -55,7 +57,6 @@ public class SparkSQLExecutionContext implements ExecutionContext {
   @Override
   public void start(SparkListenerJobStart jobStart) {
     log.info("Starting job as part of spark-sql:" + jobStart.jobId());
-    QueryExecution queryExecution = SQLExecution.getQueryExecution(executionId);
     if (queryExecution == null) {
       log.info("No execution info {}", queryExecution);
       return;
@@ -98,7 +99,6 @@ public class SparkSQLExecutionContext implements ExecutionContext {
   @Override
   public void end(SparkListenerJobEnd jobEnd) {
     log.info("Ending job as part of spark-sql:" + jobEnd.jobId());
-    QueryExecution queryExecution = SQLExecution.getQueryExecution(executionId);
     if (queryExecution == null) {
       log.info("No execution info {}", queryExecution);
       return;


### PR DESCRIPTION
Upgraded to JUnit 5 in order to use the `@RepeatedTest` annotation to run the `LibraryTest` many times. This got the build to reliably fail (though I had to use a big number to get it fail at least once every build). I also had to configure the build to print out the test result text files (and configured circle to upload the test results). I found the test was due to a concurrency problem where the queryExecution was sometimes removed from a map before we had a chance to access it. Changing the code to keep a reference to the queryExecution means we're not subject to concurrency problems anymore. Build now reliably passes.