### PR TITLE
Add sentry config

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     compile "org.jdbi:jdbi3-postgres:${jdbi3Version}"
     compile "org.jdbi:jdbi3-sqlobject:${jdbi3Version}"
     compile 'com.google.guava:guava:30.1-jre'
+    compile 'org.dhatim:dropwizard-sentry:2.0.20'
     compile 'org.flywaydb:flyway-core:6.5.7'
     compile 'org.postgresql:postgresql:42.2.19'
     compile 'com.graphql-java:graphql-java:16.2'

--- a/marquez.example.yml
+++ b/marquez.example.yml
@@ -64,7 +64,7 @@ logging:
     #   threshold: ${SENTRY_THRESHOLD:-ERROR}
     #   dsn: ${SENTRY_DSN}
     #   environment: ${SENTRY_ENVIRONMENT}
-    #   stacktraceAppPackages: ['com.marquez']
+    #   stacktraceAppPackages: ['marquez']
 
 ### METRICS CONFIG ###
 

--- a/marquez.example.yml
+++ b/marquez.example.yml
@@ -59,7 +59,7 @@ logging:
       # Enables app logs formatted as JSON
       # layout:
       #   type: json
-    # Enables capturing app error logging with sentry (see: https://github.com/dhatim/dropwizard-sentry#configuration)
+    # Enables capturing app error logs with sentry (see: https://github.com/dhatim/dropwizard-sentry#configuration)
     # - type: sentry
     #   threshold: ${SENTRY_THRESHOLD:-ERROR}
     #   dsn: ${SENTRY_DSN}

--- a/marquez.example.yml
+++ b/marquez.example.yml
@@ -59,7 +59,7 @@ logging:
       # Enables app logs formatted as JSON
       # layout:
       #   type: json
-    # Enables error logging to sentry (see: https://github.com/dhatim/dropwizard-sentry#configuration)
+    # Enables capturing app error logging with sentry (see: https://github.com/dhatim/dropwizard-sentry#configuration)
     # - type: sentry
     #   threshold: ${SENTRY_THRESHOLD:-ERROR}
     #   dsn: ${SENTRY_DSN}

--- a/marquez.example.yml
+++ b/marquez.example.yml
@@ -59,6 +59,12 @@ logging:
       # Enables app logs formatted as JSON
       # layout:
       #   type: json
+    # Enables error logging to sentry (see: https://github.com/dhatim/dropwizard-sentry#configuration)
+    # - type: sentry
+    #   threshold: ${SENTRY_THRESHOLD:-ERROR}
+    #   dsn: ${SENTRY_DSN}
+    #   environment: ${SENTRY_ENV}
+    #   stacktraceAppPackages: ['com.marquez']
 
 ### METRICS CONFIG ###
 

--- a/marquez.example.yml
+++ b/marquez.example.yml
@@ -63,7 +63,7 @@ logging:
     # - type: sentry
     #   threshold: ${SENTRY_THRESHOLD:-ERROR}
     #   dsn: ${SENTRY_DSN}
-    #   environment: ${SENTRY_ENV}
+    #   environment: ${SENTRY_ENVIRONMENT}
     #   stacktraceAppPackages: ['com.marquez']
 
 ### METRICS CONFIG ###


### PR DESCRIPTION
This PR enables configuring error logging with [`sentry`](https://sentry.io/) using the [`dropwizard-sentry`](https://github.com/dhatim/dropwizard-sentry) integration for dropwizard.