### PR TITLE
Fix url encoding for java 8 in client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,14 +56,15 @@ jobs:
           key: v1-web-{{ .Branch }}-{{ .Revision }}
 
   build-client-java:
-    <<: *machine
+    working_directory: ~/marquez
+    docker:
+      - image: circleci/openjdk:8-jdk
     steps:
       - checkout
       - restore_cache:
           keys:
             - v1-client-java-{{ .Branch }}-{{ .Revision }}
             - v1-client-java-{{ .Branch }}
-      - run: ./.circleci/get-jdk11.sh
       - run: ./gradlew --no-daemon --stacktrace clients:java:build
       - run: ./gradlew --no-daemon clients:java:jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)

--- a/clients/java/src/main/java/marquez/client/FileBackend.java
+++ b/clients/java/src/main/java/marquez/client/FileBackend.java
@@ -1,6 +1,5 @@
 package marquez.client;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.http.protocol.HTTP.USER_AGENT;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -50,7 +49,7 @@ class FileBackend implements Backend {
       log.error("Can't write Marquez calls. " + parentFile + " can not be created.");
     } else {
       try {
-        return new FileWriter(file, UTF_8, true);
+        return new FileWriter(file, true);
       } catch (IOException e) {
         log.error("Can't write Marquez calls. " + file + " can not be written to.", e);
       }

--- a/clients/java/src/test/java/marquez/client/MarquezWriteOnlyClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezWriteOnlyClientTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
@@ -92,10 +93,10 @@ public class MarquezWriteOnlyClientTest {
   }
 
   @Test
-  public void testMarkRunAs() {
+  public void testMarkRunAs() throws UnsupportedEncodingException {
     String runId = UUID.randomUUID().toString();
     Instant at = Instant.now();
-    String atParam = URLEncoder.encode(String.valueOf(at), UTF_8);
+    String atParam = URLEncoder.encode(String.valueOf(at), UTF_8.name());
     client.markRunAsRunning(runId, at);
     verify(backend, times(1)).post("/api/v1/jobs/runs/" + runId + "/start?at=" + atParam);
     client.markRunAsAborted(runId, at);


### PR DESCRIPTION
This PR fixes a bug related to url encoding for java 8 in the java client. Below are the failing tests that have been fixed:

```bash
marquez.client.FileBackendTest
  Test testInitFileNotWritable FAILED

  java.lang.NoSuchMethodError: java.io.FileWriter.<init>(Ljava/io/File;Ljava/nio/charset/Charset;Z)V
      at marquez.client.FileBackendTest.testInitFileNotWritable(FileBackendTest.java:99)
...
marquez.client.MarquezWriteOnlyClientTest
  Test testMarkRunAs FAILED

  java.lang.NoSuchMethodError: java.net.URLEncoder.encode(Ljava/lang/String;Ljava/nio/charset/Charset;)Ljava/lang/String;
      at marquez.client.MarquezWriteOnlyClientTest.testMarkRunAs(MarquezWriteOnlyClientTest.java:98)

...
marquez.client.BackendsTest
  Test testFile FAILED

  java.lang.NoSuchMethodError: java.io.FileWriter.<init>(Ljava/io/File;Ljava/nio/charset/Charset;Z)V
      at marquez.client.BackendsTest.testFile(BackendsTest.java:57)
``` 