### PR TITLE
Add airflow custom facets, bigquery statistics facet

### DIFF
--- a/integrations/airflow/marquez_airflow/dag.py
+++ b/integrations/airflow/marquez_airflow/dag.py
@@ -16,6 +16,7 @@ import airflow.models
 import time
 
 from airflow.contrib.operators.bigquery_operator import BigQueryOperator
+from airflow.models import DagRun
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.utils.state import State
 
@@ -25,7 +26,8 @@ from marquez_airflow.extractors.postgres_extractor import PostgresExtractor
 from marquez_airflow.utils import (
     JobIdMapping,
     get_location,
-    DagUtils
+    DagUtils,
+    get_custom_facets
 )
 
 # Handling of import of different airflow versions
@@ -64,6 +66,7 @@ class DAG(airflow.models.DAG, LoggingMixin):
         try:
             self._register_dagrun(
                 dagrun,
+                kwargs.get('external_trigger', False),
                 DagUtils.get_execution_date(**kwargs)
             )
         except Exception as e:
@@ -78,7 +81,7 @@ class DAG(airflow.models.DAG, LoggingMixin):
     # tasks can be safely marked as started as well.
     # Doing it other way would require to hook up to
     # scheduler, where tasks are actually started
-    def _register_dagrun(self, dagrun, execution_date):
+    def _register_dagrun(self, dagrun: DagRun, is_external_trigger: bool, execution_date: str):
         self.log.debug(f"self.task_dict: {self.task_dict}")
         # Register each task in the DAG
         for task_id, task in self.task_dict.items():
@@ -94,11 +97,12 @@ class DAG(airflow.models.DAG, LoggingMixin):
                     job_name,
                     self.description,
                     DagUtils.to_iso_8601(self._now_ms()),
-                    None,  # TODO: add parent hierarchy
+                    dagrun.run_id,
                     self._get_location(task),
                     DagUtils.get_start_time(execution_date),
                     DagUtils.get_end_time(execution_date, self.following_schedule(execution_date)),
-                    step
+                    step,
+                    get_custom_facets(task, is_external_trigger)
                 )
 
                 JobIdMapping.set(
@@ -113,7 +117,7 @@ class DAG(airflow.models.DAG, LoggingMixin):
                     exc_info=True)
 
     def handle_callback(self, *args, **kwargs):
-        self.log.debug(f"handle_callback({args}, {kwargs})")
+        self.log.info(f"handle_callback({args}, {kwargs})")
         try:
             dagrun = args[0]
             self.log.debug(f"handle_callback() dagrun : {dagrun}")
@@ -158,7 +162,7 @@ class DAG(airflow.models.DAG, LoggingMixin):
                 job_name,
                 self.description,
                 DagUtils.to_iso_8601(task_instance.start_date),
-                None,  # TODO: add parent hierarchy
+                dagrun.run_id,
                 self._get_location(task),
                 DagUtils.to_iso_8601(task_instance.start_date),
                 DagUtils.to_iso_8601(task_instance.end_date),
@@ -166,7 +170,7 @@ class DAG(airflow.models.DAG, LoggingMixin):
             )
 
             if not task_run_id:
-                self.log.warn('Could not emit lineage')
+                self.log.warning('Could not emit lineage')
 
         self.log.debug(f'Setting task state: {task_instance.state}'
                        f' for {task_instance.task_id}')

--- a/integrations/airflow/marquez_airflow/dag.py
+++ b/integrations/airflow/marquez_airflow/dag.py
@@ -117,7 +117,7 @@ class DAG(airflow.models.DAG, LoggingMixin):
                     exc_info=True)
 
     def handle_callback(self, *args, **kwargs):
-        self.log.info(f"handle_callback({args}, {kwargs})")
+        self.log.debug(f"handle_callback({args}, {kwargs})")
         try:
             dagrun = args[0]
             self.log.debug(f"handle_callback() dagrun : {dagrun}")

--- a/integrations/airflow/marquez_airflow/dag.py
+++ b/integrations/airflow/marquez_airflow/dag.py
@@ -102,7 +102,7 @@ class DAG(airflow.models.DAG, LoggingMixin):
                     DagUtils.get_start_time(execution_date),
                     DagUtils.get_end_time(execution_date, self.following_schedule(execution_date)),
                     step,
-                    get_custom_facets(task, is_external_trigger)
+                    {**step.run_facets, **get_custom_facets(task, is_external_trigger)}
                 )
 
                 JobIdMapping.set(
@@ -167,6 +167,7 @@ class DAG(airflow.models.DAG, LoggingMixin):
                 DagUtils.to_iso_8601(task_instance.start_date),
                 DagUtils.to_iso_8601(task_instance.end_date),
                 step,
+                {**step.run_facets, **get_custom_facets(task, False)}
             )
 
             if not task_run_id:

--- a/integrations/airflow/marquez_airflow/dag.py
+++ b/integrations/airflow/marquez_airflow/dag.py
@@ -117,7 +117,7 @@ class DAG(airflow.models.DAG, LoggingMixin):
                     exc_info=True)
 
     def handle_callback(self, *args, **kwargs):
-        self.log.debug(f"handle_callback({args}, {kwargs})")
+        self.log.info(f"handle_callback({args}, {kwargs})")
         try:
             dagrun = args[0]
             self.log.debug(f"handle_callback() dagrun : {dagrun}")

--- a/integrations/airflow/marquez_airflow/extractors/__init__.py
+++ b/integrations/airflow/marquez_airflow/extractors/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from enum import Enum
-from typing import List, Union, Type, Optional
+from typing import List, Union, Type, Optional, Dict
 from abc import ABC, abstractmethod
 
 from airflow import LoggingMixin
@@ -77,9 +77,11 @@ class Field:
 class Dataset:
     def __init__(self, source: Source, name: str, type: DatasetType,
                  fields: List[Field] = None, description: Optional[str] = None,
-                 custom_facets: Optional[Type[BaseFacet]] = None):
+                 custom_facets: Dict[str, Type[BaseFacet]] = None):
         if fields is None:
             fields = []
+        if custom_facets is None:
+            custom_facets = {}
         self.source = source
         self.name = name
         self.type = type
@@ -143,7 +145,7 @@ class StepMetadata:
             inputs: List[Dataset] = None,
             outputs: List[Dataset] = None,
             context=None,
-            run_facets: List[BaseFacet] = None
+            run_facets: Dict[str, BaseFacet] = None
     ):
         # TODO: Define a common way across extractors to build the
         # job name for an operator
@@ -161,7 +163,7 @@ class StepMetadata:
         if not context:
             self.context = {}
         if not run_facets:
-            self.run_facets = []
+            self.run_facets = {}
 
     def __repr__(self):
         return "name: {}\t inputs: {} \t outputs: {}".format(

--- a/integrations/airflow/marquez_airflow/extractors/__init__.py
+++ b/integrations/airflow/marquez_airflow/extractors/__init__.py
@@ -10,13 +10,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from enum import Enum
-from typing import List, Union
+from typing import List, Union, Type, Optional
 from abc import ABC, abstractmethod
 
 from airflow import LoggingMixin
 from airflow.models import BaseOperator
 
 from marquez_airflow.models import DbTableSchema, DbColumn
+from openlineage.facet import BaseFacet
 
 
 class DatasetType(Enum):
@@ -45,11 +46,14 @@ class Source:
 
 class Field:
     def __init__(self, name: str, type: str,
-                 tags: List[str] = [], description: str = None):
+                 tags: List[str] = None, description: str = None):
         self.name = name
         self.type = type
         self.tags = tags
         self.description = description
+
+        if self.tags is None:
+            self.tags = []
 
     @staticmethod
     def from_column(column: DbColumn):
@@ -72,7 +76,8 @@ class Field:
 
 class Dataset:
     def __init__(self, source: Source, name: str, type: DatasetType,
-                 fields=None, description=None):
+                 fields: List[Field] = None, description: Optional[str] = None,
+                 custom_facets: Optional[Type[BaseFacet]] = None):
         if fields is None:
             fields = []
         self.source = source
