### PR TITLE
Updated NodeId regex to support URIs with scheme and ports

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -12,8 +12,9 @@
  * limitations under the License.
  */
 
+
 import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
-import org.apache.tools.ant.filters.*
+import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
     id 'maven-publish'
@@ -55,7 +56,8 @@ dependencies {
 
     testCompile "io.dropwizard:dropwizard-testing:${dropwizardVersion}"
     testCompile "org.jdbi:jdbi3-testing:${jdbi3Version}"
-    testCompile 'junit:junit:4.13.2'
+    testImplementation(platform('org.junit:junit-bom:5.7.1'))
+    testImplementation('org.junit.jupiter:junit-jupiter:5.7.1')
     testCompile 'org.assertj:assertj-core:3.19.0'
     testCompile 'org.mockito:mockito-core:3.8.0'
     testCompile 'org.testcontainers:postgresql:1.15.2'

--- a/api/src/main/java/marquez/service/models/NodeId.java
+++ b/api/src/main/java/marquez/service/models/NodeId.java
@@ -167,6 +167,8 @@ public final class NodeId {
 
   @JsonIgnore
   private String[] parts(int expectedParts, String expectedType) {
+
+    // dead simple splitting by token- matches most ids
     String[] parts = value.split(ID_DELIM + "|" + VERSION_DELIM);
     if (parts.length < expectedParts) {
       throw new UnsupportedOperationException(
@@ -176,7 +178,8 @@ public final class NodeId {
     } else if (parts.length == expectedParts) {
       return parts;
     } else {
-      Pattern p = Pattern.compile(ID_DELIM + "|" + VERSION_DELIM);
+      // try to avoid matching colons in URIs- e.g., scheme://authority and host:port patterns
+      Pattern p = Pattern.compile("(?:" + ID_DELIM + "(?!//|\\d+))|" + VERSION_DELIM);
       Matcher matcher = p.matcher(value);
       String[] returnParts = new String[expectedParts];
 

--- a/api/src/test/java/marquez/service/models/NodeIdTest.java
+++ b/api/src/test/java/marquez/service/models/NodeIdTest.java
@@ -1,0 +1,33 @@
+package marquez.service.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import marquez.common.models.DatasetId;
+import marquez.common.models.DatasetName;
+import marquez.common.models.NamespaceName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class NodeIdTest {
+
+  @ParameterizedTest(name = "testDatasetWithUrl-{index} {argumentsWithNames}")
+  @CsvSource({"gs://bucket,/path/to/data", "postgresql://hostname:5432/database,my_table"})
+  public void testDatasetWithUrl() {
+    String namespace = "gs://bucket";
+    String datasetName = "/path/to/data";
+    DatasetName dsName = DatasetName.of(datasetName);
+    DatasetId dsId = new DatasetId(NamespaceName.of(namespace), dsName);
+    NodeId nodeId = NodeId.of(dsId);
+    assertFalse(nodeId.isRunType());
+    assertFalse(nodeId.isJobType());
+    assertTrue(nodeId.isDatasetType());
+    assertFalse(nodeId.hasVersion());
+    assertEquals(dsId, nodeId.asDatasetId());
+    assertEquals(nodeId, NodeId.of(nodeId.getValue()));
+    DatasetId ds = nodeId.asDatasetId();
+    assertEquals(namespace, ds.getNamespace().getValue());
+    assertEquals(datasetName, ds.getName().getValue());
+  }
+}


### PR DESCRIPTION
Missed in the port of the lineage API- the NodeId splits on `:`, which causes dataset name parsing issues when dealing with URIs (e.g., `gs://bucket/path` or `postgres://host:port/database`). 