### PR TITLE
Update spark job name to reflect spark application name and execution node

### DIFF
--- a/integrations/spark/integrations/sparkrdd/1.json
+++ b/integrations/spark/integrations/sparkrdd/1.json
@@ -7,7 +7,7 @@
   },
   "job" : {
     "namespace" : "ns_name",
-    "name" : "job_name"
+    "name" : "word_count"
   },
   "inputs" : [ {
     "namespace" : "gs.bucket",

--- a/integrations/spark/integrations/sparkrdd/2.json
+++ b/integrations/spark/integrations/sparkrdd/2.json
@@ -7,7 +7,7 @@
   },
   "job" : {
     "namespace" : "ns_name",
-    "name" : "job_name"
+    "name" : "word_count"
   },
   "inputs" : [ {
     "namespace" : "gs.bucket",

--- a/integrations/spark/integrations/sparksql/1.json
+++ b/integrations/spark/integrations/sparksql/1.json
@@ -2,7 +2,7 @@
   "eventType": "START",
   "eventTime": "2021-01-01T00:00:00Z",
   "run": {
-    "runId": "ea445b5c-22eb-457a-8007-01c7c52b6e54",
+    "runId": "fake_run_id",
     "facets": {
       "parent": {
         "_producer": "https://github.com/MarquezProject/marquez/tree/0.12.0/integrations/spark",
@@ -146,7 +146,7 @@
   },
   "job": {
     "namespace": "ns_name",
-    "name": "job_name"
+    "name": "word_count.hash_aggregate"
   },
   "inputs": [
     {

--- a/integrations/spark/integrations/sparksql/2.json
+++ b/integrations/spark/integrations/sparksql/2.json
@@ -2,7 +2,7 @@
   "eventType": "COMPLETE",
   "eventTime": "2021-01-01T00:00:00Z",
   "run": {
-    "runId": "ea445b5c-22eb-457a-8007-01c7c52b6e54",
+    "runId": "fake_run_id",
     "facets": {
       "parent": {
         "_producer": "https://github.com/MarquezProject/marquez/tree/0.12.0/integrations/spark",
@@ -146,7 +146,7 @@
   },
   "job": {
     "namespace": "ns_name",
-    "name": "job_name"
+    "name": "word_count.hash_aggregate"
   },
   "inputs": [
     {

--- a/integrations/spark/integrations/sparksql/3.json
+++ b/integrations/spark/integrations/sparksql/3.json
@@ -2,7 +2,7 @@
   "eventType": "START",
   "eventTime": "2021-01-01T00:00:00Z",
   "run": {
-    "runId": "ea445b5c-22eb-457a-8007-01c7c52b6e54",
+    "runId": "fake_run_id",
     "facets": {
       "parent": {
         "_producer": "https://github.com/MarquezProject/marquez/tree/0.12.0/integrations/spark",
@@ -146,7 +146,7 @@
   },
   "job": {
     "namespace": "ns_name",
-    "name": "job_name"
+    "name": "word_count.hash_aggregate"
   },
   "inputs": [
     {

--- a/integrations/spark/integrations/sparksql/4.json
+++ b/integrations/spark/integrations/sparksql/4.json
@@ -2,7 +2,7 @@
   "eventType": "COMPLETE",
   "eventTime": "2021-01-01T00:00:00Z",
   "run": {
-    "runId": "ea445b5c-22eb-457a-8007-01c7c52b6e54",
+    "runId": "fake_run_id",
     "facets": {
       "parent": {
         "_producer": "https://github.com/MarquezProject/marquez/tree/0.12.0/integrations/spark",
@@ -146,7 +146,7 @@
   },
   "job": {
     "namespace": "ns_name",
-    "name": "job_name"
+    "name": "word_count.hash_aggregate"
   },
   "inputs": [
     {

--- a/integrations/spark/src/main/java/marquez/spark/agent/lifecycle/ExecutionContext.java
+++ b/integrations/spark/src/main/java/marquez/spark/agent/lifecycle/ExecutionContext.java
@@ -6,6 +6,14 @@ import org.apache.spark.scheduler.SparkListenerJobStart;
 
 public interface ExecutionContext {
 
+  /**
+   * Pattern used to match a variety of patterns in job names, including camel case and token
+   * separated (whitespace, dash, or underscore), with special handling for upper-case
+   * abbreviations, like XML or JDBC
+   */
+  String CAMEL_TO_SNAKE_CASE =
+      "[\\s\\-_]?((?<=.)[A-Z](?=[a-z\\s\\-_])|(?<=[^A-Z])[A-Z]|((?<=[\\s\\-_])[a-z\\d]))";
+
   void setActiveJob(ActiveJob activeJob);
 
   void start(SparkListenerJobStart jobStart);

--- a/integrations/spark/src/test/java/marquez/spark/agent/lifecycle/ExecutionContextTest.java
+++ b/integrations/spark/src/test/java/marquez/spark/agent/lifecycle/ExecutionContextTest.java
@@ -1,0 +1,23 @@
+package marquez.spark.agent.lifecycle;
+
+import java.util.Locale;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class ExecutionContextTest {
+
+  @ParameterizedTest
+  @CsvSource({
+    "A Test Application,a_test_application",
+    "MyTestApplication,my_test_application",
+    "MyXMLBasedApplication,my_xml_based_application",
+    "JDBCRelationApplication,jdbc_relation_application",
+    "Test With a Single LetterBetweenWords,test_with_a_single_letter_between_words"
+  })
+  public void testCamelCaseToSnakeCase(String appName, String expected) {
+    String actual =
+        appName.replaceAll(ExecutionContext.CAMEL_TO_SNAKE_CASE, "_$1").toLowerCase(Locale.ROOT);
+    Assertions.assertEquals(expected, actual);
+  }
+}

--- a/integrations/spark/src/test/java/marquez/spark/agent/lifecycle/LibraryTest.java
+++ b/integrations/spark/src/test/java/marquez/spark/agent/lifecycle/LibraryTest.java
@@ -100,6 +100,10 @@ public class LibraryTest {
     map.remove("exprId");
     map.remove("resultId");
 
+    if (map.containsKey("facets") && map.containsKey("runId")) {
+      map.put("runId", "fake_run_id");
+    }
+
     // timezone is different in CI than local
     map.remove("timeZoneId");
     if (map.containsKey("namespace") && map.get("namespace").equals("file")) {


### PR DESCRIPTION
This change changes the job naming behavior creating a new job name for each query execution in the spark application. For each query execution, a new job is created, with a unique `runId` and a parent facet pointing to the run identified by the parameters passed into the agent. 

As an example, one job name I generated in testing was `orders_dump_to_gcs.execute_insert_into_hadoop_fs_relation_command`, where `orders_dump_to_gcs` is the spark application name and `execute_insert_into_hadoop_fs_relation_command` is the node name returned by the `DataWritingCommandExec` physical plan node.