### PR TITLE
Spark integration fixes

### DIFF
--- a/api/src/main/java/marquez/common/models/FieldType.java
+++ b/api/src/main/java/marquez/common/models/FieldType.java
@@ -36,6 +36,7 @@ public enum FieldType {
   INT4,
   INT8,
   INTEGER,
+  LONG,
   NCHAR,
   NUMBER,
   NUMERIC,

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -49,6 +49,7 @@ import marquez.service.models.LineageEvent.SchemaField;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.postgresql.util.PGobject;
+import org.slf4j.LoggerFactory;
 
 public interface OpenLineageDao extends BaseDao {
   public String DEFAULT_SOURCE_NAME = "default";
@@ -414,6 +415,7 @@ public interface OpenLineageDao extends BaseDao {
     try {
       return FieldType.valueOf(type.toUpperCase()).name();
     } catch (Exception e) {
+      LoggerFactory.getLogger(getClass()).warn("Can't handle field of type {}", type.toUpperCase());
       return null;
     }
   }

--- a/integrations/spark/src/main/java/marquez/spark/agent/SparkListener.java
+++ b/integrations/spark/src/main/java/marquez/spark/agent/SparkListener.java
@@ -162,7 +162,9 @@ public class SparkListener {
   /** called by the SparkListener when a spark-sql (Dataset api) execution ends */
   private static void sparkSQLExecEnd(SparkListenerSQLExecutionEnd endEvent) {
     SparkSQLExecutionContext context = sparkSqlExecutionRegistry.remove(endEvent.executionId());
-    context.end(endEvent);
+    if (context != null) {
+      context.end(endEvent);
+    }
   }
 
   /** called by the SparkListener when a job starts */

--- a/integrations/spark/src/main/java/marquez/spark/agent/lifecycle/plan/JDBCRelationVisitor.java
+++ b/integrations/spark/src/main/java/marquez/spark/agent/lifecycle/plan/JDBCRelationVisitor.java
@@ -77,7 +77,7 @@ public class JDBCRelationVisitor extends AbstractPartialFunction<LogicalPlan, Li
                               return "COMPLEX";
                             }
                           });
-              URI connectionUri = URI.create(relation.jdbcOptions().url());
+              URI connectionUri = URI.create(relation.jdbcOptions().url() + "/" + tableName);
               return Collections.singletonList(
                   PlanUtils.getDataset(connectionUri, relation.schema()));
             })


### PR DESCRIPTION
These fixes address some failures happening when posting lineage events from Spark to Marquez. Notably, datasets with `long` data types (there are many :) ) fail to get written. This was irritating to track down because the code swallows the error if no type mapping is found. Additionally, the JDBC relation visitor didn't include the table name in the URI, which caused the dataset to have a namespace, but no name. 

Finally, I've seen the `SparkSQLExecutionContext` in the context map return null, causing some NPEs. Added a null check for that.