### PR TITLE
Add GA tag for website tracking

### DIFF
--- a/docs/_layouts/index.html
+++ b/docs/_layouts/index.html
@@ -2,6 +2,14 @@
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>
     {% seo %}
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-9S43L0BB9X"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-9S43L0BB9X');
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#157878">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross@datakin.com>

This adds a Google Analytics tracker to the website header so we can study traffic and improve user experience.