### PR TITLE
Downgraded Java Client Library

### DIFF
--- a/clients/java/build.gradle
+++ b/clients/java/build.gradle
@@ -20,8 +20,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {

--- a/clients/java/gradle.properties
+++ b/clients/java/gradle.properties
@@ -1,1 +1,2 @@
 version=0.13.0-SNAPSHOT
+jdk8.build=true


### PR DESCRIPTION
Downgraded the Java Client library to use Java 1.8 compatibility. This will lessen the environmental requirements of applications seeking to use the library to facilitate calls to the REST API.