### PR TITLE
Unify common deps gradle

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -27,9 +27,9 @@ java {
 }
 
 ext {
-    dropwizardVersion = '2.0.20'
     jdbi3Version = '3.18.0'
     prometheusVersion = '0.10.0'
+    testcontainersVersion = '1.15.2'
 }
 
 dependencies {
@@ -51,20 +51,15 @@ dependencies {
     compile 'org.postgresql:postgresql:42.2.19'
     compile 'com.graphql-java:graphql-java:16.2'
     compile 'com.graphql-java-kickstart:graphql-java-servlet:11.1.0'
-    compileOnly "org.projectlombok:lombok:${lombokVersion}"
-    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
     testCompile "io.dropwizard:dropwizard-testing:${dropwizardVersion}"
     testCompile "org.jdbi:jdbi3-testing:${jdbi3Version}"
-    testCompile 'org.junit.jupiter:junit-jupiter:5.7.1'
-    testCompile 'org.junit.vintage:junit-vintage-engine:5.7.1'
-    testCompile 'org.assertj:assertj-core:3.19.0'
-    testCompile 'org.mockito:mockito-core:3.8.0'
-    testCompile 'org.mockito:mockito-junit-jupiter:3.8.0'
-    testCompile 'org.testcontainers:postgresql:1.15.2'
-    testCompile "org.testcontainers:junit-jupiter:1.15.2"
+    testCompile "org.junit.vintage:junit-vintage-engine:${junit5Version}"
+    testCompile "org.testcontainers:postgresql:${testcontainersVersion}"
+    testCompile "org.testcontainers:junit-jupiter:${testcontainersVersion}"
 
 }
+
 task testUnit(type: Test) {
     useJUnitPlatform {
         includeTags 'UnitTests'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     compile 'com.google.guava:guava:30.1-jre'
     compile 'org.dhatim:dropwizard-sentry:2.0.20'
     compile 'org.flywaydb:flyway-core:6.5.7'
-    compile 'org.postgresql:postgresql:42.2.19'
+    compile "org.postgresql:postgresql:${postgresqlVersion}"
     compile 'com.graphql-java:graphql-java:16.2'
     compile 'com.graphql-java-kickstart:graphql-java-servlet:11.1.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,12 +39,6 @@ subprojects {
     apply plugin: 'com.github.johnrengelman.shadow'
     apply plugin: "com.diffplug.spotless"
 
-    compileTestJava.doFirst {
-        if (project.hasProperty("jdk8.build") && System.getenv("JDK8_HOME")) {
-            println "Switching build to JDK8 installation at ${System.getenv('JDK8_HOME')}"
-        }
-    }
-
     project(':api') {
         apply plugin: 'application'
         archivesBaseName = 'marquez-api'
@@ -61,8 +55,25 @@ subprojects {
     }
 
     ext {
+        assertjVersion = '3.19.0'
+        dropwizardVersion = '2.0.20'
+        junit5Version = '5.7.1'
         lombokVersion = '1.18.18'
+        mockitoVersion = '3.8.0'
         slf4jVersion = '1.7.30'
+        isReleaseVersion = !version.endsWith('SNAPSHOT')
+    }
+
+    dependencies {
+        compileOnly "org.projectlombok:lombok:${lombokVersion}"
+        annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+
+        testCompile "org.assertj:assertj-core:${assertjVersion}"
+        testCompile "org.junit.jupiter:junit-jupiter:${junit5Version}"
+        testCompile "org.mockito:mockito-core:${mockitoVersion}"
+        testCompile "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
+        testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+        testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     }
 
     compileJava {
@@ -73,6 +84,12 @@ subprojects {
             options.fork = true
             sourceCompatibility = JavaVersion.VERSION_1_8
             targetCompatibility = JavaVersion.VERSION_1_8
+        }
+    }
+
+    compileTestJava.doFirst {
+        if (project.hasProperty("jdk8.build") && System.getenv("JDK8_HOME")) {
+            println "Switching build to JDK8 installation at ${System.getenv('JDK8_HOME')}"
         }
     }
 
@@ -120,7 +137,6 @@ subprojects {
     }
 
     def reportsDir = "${buildDir}/reports";
-
     def coverageDir = "${reportsDir}/coverage";
 
     jacoco {

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ subprojects {
         lombokVersion = '1.18.18'
         mockitoVersion = '3.8.0'
         slf4jVersion = '1.7.30'
+        postgresqlVersion = '42.2.19'
         isReleaseVersion = !version.endsWith('SNAPSHOT')
     }
 

--- a/clients/java/build.gradle
+++ b/clients/java/build.gradle
@@ -25,18 +25,12 @@ java {
 }
 
 dependencies {
+    implementation "io.dropwizard:dropwizard-jackson:${dropwizardVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
-    implementation 'io.dropwizard:dropwizard-jackson:2.0.20'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'org.apache.maven:maven-archiver:3.5.1'
-    compileOnly "org.projectlombok:lombok:${lombokVersion}"
-    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
     testImplementation "org.slf4j:slf4j-simple:${slf4jVersion}"
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'
-    testImplementation 'org.assertj:assertj-core:3.19.0'
-    testImplementation 'org.mockito:mockito-core:3.8.0'
-    testImplementation 'org.mockito:mockito-junit-jupiter:3.8.0'
 }
 
 task testUnit(type: Test) {

--- a/integrations/spark/build.gradle
+++ b/integrations/spark/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     testImplementation "org.apache.spark:spark-core_2.11:${sparkVersion}"
     testImplementation "org.apache.spark:spark-sql_2.11:${sparkVersion}"
     testImplementation platform('org.junit:junit-bom:5.7.1')
-    testImplementation 'org.postgresql:postgresql:42.2.19'
+    testImplementation "org.postgresql:postgresql:${postgresqlVersion}"
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
 }
 

--- a/integrations/spark/build.gradle
+++ b/integrations/spark/build.gradle
@@ -24,30 +24,30 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+ext {
+    bytebuddyVersion = '1.10.21'
+    sparkVersion = '2.4.7'
+    jacksonVersion = '2.12.2'
+}
+
 dependencies {
     implementation 'org.javassist:javassist:3.27.0-GA'
-    compileOnly 'org.apache.spark:spark-core_2.11:2.4.7'
-    compileOnly 'org.apache.spark:spark-sql_2.11:2.4.7'
     implementation 'com.github.ok2c.hc5:hc5-async-json:0.2.1'
-    compileOnly 'org.projectlombok:lombok:1.18.18'
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.0.3'
-    testImplementation 'com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:0.19.1'
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
+    compileOnly "org.apache.spark:spark-core_2.11:${sparkVersion}"
+    compileOnly "org.apache.spark:spark-sql_2.11:${sparkVersion}"
 
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.2'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.12.2'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.1'
-    testImplementation 'net.bytebuddy:byte-buddy-agent:1.10.21'
-    testImplementation 'net.bytebuddy:byte-buddy-dep:1.10.21'
-    testImplementation 'org.apache.spark:spark-core_2.11:2.4.7'
-    testImplementation 'org.apache.spark:spark-sql_2.11:2.4.7'
-    testImplementation 'org.mockito:mockito-core:3.8.0'
-    testImplementation(platform('org.junit:junit-bom:5.7.1'))
-    testImplementation('org.junit.jupiter:junit-jupiter:5.7.1')
+    testImplementation 'com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:0.19.1'
+    testImplementation "net.bytebuddy:byte-buddy-agent:${bytebuddyVersion}"
+    testImplementation "net.bytebuddy:byte-buddy-dep:${bytebuddyVersion}"
+    testImplementation "org.apache.spark:spark-core_2.11:${sparkVersion}"
+    testImplementation "org.apache.spark:spark-sql_2.11:${sparkVersion}"
+    testImplementation platform('org.junit:junit-bom:5.7.1')
     testImplementation 'org.postgresql:postgresql:42.2.19'
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
-    testCompile 'org.projectlombok:lombok:1.18.18'
-    annotationProcessor "org.projectlombok:lombok:1.18.16"
-    testAnnotationProcessor "org.projectlombok:lombok:1.18.16"
 }
 
 test {


### PR DESCRIPTION
This PR moves common deps to the root `build.gradle` to ensure all java modules use the same versions (and are global to all modules).