### PR TITLE
Bump airflow integration's required python version to 3.6

### DIFF
--- a/integrations/airflow/README.md
+++ b/integrations/airflow/README.md
@@ -23,7 +23,7 @@ A library that integrates [Airflow `DAGs`]() with [Marquez](https://github.com/M
 
 ## Requirements
 
- - [Python 3.5.0](https://www.python.org/downloads)+
+ - [Python 3.6.0](https://www.python.org/downloads)+
  - [Airflow 1.10.4](https://pypi.org/project/apache-airflow)+
 
 ## Installation

--- a/integrations/airflow/setup.py
+++ b/integrations/airflow/setup.py
@@ -38,6 +38,7 @@ NAME = "marquez-airflow"
 
 setup(
     name=NAME,
+    python_requires='>=3.6',
     version=get_version('marquez_airflow/version.py'),
     author="Marquez Team",
     author_email="",


### PR DESCRIPTION
This change is more about acknowledging fact than dropping support, as python >3.5 features are used in codebase, like f-strings.