### PR TITLE
Minor CI config changes to jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,25 +221,15 @@ workflows:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
             branches:
               ignore: /.*/
-          requires:
-            - build-api
-            - build-client-java
-            - build-integration-spark
       - release-python:
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
             branches:
               ignore: /.*/
-          requires:
-            - build-client-python
-            - build-integration-airflow
       - release-docker:
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
             branches:
               ignore: /.*/
-          requires:
-            - test-web
-            - build-api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,23 @@
 version: 2.1
 
 # Define reusable config (see: https://yaml.org/spec/1.2/spec.html#id2765878)
-machine: &machine
-  working_directory: ~/marquez
-  machine: true
-
 checkout_project_root: &checkout_project_root
   # Override checkout path to project root (see: https://circleci.com/docs/2.0/configuration-reference/#checkout)
   checkout:
     path: ~/marquez
 
+# Only trigger CI job on release (=X.Y.Z)
+only-on-release: &only-on-release
+  filters:
+    tags:
+      only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+    branches:
+      ignore: /.*/
+
 jobs:
   build-api:
-    <<: *machine
+    working_directory: ~/marquez
+    machine: true
     environment:
       TESTCONTAINERS_RYUK_DISABLED: true
     steps:
@@ -27,9 +32,9 @@ jobs:
       - run: ./gradlew --no-daemon api:jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)
       - store_test_results:
-          path: build/test-results/test
+          path: api/build/test-results/test
       - store_artifacts:
-          path: build/reports/tests/test
+          path: api/build/reports/tests/test
           destination: test-report
       - save_cache:
           key: v1-api-{{ .Branch }}-{{ .Revision }}
@@ -69,9 +74,9 @@ jobs:
       - run: ./gradlew --no-daemon clients:java:jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)
       - store_test_results:
-          path: build/test-results/test
+          path: client/java/build/test-results/test
       - store_artifacts:
-          path: build/reports/tests/test
+          path: client/java/build/reports/tests/test
           destination: test-report
       - save_cache:
           key: v1-client-java-{{ .Branch }}-{{ .Revision }}
@@ -117,6 +122,9 @@ jobs:
           command: cat integrations/spark/build/test-results/test/TEST-*.xml
       - store_test_results:
           path: integrations/spark/build/test-results/test
+      - store_artifacts:
+          path: integrations/spark/build/reports/tests/test
+          destination: test-report
       - save_cache:
           key: v1-integration-spark-{{ .Branch }}-{{ .Revision }}
           paths:
@@ -148,7 +156,7 @@ jobs:
             - ./*
 
   integration-test-airflow:
-    working_directory: ~/marquez/integrations/airflow/
+    working_directory: ~/marquez/integrations/airflow
     machine: true
     steps:
       - *checkout_project_root
@@ -157,7 +165,8 @@ jobs:
       - run: ./tests/integration/docker/up.sh
 
   release-java:
-    <<: *machine
+    working_directory: ~/marquez
+    machine: true
     steps:
       - checkout
       - run: ./.circleci/get-jdk11.sh
@@ -168,7 +177,8 @@ jobs:
 
 
   release-docker:
-    <<: *machine
+    working_directory: ~/marquez
+    machine: true
     steps:
       - checkout
       - run: ./.circleci/get-jdk11.sh
@@ -177,13 +187,13 @@ jobs:
       - run: ./docker/build-and-push.sh $CIRCLE_TAG
 
   release-python:
+    working_directory: ~/marquez
     docker:
       - image: circleci/python:3.6
     steps:
       - checkout
       - attach_workspace:
           at: /tmp/workspace
-      - run: ls -la /tmp/workspace
       - run: pip install wheel twine
       - run: python -m twine upload --non-interactive --repository pypi /tmp/workspace/python/*
 
@@ -196,40 +206,16 @@ workflows:
       - build-integration-spark
       - test-client-python
       - build-client-python:
-          requires:
-            - test-client-python
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
-            branches:
-              ignore: /.*/
+          <<: *only-on-release
       - test-integration-airflow
+      - integration-test-airflow:
+          requires:
+            - test-integration-airflow
       - build-integration-airflow:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
-            branches:
-              ignore: /.*/
-          requires:
-            - test-integration-airflow
-      - test-integration-airflow:
-          requires:
-            - test-integration-airflow
+          <<: *only-on-release
       - release-java:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
-            branches:
-              ignore: /.*/
+          <<: *only-on-release
       - release-python:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
-            branches:
-              ignore: /.*/
+          <<: *only-on-release
       - release-docker:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
-            branches:
-              ignore: /.*/
+          <<: *only-on-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,9 @@ jobs:
       - run: ./gradlew --no-daemon api:jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)
       - store_test_results:
-          path: api/build/test-results/test
+          path: build/test-results/test
       - store_artifacts:
-          path: api/build/reports/tests/test
+          path: build/reports/tests/test
           destination: test-report
       - save_cache:
           key: v1-api-{{ .Branch }}-{{ .Revision }}
@@ -74,9 +74,9 @@ jobs:
       - run: ./gradlew --no-daemon clients:java:jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)
       - store_test_results:
-          path: client/java/build/test-results/test
+          path: build/test-results/test
       - store_artifacts:
-          path: client/java/build/reports/tests/test
+          path: build/reports/tests/test
           destination: test-report
       - save_cache:
           key: v1-client-java-{{ .Branch }}-{{ .Revision }}
@@ -121,9 +121,9 @@ jobs:
           when: on_fail
           command: cat integrations/spark/build/test-results/test/TEST-*.xml
       - store_test_results:
-          path: integrations/spark/build/test-results/test
+          path: build/test-results/test
       - store_artifacts:
-          path: integrations/spark/build/reports/tests/test
+          path: build/reports/tests/test
           destination: test-report
       - save_cache:
           key: v1-integration-spark-{{ .Branch }}-{{ .Revision }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run: ./gradlew --no-daemon api:jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)
       - store_test_results:
-          path: build/test-results/test
+          path: api/build/test-results/test
       - store_artifacts:
           path: build/reports/tests/test
           destination: test-report
@@ -74,7 +74,7 @@ jobs:
       - run: ./gradlew --no-daemon clients:java:jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)
       - store_test_results:
-          path: build/test-results/test
+          path: clients/java/build/test-results/test
       - store_artifacts:
           path: build/reports/tests/test
           destination: test-report
@@ -120,8 +120,9 @@ jobs:
       - run:
           when: on_fail
           command: cat integrations/spark/build/test-results/test/TEST-*.xml
+      - run: ./gradlew --no-daemon :integrations:spark:jacocoTestReport
       - store_test_results:
-          path: build/test-results/test
+          path: integrations/spark/build/test-results/test
       - store_artifacts:
           path: build/reports/tests/test
           destination: test-report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
           paths:
             - ./*
 
-  test-integration-test-airflow:
+  integration-test-airflow:
     working_directory: ~/marquez/integrations/airflow/
     machine: true
     steps:
@@ -212,7 +212,7 @@ workflows:
               ignore: /.*/
           requires:
             - test-integration-airflow
-      - test-integration-test-airflow:
+      - test-integration-airflow:
           requires:
             - test-integration-airflow
       - release-java:


### PR DESCRIPTION
This PR makes some minor changes to the naming of CI jobs and ensures jobs that run when a release is tagged are triggered by removing the list of `required` jobs. That is, the required list of jobs aren't triggered on a release, resulting in the release jobs never running.