### PR TITLE
Add args to new-version.sh

### DIFF
--- a/new-version.sh
+++ b/new-version.sh
@@ -19,12 +19,18 @@
 #   * You're on the 'main' branch
 #   * You've installed 'bump2version'
 #
-# Usage: $ ./new-version.sh <RELEASE_VERSION> <NEXT_VERSION>
+# Usage: $ ./new-version.sh --release-version RELEASE_VERSION --next-version NEXT_VERSION
 
 set -e
 
 usage() {
-  echo "usage: ./$(basename -- ${0}) <RELEASE_VERSION> <NEXT_VERSION>"
+  echo "usage: ./$(basename -- "${0}") --release-version RELEASE_VERSION --next-version NEXT_VERSION"
+  echo ""
+  echo "a script used to release Marquez"
+  echo ""
+  echo "arguments:"
+  echo "  --release-version RELEASE_VERSION       the release version (ex: X.Y.Z, X.Y.Z-rc.*)"
+  echo "  --next-version NEXT_VERSION             the next version (ex: X.Y.Z, X.Y.Z-SNAPSHOT)"
   exit 1
 }
 
@@ -44,7 +50,7 @@ fi
 
 branch=$(git symbolic-ref --short HEAD)
 if [[ "${branch}" != "main" ]]; then
-  echo "Error: You may only release on 'main'!"
+  echo "error: you may only release on 'main'!"
   exit 1;
 fi
 
@@ -52,8 +58,24 @@ if [[ $# -eq 0 ]] ; then
   usage
 fi
 
-RELEASE_VERSION="${1}"
-NEXT_VERSION="${2}"
+while [ $# -gt 0 ]; do
+  case $1 in
+    '--release-version'|-r)
+       shift
+       RELEASE_VERSION="${1}"
+       ;;
+    '--next-version'|-n)
+       shift
+       NEXT_VERSION="${1}"
+       ;;
+    '--help'|-h)
+       usage
+       ;;
+    *) exit 1
+       ;;
+  esac
+  shift
+done
 
 # Append '-SNAPSHOT' to 'NEXT_VERSION' if not a release candidate, or missing
 if [[ ! "${NEXT_VERSION}" == *-rc.? &&

--- a/new-version.sh
+++ b/new-version.sh
@@ -56,8 +56,8 @@ RELEASE_VERSION="${1}"
 NEXT_VERSION="${2}"
 
 # Append '-SNAPSHOT' to 'NEXT_VERSION' if not a release candidate, or missing
-if [[ ! "${NEXT_VERSION}" = *-rc.? &&
-      ! "${NEXT_VERSION}" = *-SNAPSHOT ]]; then
+if [[ ! "${NEXT_VERSION}" == *-rc.? &&
+      ! "${NEXT_VERSION}" == *-SNAPSHOT ]]; then
   NEXT_VERSION="${NEXT_VERSION}-SNAPSHOT"
 fi
 

--- a/new-version.sh
+++ b/new-version.sh
@@ -24,13 +24,23 @@
 set -e
 
 usage() {
-  echo "usage: ./$(basename -- "${0}") --release-version RELEASE_VERSION --next-version NEXT_VERSION"
+  echo "Usage: ./$(basename -- "${0}") --release-version RELEASE_VERSION --next-version NEXT_VERSION"
   echo ""
-  echo "a script used to release Marquez"
+  echo "A script used to release Marquez"
   echo ""
-  echo "arguments:"
-  echo "  --release-version RELEASE_VERSION       the release version (ex: X.Y.Z, X.Y.Z-rc.*)"
-  echo "  --next-version NEXT_VERSION             the next version (ex: X.Y.Z, X.Y.Z-SNAPSHOT)"
+  echo "Examples:"
+  echo "  # Bump version ('-SNAPSHOT' will automatically be appended to '0.0.2')"
+  echo "  ./new-version.sh -r 0.0.1 -n 0.0.2"
+  echo ""
+  echo "  # Bump version (with '-SNAPSHOT' already appended to '0.0.2')"
+  echo "  ./new-version.sh -r 0.0.1 -n 0.0.2-SNAPSHOT"
+  echo ""
+  echo "  # Bump release candidate"
+  echo "  $ ./new-version.sh -r 0.0.1-rc.1 -n 0.0.2-rc.2"
+  echo ""
+  echo "Arguments:"
+  echo "  -r, --release-version string       the release version (ex: X.Y.Z, X.Y.Z-rc.*)"
+  echo "  -n, --next-version string          the next version (ex: X.Y.Z, X.Y.Z-SNAPSHOT)"
   exit 1
 }
 

--- a/new-version.sh
+++ b/new-version.sh
@@ -55,6 +55,12 @@ fi
 RELEASE_VERSION="${1}"
 NEXT_VERSION="${2}"
 
+# Append '-SNAPSHOT' to 'NEXT_VERSION' if not a release candidate, or missing
+if [[ ! "${NEXT_VERSION}" = *-rc.? &&
+      ! "${NEXT_VERSION}" = *-SNAPSHOT ]]; then
+  NEXT_VERSION="${NEXT_VERSION}-SNAPSHOT"
+fi
+
 # Ensure valid versions
 VERSIONS=($RELEASE_VERSION $NEXT_VERSION)
 for VERSION in "${VERSIONS[@]}"; do
@@ -76,7 +82,7 @@ sed -i "" "s/version=.*/version=${RELEASE_VERSION}/g" gradle.properties
 # (3) Prepare release commit
 git commit -am "Prepare for release ${RELEASE_VERSION}"
 
-# (4) Prepare release tag
+# (4) Pull latest tags, then prepare release tag
 git fetch --all --tags
 git tag -a "${RELEASE_VERSION}" -m "marquez ${RELEASE_VERSION}"
 


### PR DESCRIPTION
This PR adds a helpful message (with examples) to [`new-version.sh`](https://github.com/MarquezProject/marquez/blob/main/new-version.sh). This PR also adds named arguments for usability: 

```
$ ./new-version.sh --help
Usage: ./new-version.sh --release-version RELEASE_VERSION --next-version NEXT_VERSION

A script used to release Marquez

Examples:
  # Bump version ('-SNAPSHOT' will automatically be appended to '0.0.2')
  ./new-version.sh -r 0.0.1 -n 0.0.2

  # Bump version (with '-SNAPSHOT' already appended to '0.0.2')
  ./new-version.sh -r 0.0.1 -n 0.0.2-SNAPSHOT

  # Bump release candidate
  $ ./new-version.sh -r 0.0.1-rc.1 -n 0.0.2-rc.2

Arguments:
  -r, --release-version string       the release version (ex: X.Y.Z, X.Y.Z-rc.*)
  -n, --next-version string          the next version (ex: X.Y.Z, X.Y.Z-SNAPSHOT)
```