@@ -80,6 +85,7 @@ class Dataset:
         self.type = type
         self.fields = fields
         self.description = description
+        self.custom_facets = custom_facets
 
     @staticmethod
     def from_table(source: Source, table_name: str,
@@ -136,7 +142,8 @@ class StepMetadata:
             location=None,
             inputs: List[Dataset] = None,
             outputs: List[Dataset] = None,
-            context=None
+            context=None,
+            run_facets: List[BaseFacet] = None
     ):
         # TODO: Define a common way across extractors to build the
         # job name for an operator
@@ -145,6 +152,7 @@ class StepMetadata:
         self.inputs = inputs
         self.outputs = outputs
         self.context = context
+        self.run_facets = run_facets
 
         if not inputs:
             self.inputs = []
@@ -152,6 +160,8 @@ class StepMetadata:
             self.outputs = []
         if not context:
             self.context = {}
+        if not run_facets:
+            self.run_facets = []
 
     def __repr__(self):
         return "name: {}\t inputs: {} \t outputs: {}".format(
@@ -161,8 +171,8 @@ class StepMetadata:
 
 
 class BaseExtractor(ABC, LoggingMixin):
-    operator: BaseOperator = None
-    operator_class = None
+    operator_class: Type[BaseOperator] = None
+    operator: operator_class = None
 
     def __init__(self, operator):
         self.operator = operator

--- a/integrations/airflow/marquez_airflow/extractors/bigquery_extractor.py
+++ b/integrations/airflow/marquez_airflow/extractors/bigquery_extractor.py
@@ -40,8 +40,7 @@ from marquez_airflow.utils import (
 # Required to pass marquez server validation.
 from openlineage.facet import BaseFacet
 
-_BIGQUERY_CONN_URL = \
-    'jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443'
+_BIGQUERY_CONN_URL = 'bigquery://https://www.googleapis.com/bigquery/v2:443'
 
 log = logging.getLogger(__name__)
 
@@ -58,8 +57,12 @@ def get_from_nullable_chain(source: Mapping[str, Any], chain: List[str]) -> Opti
 
 @attr.s
 class BigQueryErrorRunFacet(BaseFacet):
+    """
+    Represents errors that can happen during execution of BigqueryExtractor
+    :param clientError: represents errors originating in bigquery client
+    :param parserError: represents errors that happened during parsing SQL provided to bigquery
+    """
     clientError: str = attr.ib(default=None)
-    schemaError: str = attr.ib(default=None)
     parserError: str = attr.ib(default=None)
 
     @staticmethod
@@ -69,6 +72,14 @@ class BigQueryErrorRunFacet(BaseFacet):
 
 @attr.s
 class BigQueryStaticticsRunFacet(BaseFacet):
+    """
+    Facet that represents relevant statistics of bigquery run.
+    :param cached: bigquery caches query results. Rest of the statistics will not be provided
+        for cached queries.
+    :param outputRows: how many rows query produced.
+    :param billedBytes: how many bytes bigquery bills for.
+    :param properties: full property tree of bigquery run.
+    """
     cached: bool = attr.ib()
     outputRows: int = attr.ib(default=None)
     billedBytes: int = attr.ib(default=None)
@@ -81,6 +92,7 @@ class BigQueryStaticticsRunFacet(BaseFacet):
 
 @attr.s
 class SqlContext:
+    """Internal SQL context for holding query parser results"""
     sql: str = attr.ib()
     inputs: Optional[str] = attr.ib(default=None)
     outputs: Optional[str] = attr.ib(default=None)

--- a/integrations/airflow/marquez_airflow/extractors/bigquery_extractor.py
+++ b/integrations/airflow/marquez_airflow/extractors/bigquery_extractor.py
@@ -13,9 +13,11 @@
 import json
 import logging
 import traceback
+from typing import Optional, Any, List, Mapping
 
 from airflow.contrib.operators.bigquery_operator import BigQueryOperator
 from google.cloud import bigquery
+import attr
 
 from marquez_airflow.extractors import (
     BaseExtractor,
@@ -29,22 +31,66 @@ from marquez_airflow.models import (
     DbColumn
 )
 from marquez_airflow.extractors.sql import SqlParser
+from marquez_airflow.schema import GITHUB_LOCATION
 from marquez_airflow.utils import (
     get_job_name
 )
 
 # BIGQUERY DAGs doesn't use this.
 # Required to pass marquez server validation.
+from openlineage.facet import BaseFacet
+
 _BIGQUERY_CONN_URL = \
     'jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443'
 
 log = logging.getLogger(__name__)
 
 
+def get_from_nullable_chain(source: Mapping[str, Any], chain: List[str]) -> Optional[Any]:
+    chain.reverse()
+    try:
+        while chain:
+            source = source.get(chain.pop())
+        return source
+    except AttributeError:
+        return
+
+
+@attr.s
+class BigQueryErrorRunFacet(BaseFacet):
+    clientError: str = attr.ib(default=None)
+    schemaError: str = attr.ib(default=None)
+    parserError: str = attr.ib(default=None)
+
+    @staticmethod
+    def _get_schema() -> str:
+        return GITHUB_LOCATION + "bq-error-run-facet.json"
+
+
+@attr.s
+class BigQueryStaticticsRunFacet(BaseFacet):
+    cached: bool = attr.ib()
+    outputRows: int = attr.ib(default=None)
+    billedBytes: int = attr.ib(default=None)
+    properties: str = attr.ib(default=None)
+
+    @staticmethod
+    def _get_schema() -> str:
+        return GITHUB_LOCATION + "bq-statistics-run-facet.json"
+
+
+@attr.s
+class SqlContext:
+    sql: str = attr.ib()
+    inputs: Optional[str] = attr.ib(default=None)
+    outputs: Optional[str] = attr.ib(default=None)
+    parser_error: Optional[str] = attr.ib(default=None)
+
+
 class BigQueryExtractor(BaseExtractor):
     operator_class = BigQueryOperator
 
-    def __init__(self, operator):
+    def __init__(self, operator: BigQueryOperator):
         super().__init__(operator)
 
     def _source(self) -> Source:
@@ -70,33 +116,37 @@ class BigQueryExtractor(BaseExtractor):
 
         try:
             bigquery_job_id = self._get_xcom_bigquery_job_id(task_instance)
-            context['bigquery.job_id'] = bigquery_job_id
             if bigquery_job_id is None:
                 raise Exception("Xcom could not resolve BigQuery job id." +
                                 "Job may have failed.")
         except Exception as e:
             log.error(f"Cannot retrieve job details from BigQuery.Client. {e}",
                       exc_info=True)
-            context['bigquery.extractor.client_error'] = \
-                f"{e}: {traceback.format_exc()}"
             return StepMetadata(
                 name=get_job_name(task=self.operator),
-                context=context,
                 inputs=None,
-                outputs=None
+                outputs=None,
+                run_facets=[
+                    BigQueryErrorRunFacet(
+                        clientError=f"{e}: {traceback.format_exc()}",
+                        parserError=context.parser_error
+                    )
+                ]
             )
 
         inputs = None
         outputs = None
+        run_facets = []
         try:
             client = bigquery.Client()
             try:
                 job = client.get_job(job_id=bigquery_job_id)
-                job_properties_str = json.dumps(job._properties)
-                context['bigquery.job_properties'] = job_properties_str
+                props = job._properties
 
-                inputs = self._get_input_from_bq(job, context, source, client)
-                outputs = self._get_output_from_bq(job, source, client)
+                run_facets.append(self._get_output_statistics(props))
+
+                inputs = self._get_input_from_bq(props, source, client)
+                outputs = self._get_output_from_bq(props, source, client)
             finally:
                 # Ensure client has close() defined, otherwise ignore.
                 # NOTE: close() was introduced in python-bigquery v1.23.0
@@ -105,26 +155,50 @@ class BigQueryExtractor(BaseExtractor):
         except Exception as e:
             log.error(f"Cannot retrieve job details from BigQuery.Client. {e}",
                       exc_info=True)
-            context['bigquery.extractor.error'] = \
-                f"{e}: {traceback.format_exc()}"
+            run_facets.append(BigQueryErrorRunFacet(
+                clientError=f"{e}: {traceback.format_exc()}",
+                parserError=context.parser_error
+            ))
 
         return StepMetadata(
             name=get_job_name(task=self.operator),
             inputs=inputs,
             outputs=outputs,
-            context=context
+            run_facets=run_facets
         )
 
-    def _get_input_from_bq(self, job, context, source, client):
-        if not job._properties.get('statistics')\
-              or not job._properties.get('statistics').get('query')\
-              or not job._properties.get('statistics').get('query')\
-                  .get('referencedTables'):
-            return None
+    def _get_output_statistics(self, properties):
+        stages = get_from_nullable_chain(properties, ['statistics', 'query', 'queryPlan'])
+        json_props = json.dumps(properties)
 
-        bq_input_tables = job._properties.get('statistics')\
-            .get('query')\
-            .get('referencedTables')
+        if not stages:
+            # we're probably getting cached results
+            if get_from_nullable_chain(properties, ['statistics', 'query', 'cacheHit']):
+                return BigQueryStaticticsRunFacet(cached=True)
+            if get_from_nullable_chain(properties, ['status', 'state']) != "DONE":
+                raise ValueError("Trying to extract data from running bigquery job")
+            raise ValueError(
+                f"BigQuery properties did not have required data: queryPlan - {json_props}"
+            )
+
+        out_stage = stages[-1]
+        out_rows = out_stage.get("recordsWritten", None)
+        billed_bytes = get_from_nullable_chain(properties, [
+            'statistics', 'query', 'totalBytesBilled'
+        ])
+        return BigQueryStaticticsRunFacet(
+            cached=False,
+            outputRows=int(out_rows) if out_rows else None,
+            billedBytes=int(billed_bytes) if billed_bytes else None,
+            properties=json_props
+        )
+
+    def _get_input_from_bq(self, properties, source, client):
+        bq_input_tables = get_from_nullable_chain(properties, [
+            'statistics', 'query', 'referencedTables'
+        ])
+        if not bq_input_tables:
+            return None
 
         input_table_names = [
             self._bq_table_name(bq_t) for bq_t in bq_input_tables
@@ -140,24 +214,19 @@ class BigQueryExtractor(BaseExtractor):
                 )
             ]
         except Exception as e:
-            log.warn(f'Could not extract schema from bigquery. {e}')
-            context['bigquery.extractor.bq_schema_error'] = \
-                f'{e}: {traceback.format_exc()}'
+            log.warning(f'Could not extract schema from bigquery. {e}')
             return [
                 Dataset.from_table(source, table)
                 for table in input_table_names
             ]
 
-    def _get_output_from_bq(self, job, source, client):
-        if not job._properties.get('configuration') or\
-              not job._properties.get('configuration').get('query') or\
-              not job._properties.get('configuration').get('query')\
-                  .get('destinationTable'):
+    def _get_output_from_bq(self, properties, source, client):
+        bq_output_table = get_from_nullable_chain(properties, [
+            'configuration', 'query', 'destinationTable'
+        ])
+        if not bq_output_table:
             return None
 
-        bq_output_table = job._properties.get('configuration') \
-            .get('query') \
-            .get('destinationTable')
         output_table_name = self._bq_table_name(bq_output_table)
         table_schema = self._get_table_safely(output_table_name, client)
         if table_schema:
@@ -166,7 +235,7 @@ class BigQueryExtractor(BaseExtractor):
                 table_schema=table_schema
             )]
         else:
