### PR TITLE
Eenable release via CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,8 @@ jobs:
   release-java:
     working_directory: ~/marquez
     machine: true
+    environment:
+      JDK8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
     steps:
       - checkout
       - run: ./.circleci/get-jdk11.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,9 +171,6 @@ jobs:
     steps:
       - checkout
       - run: ./.circleci/get-jdk11.sh
-      - run: ./gradlew --no-daemon -x test :api:release -Prelease.useAutomaticVersion=true
-      - run: ./gradlew --no-daemon -x test :clients:java:release -Prelease.useAutomaticVersion=true
-      - run: ./gradlew --no-daemon -x test :integrations:spark:release -Prelease.useAutomaticVersion=true
       - run: ./gradlew publish
 
 
@@ -182,8 +179,6 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: ./.circleci/get-jdk11.sh
-      - run: ./.circleci/replace-gradle-version.sh $CIRCLE_TAG gradle.properties api/gradle.properties
       - run: ./docker/login.sh
       - run: ./docker/build-and-push.sh $CIRCLE_TAG
 

--- a/api/gradle.properties
+++ b/api/gradle.properties
@@ -1,1 +1,0 @@
-version=0.13.2-SNAPSHOT

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ buildscript {
         classpath 'com.adarshr:gradle-test-logger-plugin:2.1.1'
         classpath 'com.github.jengelman.gradle.plugins:shadow:6.1.0'
         classpath 'com.diffplug.spotless:spotless-plugin-gradle:5.11.0'
-        classpath 'net.researchgate:gradle-release:2.8.1'
     }
 }
 
