### PR TITLE
ci: use context on deploy jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,10 @@ only-on-release: &only-on-release
     branches:
       ignore: /.*/
 
+deploy-context: &deploy-context
+  context:
+    - deploy
+
 jobs:
   build-api:
     working_directory: ~/marquez
@@ -213,7 +217,10 @@ workflows:
           <<: *only-on-release
       - release-java:
           <<: *only-on-release
+          <<: *deploy-context
       - release-python:
           <<: *only-on-release
+          <<: *deploy-context
       - release-docker:
           <<: *only-on-release
+          <<: *deploy-context


### PR DESCRIPTION
Release jobs should be the only ones that have access to deploy environment values.

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>