-            log.warn("Could not resolve output table from bq")
+            log.warning("Could not resolve output table from bq")
             return [
                 Dataset.from_table(source, output_table_name)
             ]
@@ -180,23 +249,23 @@ class BigQueryExtractor(BaseExtractor):
 
     def _get_table_schemas(self, tables: [str], client: bigquery.Client) \
             -> [DbTableSchema]:
-        # Avoid querying postgres by returning an empty array
+        # Avoid querying BigQuery by returning an empty array
         # if no tables have been provided.
         if not tables:
             return []
 
         return [self._get_table(table, client) for table in tables]
 
-    def _get_table(self, table: str, client: bigquery.Client) -> DbTableSchema:
+    def _get_table(self, table: str, client: bigquery.Client) -> Optional[DbTableSchema]:
         bq_table = client.get_table(table)
         if not bq_table._properties:
             return
         table = bq_table._properties
 
-        if not table.get('schema') or not table.get('schema').get('fields'):
+        fields = get_from_nullable_chain(table, ['schema', 'fields'])
+        if not fields:
             return
 
-        fields = table.get('schema').get('fields')
         columns = [DbColumn(
             name=fields[i].get('name'),
             type=fields[i].get('type'),
@@ -204,6 +273,7 @@ class BigQueryExtractor(BaseExtractor):
             ordinal_position=i
         ) for i in range(len(fields))]
         self.log.info(DbTableName(table.get('tableReference').get('tableId')))
+
         return DbTableSchema(
             schema_name=table.get('tableReference').get('projectId') + '.' +
             table.get('tableReference').get('datasetId'),
@@ -216,26 +286,25 @@ class BigQueryExtractor(BaseExtractor):
             task_ids=task_instance.task_id, key='job_id')
 
         log.info(f"bigquery_job_id: {bigquery_job_id}")
-
         return bigquery_job_id
 
-    def parse_sql_context(self):
-        context = {
-            'sql': self.operator.sql,
-        }
+    def parse_sql_context(self) -> SqlContext:
         try:
             sql_meta = SqlParser.parse(self.operator.sql, None)
             log.debug(f"bigquery sql parsed and obtained meta: {sql_meta}")