@@ -39,7 +38,6 @@ subprojects {
     apply plugin: 'com.adarshr.test-logger'
     apply plugin: 'com.github.johnrengelman.shadow'
     apply plugin: "com.diffplug.spotless"
-    apply plugin: 'net.researchgate.release'
 
     compileTestJava.doFirst {
         if (project.hasProperty("jdk8.build") && System.getenv("JDK8_HOME")) {
@@ -65,7 +63,6 @@ subprojects {
     ext {
         lombokVersion = '1.18.18'
         slf4jVersion = '1.7.30'
-        isReleaseVersion = !version.endsWith("SNAPSHOT")
     }
 
     compileJava {
@@ -104,12 +101,6 @@ subprojects {
     task javadocJar(type: Jar, dependsOn: javadoc) {
         classifier 'javadoc'
         from javadoc.destinationDir
-    }
-
-    release {
-        git {
-            requireBranch = 'release-automation'
-        }
     }
 
     spotless {

--- a/clients/java/gradle.properties
+++ b/clients/java/gradle.properties
@@ -1,2 +1,1 @@
-version=0.13.2-SNAPSHOT
 jdk8.build=true

--- a/integrations/spark/gradle.properties
+++ b/integrations/spark/gradle.properties
@@ -1,2 +1,1 @@
-version=0.13.2-SNAPSHOT
 jdk8.build=true

--- a/new-version.sh
+++ b/new-version.sh
@@ -19,12 +19,12 @@
 #   * You're on the 'main' branch
 #   * You've installed 'bump2version'
 #
-# Usage: $ ./new-version.sh <NEW_VERSION> <NEXT_VERSION>
+# Usage: $ ./new-version.sh <RELEASE_VERSION> <NEXT_VERSION>
 
 set -e
 
 usage() {
-  echo "usage: ./$(basename -- ${0}) <NEW_VERSION> <NEXT_VERSION>"
+  echo "usage: ./$(basename -- ${0}) <RELEASE_VERSION> <NEXT_VERSION>"
   exit 1
 }
 
@@ -52,11 +52,11 @@ if [[ $# -eq 0 ]] ; then
   usage
 fi
 
-NEW_VERSION="${1}"
+RELEASE_VERSION="${1}"
 NEXT_VERSION="${2}"
 
 # Ensure valid versions
-VERSIONS=($NEW_VERSION $NEXT_VERSION)
+VERSIONS=($RELEASE_VERSION $NEXT_VERSION)
 for VERSION in "${VERSIONS[@]}"; do
   if [[ ! "${VERSION}" =~ ${SEMVER_REGEX} ]]; then
     echo "Error: Version '${VERSION}' must match '${SEMVER_REGEX}'"
@@ -67,18 +67,18 @@ done
 # (1) Bump python module versions
 PYTHON_MODULES=(clients/python/ integrations/airflow/)
 for PYTHON_MODULE in "${PYTHON_MODULES[@]}"; do
-  (cd "${PYTHON_MODULE}" && bump2version manual --new-version "${NEW_VERSION}")
+  (cd "${PYTHON_MODULE}" && bump2version manual --new-version "${RELEASE_VERSION}")
 done
 
 # (2) Bump java module versions
-sed -i "" "s/version=.*/version=${NEW_VERSION}/g" gradle.properties
+sed -i "" "s/version=.*/version=${RELEASE_VERSION}/g" gradle.properties
 
 # (3) Prepare release commit
-git commit -am "Prepare for release ${NEW_VERSION}"
+git commit -am "Prepare for release ${RELEASE_VERSION}"
 
 # (4) Prepare release tag
 git fetch --all --tags > /dev/null 2>&1
-git tag -a "${NEW_VERSION}" -m "marquez ${NEW_VERSION}"
+git tag -a "${RELEASE_VERSION}" -m "marquez ${RELEASE_VERSION}"
 
 # (5) Prepare next development version
 sed -i "" "s/version=.*/version=${NEXT_VERSION}/g" gradle.properties
@@ -87,6 +87,6 @@ sed -i "" "s/version=.*/version=${NEXT_VERSION}/g" gradle.properties
 git commit -am "Prepare next development version"
 
 # (7) Push commits and tag
-git push origin main && git push origin "${NEW_VERSION}"
+git push origin main && git push origin "${RELEASE_VERSION}"
 
 echo "DONE!"

--- a/new-version.sh
+++ b/new-version.sh
@@ -77,7 +77,7 @@ sed -i "" "s/version=.*/version=${RELEASE_VERSION}/g" gradle.properties
 git commit -am "Prepare for release ${RELEASE_VERSION}"
 
 # (4) Prepare release tag
-git fetch --all --tags > /dev/null 2>&1
+git fetch --all --tags
 git tag -a "${RELEASE_VERSION}" -m "marquez ${RELEASE_VERSION}"
 
 # (5) Prepare next development version

--- a/new-version.sh
+++ b/new-version.sh
@@ -24,9 +24,9 @@ usage() {
   exit 1
 }
 
-readonly SEMVER_REGEX="^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?(-SNAPSHOT)?$" # X.Y.Z
-                                                                        # X.Y.Z-rc.*
-                                                                        # X.Y.Z-SNAPSHOT
+readonly SEMVER_REGEX="^[0-9]+(\.[0-9]+){2}((-rc\.[0-9]+)?|(-SNAPSHOT)?)$" # X.Y.Z
+                                                                           # X.Y.Z-rc.*
+                                                                           # X.Y.Z-SNAPSHOT
 
 # Change working directory to project root
 project_root=$(git rev-parse --show-toplevel)

--- a/new-version.sh
+++ b/new-version.sh
@@ -39,7 +39,7 @@ if [[ ! $(type -P bump2version) ]]; then
 fi
 
 branch=$(git symbolic-ref --short HEAD)
-if [[ "${branch}" == "main" ]]; then
+if [[ "${branch}" != "main" ]]; then
   echo "Error: You may only release on 'main'!"
   exit 1;
 fi

--- a/new-version.sh
+++ b/new-version.sh
@@ -15,6 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Requirements:
+#   * You're on the 'main' branch
+#   * You've installed 'bump2version'
+#
 # Usage: $ ./new-version.sh <NEW_VERSION> <NEXT_VERSION>
 
 set -e

--- a/new-version.sh
+++ b/new-version.sh
@@ -15,12 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Usage: $ ./new-version.sh <VERSION>
+# Usage: $ ./new-version.sh <NEW_VERSION> <NEXT_VERSION>
 
 set -e
 
 usage() {
-  echo "usage: ./$(basename -- ${0}) NEW_VERSION NEXT_VERSION"
+  echo "usage: ./$(basename -- ${0}) <NEW_VERSION> <NEXT_VERSION>"
   exit 1
 }
 

--- a/new-version.sh
+++ b/new-version.sh
@@ -57,7 +57,7 @@ fi
 # Bump python module versions
 PYTHON_MODULES=(clients/python/ integrations/airflow/)
 for PYTHON_MODULE in "${PYTHON_MODULES[@]}"; do
- (cd "${PYTHON_MODULE}" && bump2version manual --new-version "${NEW_VERSION}" --allow-dirty)
+ (cd "${PYTHON_MODULE}" && bump2version manual --new-version "${NEW_VERSION}")
 done
 
 # Bump java module versions

--- a/new-version.sh
+++ b/new-version.sh
@@ -20,11 +20,13 @@
 set -e
 
 usage() {
-  echo "usage: ./$(basename -- ${0}) VERSION"
+  echo "usage: ./$(basename -- ${0}) NEW_VERSION NEXT_VERSION"
   exit 1
 }
 
-readonly SEMVER_REGEX="^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$" # X.Y.Z-rc.*
+readonly SEMVER_REGEX="^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?(-SNAPSHOT)?$" # X.Y.Z
+                                                                        # X.Y.Z-rc.*
+                                                                        # X.Y.Z-SNAPSHOT
 
 # Change working directory to project root
 project_root=$(git rev-parse --show-toplevel)
@@ -32,12 +34,12 @@ cd "${project_root}"
 
 # Verify bump2version is installed
 if [[ ! $(type -P bump2version) ]]; then
- echo "bump2version not installed! Please see https://github.com/c4urself/bump2version#installation"
- exit 1
+  echo "bump2version not installed! Please see https://github.com/c4urself/bump2version#installation"
+  exit 1
 fi
 
 branch=$(git symbolic-ref --short HEAD)
-if [[ "${branch}" != "main" ]]; then
+if [[ "${branch}" == "main" ]]; then
   echo "Error: You may only release on 'main'!"
   exit 1;
 fi
@@ -47,20 +49,40 @@ if [[ $# -eq 0 ]] ; then
 fi
 
 NEW_VERSION="${1}"
+NEXT_VERSION="${2}"
 
-# Ensure valid version
-if [[ ! "${NEW_VERSION}" =~ ${SEMVER_REGEX} ]]; then
-  echo "Error: Version '${NEW_VERSION}' must match '${SEMVER_REGEX}'"
-  exit 1
-fi
-
-# Bump python module versions
-PYTHON_MODULES=(clients/python/ integrations/airflow/)
-for PYTHON_MODULE in "${PYTHON_MODULES[@]}"; do
- (cd "${PYTHON_MODULE}" && bump2version manual --new-version "${NEW_VERSION}")
+# Ensure valid versions
+VERSIONS=($NEW_VERSION $NEXT_VERSION)
+for VERSION in "${VERSIONS[@]}"; do
+  if [[ ! "${VERSION}" =~ ${SEMVER_REGEX} ]]; then
+    echo "Error: Version '${VERSION}' must match '${SEMVER_REGEX}'"
+    exit 1
+  fi
 done
 
-# Bump java module versions
+# (1) Bump python module versions
+PYTHON_MODULES=(clients/python/ integrations/airflow/)
+for PYTHON_MODULE in "${PYTHON_MODULES[@]}"; do
+  (cd "${PYTHON_MODULE}" && bump2version manual --new-version "${NEW_VERSION}")
+done
+
+# (2) Bump java module versions
 sed -i "" "s/version=.*/version=${NEW_VERSION}/g" gradle.properties
+
+# (3) Prepare release commit
+git commit -am "Prepare for release ${NEW_VERSION}"
+
+# (4) Prepare release tag
+git fetch --all --tags > /dev/null 2>&1
+git tag -a "${NEW_VERSION}" -m "marquez ${NEW_VERSION}"
+
+# (5) Prepare next development version
+sed -i "" "s/version=.*/version=${NEXT_VERSION}/g" gradle.properties
+
+# (6) Prepare next development version commit
+git commit -am "Prepare next development version"
+
+# (7) Push commits and tag
+git push origin main && git push origin "${NEW_VERSION}"
 
 echo "DONE!"


### PR DESCRIPTION
This PR updates the usage [`new-release.sh`](https://github.com/MarquezProject/marquez/blob/main/new-version.sh) with the following:

```
$ ./new-version.sh
usage: ./new-version.sh <NEW_VERSION> <NEXT_VERSION>
```

where `<NEW_VERSION>` is the version of Marquez to release, and `<NEXT_VERSION>` is the next development version.

**The scripts performs the following release steps:**

1. Bump python module versions
2. Bump java module versions
3. Prepare release commit
4. Prepare release tag
5. Prepare next development version
6. Prepare next development version commit
7. Push commits and tag

After step `7`, the CI will kickoff the release pipeline triggered only via a tag. Note, since we now manage bumping versions via a script, I've removed the plugin [`gradle-release`](https://github.com/researchgate/gradle-release).