-            context['bigquery.sql.parsed.inputs'] = json.dumps(
-                [in_table.name for in_table in sql_meta.in_tables]
-            )
-            context['bigquery.sql.parsed.outputs'] = json.dumps(
-                [out_table.name for out_table in sql_meta.out_tables]
+            return SqlContext(
+                sql=self.operator.sql,
+                inputs=json.dumps(
+                    [in_table.name for in_table in sql_meta.in_tables]
+                ),
+                outputs=json.dumps(
+                    [out_table.name for out_table in sql_meta.out_tables]
+                )
             )
         except Exception as e:
             log.error(f"Cannot parse sql query. {e}",
                       exc_info=True)
-            context['bigquery.extractor.sql_parser_error'] = \
-                f'{e}: {traceback.format_exc()}'
-        self.log.info(context)
-        return context
+            return SqlContext(
+                sql=self.operator.sql,
+                parser_error=f'{e}: {traceback.format_exc()}'
+            )

--- a/integrations/airflow/marquez_airflow/extractors/bigquery_extractor.py
+++ b/integrations/airflow/marquez_airflow/extractors/bigquery_extractor.py
@@ -170,7 +170,7 @@ class BigQueryExtractor(BaseExtractor):
                 inputs=None,
                 outputs=None,
                 run_facets={
-                    "bigQueryError": BigQueryErrorRunFacet(
+                    "bigQuery_error": BigQueryErrorRunFacet(
                         clientError=f"{e}: {traceback.format_exc()}",
                         parserError=context.parser_error
                     )
@@ -189,14 +189,14 @@ class BigQueryExtractor(BaseExtractor):
                 run_stat_facet, dataset_stat_facet = self._get_output_statistics(props)
 
                 run_facets.update({
-                    "bigQueryStatistics": run_stat_facet
+                    "bigQuery_statistics": run_stat_facet
                 })
 
                 inputs = self._get_input_from_bq(props, client)
                 output = self._get_output_from_bq(props, client)
                 if output:
                     output.custom_facets.update({
-                        "datasetStatistics": dataset_stat_facet
+                        "stats": dataset_stat_facet
                     })
 
             finally:
@@ -208,7 +208,7 @@ class BigQueryExtractor(BaseExtractor):
             log.error(f"Cannot retrieve job details from BigQuery.Client. {e}",
                       exc_info=True)
             run_facets.update({
-                "bigQueryError": BigQueryErrorRunFacet(
+                "bigQuery_error": BigQueryErrorRunFacet(
                     clientError=f"{e}: {traceback.format_exc()}",
                     parserError=context.parser_error
                 )

--- a/integrations/airflow/marquez_airflow/extractors/bigquery_extractor.py
+++ b/integrations/airflow/marquez_airflow/extractors/bigquery_extractor.py
@@ -46,6 +46,25 @@ log = logging.getLogger(__name__)
 
 
 def get_from_nullable_chain(source: Dict[str, Any], chain: List[str]) -> Optional[Any]:
+    """
+    Get object from nested structure of dictionaries, where it's not guaranteed that
+    all keys in the nested structure exist.
+    Intended to replace chain of `dict.get()` statements.
+
+    Example usage:
+    if not job._properties.get('statistics')\
+        or not job._properties.get('statistics').get('query')\
+        or not job._properties.get('statistics').get('query')\
+            .get('referencedTables'):
+        return None
+    result = job._properties.get('statistics').get('query')\
+            .get('referencedTables')
+
+    becomes:
+    result = get_from_nullable_chain(properties, ['statistics', 'query', 'queryPlan'])
+    if not result:
+        return None
+    """
     chain.reverse()
     try:
         while chain:

--- a/integrations/airflow/marquez_airflow/facets.py
+++ b/integrations/airflow/marquez_airflow/facets.py
@@ -1,0 +1,28 @@
+import attr
+
+from airflow.version import version as AIRFLOW_VERSION
+from marquez_airflow.version import VERSION as MARQUEZ_AIRFLOW_VERSION
+
+from openlineage.facet import BaseFacet
+
+
+@attr.s
+class AirflowVersionRunFacet(BaseFacet):
+    operator: str = attr.ib()
+    taskInfo: str = attr.ib()
+    airflowVersion: str = attr.ib()
+    marquezAirflowVersion: str = attr.ib()
+
+    @classmethod
+    def from_task(cls, task):
+        return cls(
+            f'{task.__class__.__module__}.{task.__class__.__name__}',
+            str(task.__dict__),
+            AIRFLOW_VERSION,
+            MARQUEZ_AIRFLOW_VERSION
+        )
+
+
+@attr.s
+class AirflowRunArgsRunFacet(BaseFacet):
+    externalTrigger: bool = attr.ib(default=False)

--- a/integrations/airflow/marquez_airflow/marquez.py
+++ b/integrations/airflow/marquez_airflow/marquez.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import uuid
 from typing import Optional, Dict, Type
 
 from marquez_airflow.extractors import Dataset, StepMetadata

--- a/integrations/airflow/marquez_airflow/marquez.py
+++ b/integrations/airflow/marquez_airflow/marquez.py
@@ -1,6 +1,7 @@
 import os
 import logging
-from typing import Optional
+import uuid
+from typing import Optional, Dict, Type
 
 from marquez_airflow.extractors import Dataset, StepMetadata
 from marquez_airflow.version import VERSION as MARQUEZ_AIRFLOW_VERSION
@@ -8,7 +9,7 @@ from marquez_airflow.version import VERSION as MARQUEZ_AIRFLOW_VERSION
 from openlineage.client import OpenLineageClient
 from openlineage.facet import DocumentationJobFacet, SourceCodeLocationJobFacet, SqlJobFacet, \
     DocumentationDatasetFacet, SchemaDatasetFacet, SchemaField, DataSourceDatasetFacet, \
-    NominalTimeRunFacet, ParentRunFacet
+    NominalTimeRunFacet, ParentRunFacet, BaseFacet
 from openlineage.run import Dataset as OpenLineageDataset, RunEvent, RunState, Run, Job
 
 _DAG_DEFAULT_OWNER = 'anonymous'
@@ -44,6 +45,7 @@ class MarquezAdapter:
             nominal_start_time: str,
             nominal_end_time: str,
             step: Optional[StepMetadata],
+            run_facets: Optional[Dict[str, Type[BaseFacet]]] = None  # Custom run facets
     ) -> str:
         """
         Emits openlineage event of type START
@@ -66,7 +68,7 @@ class MarquezAdapter:
             eventType=RunState.START,
             eventTime=event_time,
             run=self._build_run(
-                run_id, parent_run_id, job_name, nominal_start_time, nominal_end_time
+                run_id, parent_run_id, job_name, nominal_start_time, nominal_end_time, run_facets
             ),
             job=self._build_job(
                 job_name, job_description, code_location, sql
@@ -154,7 +156,8 @@ class MarquezAdapter:
             parent_run_id: Optional[str] = None,
             job_name: Optional[str] = None,
             nominal_start_time: Optional[str] = None,
-            nominal_end_time: Optional[str] = None
+            nominal_end_time: Optional[str] = None,
+            custom_facets: Dict[str, Type[BaseFacet]] = None
     ) -> Run:
         facets = {}
         if nominal_start_time:
@@ -167,6 +170,9 @@ class MarquezAdapter:
                 _DAG_NAMESPACE,
                 job_name
             )})
+
+        if custom_facets:
+            facets.update(custom_facets)
 
         return Run(run_id, facets)
 
@@ -218,6 +224,9 @@ class MarquezAdapter:
                     ]
                 )
             })
+
+        if dataset.custom_facets:
+            facets.update(dataset.custom_facets)
 
         return OpenLineageDataset(
             namespace=_DAG_NAMESPACE,

--- a/integrations/airflow/marquez_airflow/marquez.py
+++ b/integrations/airflow/marquez_airflow/marquez.py
@@ -57,6 +57,7 @@ class MarquezAdapter:
         :param nominal_start_time: scheduled time of dag run
         :param nominal_end_time: following schedule of dag run
         :param step: metadata container with information extracted from operator
+        :param run_facets:
         :return:
         """
         sql = None

--- a/integrations/airflow/marquez_airflow/schema/__init__.py
+++ b/integrations/airflow/marquez_airflow/schema/__init__.py
@@ -1,0 +1,1 @@
+GITHUB_LOCATION = "https://github.com/MarquezProject/marquez/blob/main/integrations/airflow/marquez_airflow/schema/"  # noqa: E501

--- a/integrations/airflow/marquez_airflow/schema/bq-error-run-facet.json
+++ b/integrations/airflow/marquez_airflow/schema/bq-error-run-facet.json
@@ -1,0 +1,31 @@
+
+{
+  "$schema": "http://json-schema.org/schema#",
+  "definitions": {
+    "BigQueryErrorRunFacet": {
+      "allOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/BaseFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "clientError": {
+              "type": "string",
+              "example": "Xcom could not resolve BigQuery job id. Job may have failed"
+            },
+            "schemaError": {
+              "type": "string",
+              "example": "Could not extract schema from bigquery"
+            },
+            "parserError": {
+              "type": "string",
+              "format": "Cannot parse sql query"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/integrations/airflow/marquez_airflow/schema/bq-statistics-dataset-facet.json
+++ b/integrations/airflow/marquez_airflow/schema/bq-statistics-dataset-facet.json
@@ -1,8 +1,7 @@
-
 {
   "$schema": "http://json-schema.org/schema#",
   "definitions": {
-    "BigQueryErrorRunFacet": {
+    "BigQueryStatisticsDatasetFacet": {
       "allOf": [
         {
           "$ref": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/BaseFacet"
@@ -10,15 +9,19 @@
         {
           "type": "object",
           "properties": {
-            "clientError": {
-              "type": "string",
-              "example": "Xcom could not resolve BigQuery job id. Job may have failed"
+            "rowCount": {
+              "type": "int",
+              "example": 20
             },
-            "parserError": {
-              "type": "string",
-              "format": "Cannot parse sql query"
+            "size": {
+              "type": "int",
+              "example": 321
             }
-          }
+          },
+          "required": [
+            "rowCount",
+            "size"
+          ]
         }
       ],
       "type": "object"

--- a/integrations/airflow/marquez_airflow/schema/bq-statistics-run-facet.json
+++ b/integrations/airflow/marquez_airflow/schema/bq-statistics-run-facet.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "definitions": {
+    "AirflowVersionFacet": {
+      "allOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/BaseFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "operator": {
+              "type": "string",
+              "example": "airflow.operators.postgres_operator.PostgresOperator"
+            },
+            "taskInfo": {
+              "type": "string"
+            },
+            "airflowVersion": {
+              "type": "string",
+              "example": "1.10.12"
+            },
+            "marquezAirflowVersion": {
+              "type": "string",
+              "format": "0.12.2"
+            }
+
+          },
+          "required": [
+            "cached"
+          ]
+        }
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/integrations/airflow/marquez_airflow/schema/bq-statistics-run-facet.json
+++ b/integrations/airflow/marquez_airflow/schema/bq-statistics-run-facet.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema#",
   "definitions": {
-    "AirflowVersionFacet": {
+    "BigQueryStatisticsRunFacet": {
       "allOf": [
         {
           "$ref": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/BaseFacet"
@@ -9,22 +9,16 @@
         {
           "type": "object",
           "properties": {
-            "operator": {
-              "type": "string",
-              "example": "airflow.operators.postgres_operator.PostgresOperator"
+            "cached": {
+              "type": "boolean"
             },
-            "taskInfo": {
+            "billedBytes": {
+              "type": "int",
+              "example": 321
+            },
+            "properties": {
               "type": "string"
-            },
-            "airflowVersion": {
-              "type": "string",
-              "example": "1.10.12"
-            },
-            "marquezAirflowVersion": {
-              "type": "string",
-              "format": "0.12.2"
             }
-
           },
           "required": [
             "cached"

--- a/integrations/airflow/marquez_airflow/schema/run-args.json
+++ b/integrations/airflow/marquez_airflow/schema/run-args.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "definitions": {
+    "AirflowRunArgsFacet": {
+      "allOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/BaseFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "externalTrigger": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "externalTrigger"
+          ]
+        }
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/integrations/airflow/marquez_airflow/schema/version-facet.json
+++ b/integrations/airflow/marquez_airflow/schema/version-facet.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "definitions": {
+    "AirflowVersionFacet": {
+      "allOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/BaseFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "operator": {
+              "type": "string",
+              "example": "airflow.operators.postgres_operator.PostgresOperator"
+            },
+            "taskInfo": {
+              "type": "string"
+            },
+            "airflowVersion": {
+              "type": "string",
+              "example": "1.10.12"
+            },
+            "marquezAirflowVersion": {
+              "type": "string",
+              "format": "0.12.2"
+            }
+
+          },
+          "required": [
+            "operator", "taskInfo", "airflowVersion", "marquezAirflowVersion"
+          ]
+        }
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/integrations/airflow/marquez_airflow/schema/version-facet.json
+++ b/integrations/airflow/marquez_airflow/schema/version-facet.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema#",
   "definitions": {
-    "AirflowVersionFacet": {
+    "AirflowVersionRunFacet": {
       "allOf": [
         {
           "$ref": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/BaseFacet"

--- a/integrations/airflow/marquez_airflow/utils.py
+++ b/integrations/airflow/marquez_airflow/utils.py
@@ -151,8 +151,8 @@ def get_job_name(task):
 
 def get_custom_facets(task, is_external_trigger: bool):
     return {
-        "runArgs": AirflowRunArgsRunFacet(is_external_trigger),
-        "airflowVersion": AirflowVersionRunFacet.from_task(task)
+        "airflow_runArgs": AirflowRunArgsRunFacet(is_external_trigger),
+        "airflow_version": AirflowVersionRunFacet.from_task(task)
     }
 
 

--- a/integrations/airflow/marquez_airflow/utils.py
+++ b/integrations/airflow/marquez_airflow/utils.py
@@ -18,7 +18,8 @@ import json
 import airflow
 from airflow.models import Connection
 from airflow.utils.db import provide_session
-from airflow.version import version as AIRFLOW_VERSION
+
+from marquez_airflow.facets import AirflowVersionRunFacet, AirflowRunArgsRunFacet
 
 try:
     # Import from pendulum 1.x version
@@ -26,8 +27,6 @@ try:
 except ImportError:
     # Import for Pendulum 2.x version
     from pendulum import DateTime as Pendulum, from_timestamp
-
-from marquez_airflow.version import VERSION as MARQUEZ_AIRFLOW_VERSION
 
 log = logging.getLogger(__name__)
 _NOMINAL_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
@@ -150,31 +149,17 @@ def get_job_name(task):
     return f'{task.dag_id}.{task.task_id}'
 
 
-def add_airflow_info_to(task, step_metadata):
-    log.debug(f"add_airflow_info_to({task}, {step_metadata})")
-
-    # Add operator info
-    operator = f'{task.__class__.__module__}.{task.__class__.__name__}'
-
-    step_metadata.context['airflow.operator'] = operator
-    step_metadata.context['airflow.task_info'] = str(task.__dict__)
-
-    # Add version info
-    step_metadata.context['airflow.version'] = AIRFLOW_VERSION
-    step_metadata.context['marquez_airflow.version'] = MARQUEZ_AIRFLOW_VERSION
-
-    return step_metadata
+def get_custom_facets(task, is_external_trigger: bool):
+    return {
+        "runArgs": AirflowRunArgsRunFacet(is_external_trigger),
+        "airflowVersion": AirflowVersionRunFacet.from_task(task)
+    }
 
 
 class DagUtils:
 
     def get_execution_date(**kwargs):
         return kwargs.get('execution_date')
-
-    def get_run_args(**kwargs):
-        return {
-            'external_trigger': kwargs.get('external_trigger', False)
-        }
 
     @staticmethod
     def get_start_time(execution_date=None):

--- a/integrations/airflow/openlineage/facet.py
+++ b/integrations/airflow/openlineage/facet.py
@@ -40,14 +40,14 @@ class ParentRunFacet(BaseFacet):
     job: Dict = attr.ib()
 
     @classmethod
-    def create(cls, runId: str, namespace: str, name: str):
+    def create(cls, runId: str, namespace: str, job_name: str):
         return cls(
             run={
                 "runId": runId
             },
             job={
                 "namespace": namespace,
-                "name": name
+                "name": job_name
             }
         )
 

--- a/integrations/airflow/tests/extractors/cached_job_details.json
+++ b/integrations/airflow/tests/extractors/cached_job_details.json
@@ -1,0 +1,41 @@
+{
+    "configuration": {
+        "jobType": "QUERY",
+        "query": {
+            "destinationTable": {
+                "datasetId": "_3db94bc5bd6c409458d99623c999b9e47a898ca9",
+                "projectId": "test",
+                "tableId": "anonbbf6a8444a4f3044cdb8f179e10e4c34c95a866b"
+            },
+            "priority": "INTERACTIVE",
+            "query": "\n        SELECT name, SUM(number) as total_people\n        FROM `bigquery-public-data.usa_names.usa_1910_2013`\n        WHERE state = 'TX'\n        GROUP BY name, state\n        ORDER BY total_people DESC\n        LIMIT 20\n    ",
+            "useLegacySql": false,
+            "writeDisposition": "WRITE_TRUNCATE"
+        }
+    },
+    "etag": "LCS0kVuN4hTbZoEoKHlfLw==",
+    "id": "test:US.4653ac23-e802-4860-9d20-faac0d270582",
+    "jobReference": {
+        "jobId": "4653ac23-e802-4860-9d20-faac0d270582",
+        "location": "US",
+        "projectId": "test"
+    },
+    "kind": "bigquery#job",
+    "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/test/jobs/4653ac23-e802-4860-9d20-faac0d270582?location=US",
+    "statistics": {
+        "creationTime": 1616711902093.0,
+        "endTime": 1616711902378.0,
+        "query": {
+            "cacheHit": true,
+            "statementType": "SELECT",
+            "totalBytesBilled": "0",
+            "totalBytesProcessed": "0"
+        },
+        "startTime": 1616711902361.0,
+        "totalBytesProcessed": "0"
+    },
+    "status": {
+        "state": "DONE"
+    },
+    "user_email": "random@example.com"
+}

--- a/integrations/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integrations/airflow/tests/extractors/test_bigquery_extractor.py
@@ -110,14 +110,14 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
         assert BigQueryStatisticsDatasetFacet(
             rowCount=20,
             size=321
-        ) == step_meta.outputs[0].custom_facets['datasetStatistics']
+        ) == step_meta.outputs[0].custom_facets['stats']
 
         assert len(step_meta.run_facets) == 1
         assert BigQueryStaticticsRunFacet(
             cached=False,
             billedBytes=111149056,
             properties=json.dumps(job_details)
-        ) == step_meta.run_facets['bigQueryStatistics']
+        ) == step_meta.run_facets['bigQuery_statistics']
 
         mock_client.return_value.close.assert_called()
 
@@ -184,7 +184,7 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
         assert step_meta.outputs is not None
 
         assert len(step_meta.run_facets) == 1
-        assert step_meta.run_facets['bigQueryStatistics'] \
+        assert step_meta.run_facets['bigQuery_statistics'] \
                == BigQueryStaticticsRunFacet(cached=True)
 
     @mock.patch('airflow.contrib.operators.bigquery_operator.BigQueryHook')
@@ -229,7 +229,7 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
 
         step_meta = bq_extractor.extract_on_complete(task_instance)
 
-        assert step_meta.run_facets['bigQueryError'] == BigQueryErrorRunFacet(
+        assert step_meta.run_facets['bigQuery_error'] == BigQueryErrorRunFacet(
             clientError=mock.ANY
         )
         mock_client.return_value.get_job.assert_called_once_with(job_id=bq_job_id)

--- a/integrations/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integrations/airflow/tests/extractors/test_bigquery_extractor.py
@@ -97,6 +97,8 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
             'bigquery-public-data.usa_names.usa_1910_2013'
 
         assert step_meta.inputs[0].fields is not None
+        assert step_meta.inputs[0].source.connection_url == \
+               'bigquery:bigquery-public-data.usa_names.usa_1910_2013'
         assert len(step_meta.inputs[0].fields) == 5
         assert step_meta.outputs is not None
         assert len(step_meta.outputs) == 1

--- a/integrations/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integrations/airflow/tests/extractors/test_bigquery_extractor.py
@@ -23,7 +23,10 @@ from airflow.contrib.operators.bigquery_operator import BigQueryOperator
 from airflow.models import TaskInstance, DAG
 from airflow.utils.state import State
 
-from marquez_airflow.extractors.bigquery_extractor import BigQueryExtractor
+from marquez_airflow.extractors.bigquery_extractor import BigQueryExtractor, \
+    BigQueryStaticticsRunFacet, \
+    get_from_nullable_chain, \
+    BigQueryErrorRunFacet
 
 log = logging.getLogger(__name__)
 
@@ -85,8 +88,6 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
         task_instance.run()
 
         step_meta = bq_extractor.extract_on_complete(task_instance)
-        assert step_meta.context['bigquery.job_properties'] \
-            == json.dumps(job_details)
         mock_client.return_value \
             .get_job.assert_called_once_with(job_id=bq_job_id)
 
@@ -103,8 +104,14 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
         assert len(step_meta.outputs[0].fields) == 2
         assert step_meta.outputs[0].name == \
             'bq-airflow-marquez.new_dataset.output_table'
-        assert step_meta.context['sql'] == task.sql
-        assert step_meta.context['bigquery.job_id'] == bq_job_id
+
+        assert len(step_meta.run_facets) == 1
+        assert BigQueryStaticticsRunFacet(
+            cached=False,
+            outputRows=20,
+            billedBytes=111149056,
+            properties=json.dumps(job_details)
+        ) in step_meta.run_facets
 
         mock_client.return_value.close.assert_called()
 
@@ -124,6 +131,54 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
         details = json.loads(f.read())
         f.close()
         return details
+
+    @mock.patch('airflow.contrib.operators.bigquery_operator.BigQueryHook')
+    @mock.patch('google.cloud.bigquery.Client')
+    def test_extract_cached(self, mock_client, mock_hook):
+        bq_job_id = "foo.bq.job_id"
+
+        mock_hook.return_value \
+            .get_conn.return_value \
+            .cursor.return_value \
+            .run_query.return_value = bq_job_id
+
+        job_details = self.read_file_json(
+            "tests/extractors/cached_job_details.json"
+        )
+
+        mock_client.return_value.get_job.return_value._properties = job_details
+        # To make sure hasattr "sees" close and calls it
+        mock_client.return_value.close.return_value
+
+        mock.seal(mock_hook)
+        mock.seal(mock_client)
+
+        dag = DAG(dag_id='TestBigQueryExtractorE2E')
+        task = BigQueryOperator(
+            sql='select first_name, last_name from customers;',
+            task_id="task_id",
+            project_id="project_id",
+            dag_id="dag_id",
+            dag=dag,
+            start_date=timezone.datetime(2016, 2, 1, 0, 0, 0)
+        )
+
+        task_instance = TaskInstance(
+            task=task,
+            execution_date=datetime.utcnow().replace(tzinfo=pytz.utc))
+
+        bq_extractor = BigQueryExtractor(task)
+        steps_meta_extract = bq_extractor.extract()
+        assert steps_meta_extract is None
+
+        task_instance.run()
+
+        step_meta = bq_extractor.extract_on_complete(task_instance)
+        assert step_meta.inputs is not None
+        assert step_meta.outputs is not None
+
+        assert len(step_meta.run_facets) == 1
+        assert step_meta.run_facets.pop() == BigQueryStaticticsRunFacet(cached=True)
 
     @mock.patch('airflow.contrib.operators.bigquery_operator.BigQueryHook')
     @mock.patch('google.cloud.bigquery.Client')
@@ -166,16 +221,16 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
         task_instance.run()
 
         step_meta = bq_extractor.extract_on_complete(task_instance)
-        assert step_meta.context['bigquery.extractor.error'] is not None
-        mock_client.return_value \
-            .get_job.assert_called_once_with(job_id=bq_job_id)
+
+        assert step_meta.run_facets.pop() == BigQueryErrorRunFacet(
+            clientError=mock.ANY
+        )
+        mock_client.return_value.get_job.assert_called_once_with(job_id=bq_job_id)
 
         assert step_meta.inputs is not None
         assert len(step_meta.inputs) == 0
         assert step_meta.outputs is not None
         assert len(step_meta.outputs) == 0
-
-        assert step_meta.context['sql'] == task.sql
 
         mock_client.return_value.close.assert_called()
 
@@ -198,6 +253,14 @@ class TestBigQueryExtractor(unittest.TestCase):
 
         mock_xcom_pull.assert_called_once_with(
             task_ids=self.ti.task_id, key='job_id')
+
+    def test_nullable_chain_fails(self):
+        x = {"first": {"second": {}}}
+        assert get_from_nullable_chain(x, ['first', 'second', 'third']) is None
+
+    def test_nullable_chain_works(self):
+        x = {"first": {"second": {"third": 42}}}
+        assert get_from_nullable_chain(x, ['first', 'second', 'third']) == 42
 
     @staticmethod
     def _get_ti(task):

--- a/integrations/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integrations/airflow/tests/extractors/test_bigquery_extractor.py
@@ -269,6 +269,9 @@ class TestBigQueryExtractor(unittest.TestCase):
         x = {"first": {"second": {"third": 42}}}
         assert get_from_nullable_chain(x, ['first', 'second', 'third']) == 42
 
+        x = {"first": {"second": {"third": 42, "fourth": {"empty": 56}}}}
+        assert get_from_nullable_chain(x, ['first', 'second', 'third']) == 42
+
     @staticmethod
     def _get_ti(task):
         task_instance = TaskInstance(

--- a/integrations/airflow/tests/integration/integration.py
+++ b/integrations/airflow/tests/integration/integration.py
@@ -183,7 +183,6 @@ def check_jobs_meta():
     # TODO: waiting for backend fix
     # assert if_not_exists_job['context']['sql'] is not None
     # assert if_not_exists_job['description'] == DAG_DESCRIPTION
-
     # TODO: no airflow context data yet
     # assert if_not_exists_job['context']['airflow.operator'] == \
     #        'airflow.operators.postgres_operator.PostgresOperator'

--- a/integrations/airflow/tests/test_marquez_dag.py
+++ b/integrations/airflow/tests/test_marquez_dag.py
@@ -725,8 +725,8 @@ def test_marquez_dag_adds_custom_facets(
                     namespace=DAG_NAMESPACE,
                     job_name=f"{DAG_ID}.{TASK_ID_COMPLETED}"
                 ),
-                "runArgs": AirflowRunArgsRunFacet(False),
-                "airflowVersion": AirflowVersionRunFacet(
+                "airflow_runArgs": AirflowRunArgsRunFacet(False),
+                "airflow_version": AirflowVersionRunFacet(
                     operator="airflow.operators.dummy_operator.DummyOperator",
                     taskInfo=mock.ANY,
                     airflowVersion=AIRFLOW_VERSION,

--- a/integrations/airflow/tests/test_marquez_dag.py
+++ b/integrations/airflow/tests/test_marquez_dag.py
@@ -112,7 +112,7 @@ def test_marquez_dag(job_id_mapping, mock_get_or_create_openlineage_client,
     mock_get_or_create_openlineage_client.return_value = mock_marquez_client
     run_id_completed = f"{DAG_RUN_ID}.{TASK_ID_COMPLETED}"
     run_id_failed = f"{DAG_RUN_ID}.{TASK_ID_FAILED}"
-    get_custom_facets.return_value = None
+    get_custom_facets.return_value = {}
 
     # (2) Add task that will be marked as completed
     task_will_complete = DummyOperator(
@@ -327,7 +327,7 @@ def test_marquez_dag_with_extractor(
     # Mock the marquez client method calls
     mock_marquez_client = mock.Mock()
     mock_get_or_create_openlineage_client.return_value = mock_marquez_client
-    get_custom_facets.return_value = None
+    get_custom_facets.return_value = {}
 
     # Add task that will be marked as completed
     task_will_complete = TestFixtureDummyOperator(
@@ -443,7 +443,7 @@ def test_marquez_dag_with_extract_on_complete(
     # Mock the marquez client method calls
     mock_marquez_client = mock.Mock()
     mock_get_or_create_openlineage_client.return_value = mock_marquez_client
-    get_custom_facets.return_value = None
+    get_custom_facets.return_value = {}
 
     # Add task that will be marked as completed
     task_will_complete = TestFixtureDummyOperator(
@@ -599,7 +599,7 @@ def test_marquez_dag_with_extractor_returning_two_steps(
     # Mock the marquez client method calls
     mock_marquez_client = mock.Mock()
     mock_get_or_create_openlineage_client.return_value = mock_marquez_client
-    get_custom_facets.return_value = None
+    get_custom_facets.return_value = {}
 
     # Add task that will be marked as completed
     task_will_complete = TestFixtureDummyOperator(

--- a/integrations/airflow/tests/test_marquez_dag.py
+++ b/integrations/airflow/tests/test_marquez_dag.py
@@ -21,12 +21,14 @@ from airflow.utils.db import provide_session
 from airflow.utils.dates import days_ago
 from airflow.utils import timezone
 from airflow.utils.state import State
+from airflow.version import version as AIRFLOW_VERSION
 
 from marquez_airflow.dag import _EXTRACTORS as _DAG_EXTRACTORS
 from marquez_airflow import DAG
 from marquez_airflow.extractors import (
     BaseExtractor, StepMetadata, Source, Dataset
 )
+from marquez_airflow.facets import AirflowRunArgsRunFacet, AirflowVersionRunFacet
 from marquez_airflow.models import (
     DbTableName,
     DbTableSchema,
@@ -38,7 +40,7 @@ from marquez_airflow.version import VERSION as MARQUEZ_AIRFLOW_VERSION
 from uuid import UUID
 
 from openlineage.facet import NominalTimeRunFacet, SourceCodeLocationJobFacet, \
-    DocumentationJobFacet, DataSourceDatasetFacet, SchemaDatasetFacet, SchemaField
+    DocumentationJobFacet, DataSourceDatasetFacet, SchemaDatasetFacet, SchemaField, ParentRunFacet
 from openlineage.run import RunEvent, RunState, Job, Run, Dataset as OpenLineageDataset
 
 log = logging.getLogger(__name__)
@@ -93,12 +95,12 @@ def test_new_run_id(clear_db_airflow_dags, session=None):
 
 
 # tests a simple workflow with default extraction mechanism
+@mock.patch('marquez_airflow.dag.get_custom_facets')
 @mock.patch('marquez_airflow.marquez.MarquezAdapter.get_or_create_openlineage_client')
 @mock.patch('marquez_airflow.dag.JobIdMapping')
 @provide_session
 def test_marquez_dag(job_id_mapping, mock_get_or_create_openlineage_client,
-                     clear_db_airflow_dags, session=None):
-
+                     get_custom_facets, clear_db_airflow_dags, session=None):
     dag = DAG(
         DAG_ID,
         schedule_interval='@daily',
@@ -110,7 +112,7 @@ def test_marquez_dag(job_id_mapping, mock_get_or_create_openlineage_client,
     mock_get_or_create_openlineage_client.return_value = mock_marquez_client
     run_id_completed = f"{DAG_RUN_ID}.{TASK_ID_COMPLETED}"
     run_id_failed = f"{DAG_RUN_ID}.{TASK_ID_FAILED}"
-    # mock_uuid.side_effect = [run_id_completed, run_id_failed]
+    get_custom_facets.return_value = None
 
     # (2) Add task that will be marked as completed
     task_will_complete = DummyOperator(
@@ -140,7 +142,14 @@ def test_marquez_dag(job_id_mapping, mock_get_or_create_openlineage_client,
         mock.call(RunEvent(
             eventType=RunState.START,
             eventTime=mock.ANY,
-            run=Run(run_id_completed, {"nominalTime": NominalTimeRunFacet(start_time, end_time)}),
+            run=Run(run_id_completed, {
+                "nominalTime": NominalTimeRunFacet(start_time, end_time),
+                "parentRun": ParentRunFacet.create(
+                    runId=DAG_RUN_ID,
+                    namespace=DAG_NAMESPACE,
+                    job_name=f"{DAG_ID}.{TASK_ID_COMPLETED}"
+                )
+            }),
             job=Job("default", f"{DAG_ID}.{TASK_ID_COMPLETED}", {
                 "documentation": DocumentationJobFacet(DAG_DESCRIPTION),
                 "sourceCodeLocation": SourceCodeLocationJobFacet("", completed_task_location)
@@ -152,7 +161,14 @@ def test_marquez_dag(job_id_mapping, mock_get_or_create_openlineage_client,
         mock.call(RunEvent(
             eventType=RunState.START,
             eventTime=mock.ANY,
-            run=Run(run_id_failed, {"nominalTime": NominalTimeRunFacet(start_time, end_time)}),
+            run=Run(run_id_failed, {
+                "nominalTime": NominalTimeRunFacet(start_time, end_time),
+                "parentRun": ParentRunFacet.create(
+                    runId=DAG_RUN_ID,
+                    namespace=DAG_NAMESPACE,
+                    job_name=f"{DAG_ID}.{TASK_ID_FAILED}"
+                )
+            }),
             job=Job("default", f"{DAG_ID}.{TASK_ID_FAILED}", {
                 "documentation": DocumentationJobFacet(DAG_DESCRIPTION),
                 "sourceCodeLocation": SourceCodeLocationJobFacet("", failed_task_location)
@@ -285,12 +301,14 @@ class TestFixtureDummyExtractorOnComplete(BaseExtractor):
 
 
 # test the lifecycle including with extractors
+@mock.patch('marquez_airflow.dag.get_custom_facets')
 @mock.patch('marquez_airflow.marquez.MarquezAdapter.get_or_create_openlineage_client')
 @mock.patch('marquez_airflow.dag.JobIdMapping')
 @provide_session
 def test_marquez_dag_with_extractor(
         job_id_mapping,
         mock_get_or_create_openlineage_client,
+        get_custom_facets,
         clear_db_airflow_dags,
         session=None):
 
@@ -309,6 +327,7 @@ def test_marquez_dag_with_extractor(
     # Mock the marquez client method calls
     mock_marquez_client = mock.Mock()
     mock_get_or_create_openlineage_client.return_value = mock_marquez_client
+    get_custom_facets.return_value = None
 
     # Add task that will be marked as completed
     task_will_complete = TestFixtureDummyOperator(
@@ -337,7 +356,14 @@ def test_marquez_dag_with_extractor(
         RunEvent(
             RunState.START,
             mock.ANY,
-            Run(run_id, {"nominalTime": NominalTimeRunFacet(start_time, end_time)}),
+            Run(run_id, {
+                "nominalTime": NominalTimeRunFacet(start_time, end_time),
+                "parentRun": ParentRunFacet.create(
+                    runId=dag_run_id,
+                    namespace=DAG_NAMESPACE,
+                    job_name=f"{dag_id}.{TASK_ID_COMPLETED}"
+                )
+            }),
             Job("default", f"{dag_id}.{TASK_ID_COMPLETED}", {
                 "documentation": DocumentationJobFacet(DAG_DESCRIPTION),
                 "sourceCodeLocation": SourceCodeLocationJobFacet("", completed_task_location)
@@ -392,12 +418,14 @@ def test_marquez_dag_with_extractor(
     )
 
 
+@mock.patch('marquez_airflow.dag.get_custom_facets')
 @mock.patch('marquez_airflow.marquez.MarquezAdapter.get_or_create_openlineage_client')
 @mock.patch('marquez_airflow.dag.JobIdMapping')
 @provide_session
 def test_marquez_dag_with_extract_on_complete(
         job_id_mapping,
         mock_get_or_create_openlineage_client,
+        get_custom_facets,
         clear_db_airflow_dags,
         session=None):
 
@@ -415,6 +443,7 @@ def test_marquez_dag_with_extract_on_complete(
     # Mock the marquez client method calls
     mock_marquez_client = mock.Mock()
     mock_get_or_create_openlineage_client.return_value = mock_marquez_client
+    get_custom_facets.return_value = None
 
     # Add task that will be marked as completed
     task_will_complete = TestFixtureDummyOperator(
@@ -441,7 +470,12 @@ def test_marquez_dag_with_extract_on_complete(
             eventType=RunState.START,
             eventTime=mock.ANY,
             run=Run(run_id, {
-                "nominalTime": NominalTimeRunFacet(start_time, end_time)
+                "nominalTime": NominalTimeRunFacet(start_time, end_time),
+                "parentRun": ParentRunFacet.create(
+                    runId=dag_run_id,
+                    namespace=DAG_NAMESPACE,
+                    job_name=f"{dag_id}.{TASK_ID_COMPLETED}"
+                )
             }),
             job=Job("default",  f"{dag_id}.{TASK_ID_COMPLETED}", {
                 "documentation": DocumentationJobFacet(DAG_DESCRIPTION),
@@ -539,12 +573,14 @@ class TestFixtureDummyExtractorWithMultipleSteps(BaseExtractor):
 
 
 # test the lifecycle including with extractors
+@mock.patch('marquez_airflow.dag.get_custom_facets')
 @mock.patch('marquez_airflow.marquez.MarquezAdapter.get_or_create_openlineage_client')
 @mock.patch('marquez_airflow.dag.JobIdMapping')
 @provide_session
 def test_marquez_dag_with_extractor_returning_two_steps(
         job_id_mapping,
         mock_get_or_create_openlineage_client,
+        get_custom_facets,
         clear_db_airflow_dags,
         session=None):
 
@@ -563,6 +599,7 @@ def test_marquez_dag_with_extractor_returning_two_steps(
     # Mock the marquez client method calls
     mock_marquez_client = mock.Mock()
     mock_get_or_create_openlineage_client.return_value = mock_marquez_client
+    get_custom_facets.return_value = None
 
     # Add task that will be marked as completed
     task_will_complete = TestFixtureDummyOperator(
@@ -591,7 +628,14 @@ def test_marquez_dag_with_extractor_returning_two_steps(
         RunEvent(
             RunState.START,
             mock.ANY,
-            Run(run_id, {"nominalTime": NominalTimeRunFacet(start_time, end_time)}),
+            Run(run_id, {
+                "nominalTime": NominalTimeRunFacet(start_time, end_time),
+                "parentRun": ParentRunFacet.create(
+                    runId=dag_run_id,
+                    namespace=DAG_NAMESPACE,
+                    job_name=f"{dag_id}.{TASK_ID_COMPLETED}"
+                )
+            }),
             Job("default", f"{dag_id}.{TASK_ID_COMPLETED}", {
                 "documentation": DocumentationJobFacet(DAG_DESCRIPTION),
                 "sourceCodeLocation": SourceCodeLocationJobFacet("", completed_task_location)
@@ -634,3 +678,66 @@ def test_marquez_dag_with_extractor_returning_two_steps(
             []
         )
     )
+
+
+# tests a simple workflow with default custom facet mechanism
+@mock.patch('marquez_airflow.marquez.MarquezAdapter.get_or_create_openlineage_client')
+def test_marquez_dag_adds_custom_facets(
+        mock_get_or_create_openlineage_client,
+        clear_db_airflow_dags,
+):
+
+    dag = DAG(
+        DAG_ID,
+        schedule_interval='@daily',
+        default_args=DAG_DEFAULT_ARGS,
+        description=DAG_DESCRIPTION
+    )
+    # Mock the marquez client method calls
+    mock_openlineage_client = mock.Mock()
+    mock_get_or_create_openlineage_client.return_value = mock_openlineage_client
+    run_id_completed = f"{DAG_RUN_ID}.{TASK_ID_COMPLETED}"
+
+    # Add task that will be marked as completed
+    task_will_complete = DummyOperator(
+        task_id=TASK_ID_COMPLETED,
+        dag=dag
+    )
+    completed_task_location = get_location(task_will_complete.dag.fileloc)
+
+    # Start run
+    dag.create_dagrun(
+        run_id=DAG_RUN_ID,
+        execution_date=DEFAULT_DATE,
+        state=State.RUNNING)
+
+    # Assert emit calls
+    start_time = '2016-01-01T00:00:00.000000Z'
+    end_time = '2016-01-02T00:00:00.000000Z'
+
+    mock_openlineage_client.emit.assert_called_once_with(RunEvent(
+            eventType=RunState.START,
+            eventTime=mock.ANY,
+            run=Run(run_id_completed, {
+                "nominalTime": NominalTimeRunFacet(start_time, end_time),
+                "parentRun": ParentRunFacet.create(
+                    runId=DAG_RUN_ID,
+                    namespace=DAG_NAMESPACE,
+                    job_name=f"{DAG_ID}.{TASK_ID_COMPLETED}"
+                ),
+                "runArgs": AirflowRunArgsRunFacet(False),
+                "airflowVersion": AirflowVersionRunFacet(
+                    operator="airflow.operators.dummy_operator.DummyOperator",
+                    taskInfo=mock.ANY,
+                    airflowVersion=AIRFLOW_VERSION,
+                    marquezAirflowVersion=MARQUEZ_AIRFLOW_VERSION
+                )
+            }),
+            job=Job("default", f"{DAG_ID}.{TASK_ID_COMPLETED}", {
+                "documentation": DocumentationJobFacet(DAG_DESCRIPTION),
+                "sourceCodeLocation": SourceCodeLocationJobFacet("", completed_task_location)
+            }),
+            producer=PRODUCER,
+            inputs=[],
+            outputs=[]
+    ))


### PR DESCRIPTION
Restore functionality where custom information about Airflow version was passed via marquez context, to custom facets.
Add custom bigquery facets: error facet, and run statistics facet.

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>