### PR TITLE
Rewrite lineage IO sql queries to avoid job_versions_io_mapping_* tables

### DIFF
--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -44,12 +44,17 @@ public interface LineageDao {
    * @return
    */
   @SqlQuery(
+      // dataset_ids: all the input and output datasets of the current version of the specified jobs
       "WITH dataset_ids AS (\n"
           + "    SELECT DISTINCT dataset_uuid\n"
           + "        FROM jobs j\n"
           + "        INNER JOIN job_versions_io_mapping io ON io.job_version_uuid=j.current_version_uuid\n"
           + "        WHERE j.uuid IN (<jobIds>)\n"
           + ")\n"
+          // SELECT DISTINCT j.uuid:
+          // all the jobs that have ever read from or written to those datasets.
+          // note that this includes previous versions of jobs that no longer interact with those
+          // datasets
           + "SELECT DISTINCT j.uuid\n"
           + "    FROM job_versions_io_mapping io\n"
           + "    INNER JOIN dataset_ids ON io.dataset_uuid=dataset_ids.dataset_uuid\n"
@@ -59,6 +64,9 @@ public interface LineageDao {
 
   @SqlQuery("SELECT uuid from jobs where name = :jobName and namespace_name = :namespace")
   Optional<UUID> getJobUuid(String jobName, String namespace);
+
+  // TODO- the input and output dataset methods below can be combined into a single SQL query
+  // that fetches input and output edges for the returned datasets all at once.
 
   /**
    * Return a list of datasets that are either inputs or outputs of the specified job ids and the

--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -33,81 +33,85 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 @RegisterRowMapper(JobDataMapper.class)
 @RegisterRowMapper(RunMapper.class)
 public interface LineageDao {
+
+  /**
+   * Fetch all of the jobs that consume or produce the datasets that are consumed or produced by the
+   * input jobIds. This returns a single layer from the BFS using datasets as edges. Jobs that have
+   * no input or output datasets will have no results. Jobs that have no upstream producers or
+   * downstream consumers will have the original jobIds returned.
+   *
+   * @param jobIds
+   * @return
+   */
   @SqlQuery(
-      "select distinct io_in_2.job_uuid\n"
-          + "from jobs j\n"
-          + "inner join job_versions_io_mapping_inputs io_in on io_in.job_version_uuid = j.current_version_uuid\n"
-          + "inner join job_versions_io_mapping_inputs io_in_2 on io_in.dataset_uuid = io_in_2.dataset_uuid\n"
-          + "where j.uuid in (<jobIds>)\n"
-          + "UNION \n"
-          + "select distinct io_out_2.job_uuid\n"
-          + "from jobs j\n"
-          + "inner join job_versions_io_mapping_outputs io_out on io_out.job_version_uuid = j.current_version_uuid\n"
-          + "inner join job_versions_io_mapping_outputs io_out_2 on io_out_2.dataset_uuid = io_out.dataset_uuid\n"
-          + "where j.uuid in (<jobIds>)\n"
-          + "UNION \n"
-          + "select distinct io_out.job_uuid\n"
-          + "from jobs j\n"
-          + "inner join job_versions_io_mapping_inputs io_in on io_in.job_version_uuid = j.current_version_uuid \n"
-          + "inner join job_versions_io_mapping_outputs io_out on io_out.dataset_uuid = io_in.dataset_uuid \n"
-          + "where j.uuid in (<jobIds>)\n"
-          + "UNION \n"
-          + "select distinct io_in.job_uuid\n"
-          + "from jobs j\n"
-          + "inner join job_versions_io_mapping_outputs io_out on io_out.job_version_uuid = j.current_version_uuid\n"
-          + "inner join job_versions_io_mapping_inputs io_in on io_in.dataset_uuid = io_out.dataset_uuid\n"
-          + "where j.uuid in (<jobIds>)")
+      "WITH dataset_ids AS (\n"
+          + "    SELECT DISTINCT dataset_uuid\n"
+          + "        FROM jobs j\n"
+          + "        INNER JOIN job_versions_io_mapping io ON io.job_version_uuid=j.current_version_uuid\n"
+          + "        WHERE j.uuid IN (<jobIds>)\n"
+          + ")\n"
+          + "SELECT DISTINCT j.uuid\n"
+          + "    FROM job_versions_io_mapping io\n"
+          + "    INNER JOIN dataset_ids ON io.dataset_uuid=dataset_ids.dataset_uuid\n"
+          + "    INNER JOIN job_versions jv ON jv.uuid=io.job_version_uuid\n"
+          + "    INNER JOIN jobs j ON j.uuid=jv.job_uuid")
   Set<UUID> getLineage(@BindList Set<UUID> jobIds);
 
   @SqlQuery("SELECT uuid from jobs where name = :jobName and namespace_name = :namespace")
   Optional<UUID> getJobUuid(String jobName, String namespace);
 
+  /**
+   * Return a list of datasets that are either inputs or outputs of the specified job ids and the
+   * <i>output</i> edges of those datasets. Jobs that have no inputs or outputs will return an empty
+   * list.
+   *
+   * @param jobIds
+   * @return
+   */
   @SqlQuery(
-      "select ds.*, ARRAY(select m.uuid) as job_ids, dv.fields\n"
-          + "from datasets ds\n"
-          + "inner join (\n"
-          + "select distinct io_in_2.job_uuid as uuid, io_in_2.dataset_uuid\n"
-          + "from jobs j\n"
-          + "inner join job_versions_io_mapping_inputs io_in on io_in.job_version_uuid = j.current_version_uuid\n"
-          + "inner join job_versions_io_mapping_inputs io_in_2 on io_in.dataset_uuid = io_in_2.dataset_uuid\n"
-          + "where j.uuid in (<jobIds>)\n"
-          + "UNION\n"
-          + "select distinct j.uuid as uuid, io_in.dataset_uuid\n"
-          + "from jobs j\n"
-          + "inner join job_versions_io_mapping_inputs io_in on io_in.job_version_uuid = j.current_version_uuid\n"
-          + "where j.uuid in (<jobIds>)\n"
-          + "UNION\n"
-          + "select distinct io_in.job_uuid as uuid, io_in.dataset_uuid\n"
-          + "from jobs j\n"
-          + "inner join job_versions_io_mapping_outputs io_out on io_out.job_version_uuid = j.current_version_uuid\n"
-          + "inner join job_versions_io_mapping_inputs io_in on io_in.dataset_uuid = io_out.dataset_uuid\n"
-          + "where j.uuid in (<jobIds>)"
-          + ") m on m.dataset_uuid = ds.uuid\n"
-          + "left outer join dataset_versions dv on dv.uuid = ds.current_version_uuid\n")
+      "WITH dataset_ids AS (\n"
+          + "    SELECT DISTINCT dataset_uuid\n"
+          + "    FROM jobs j\n"
+          + "    INNER JOIN job_versions_io_mapping io ON io.job_version_uuid=j.current_version_uuid\n"
+          + "    WHERE j.uuid IN (<jobIds>)\n"
+          + ")\n"
+          + "SELECT ds.*, COALESCE(job_ids, '{}') AS job_ids, dv.fields\n"
+          + "FROM datasets ds\n"
+          + "    INNER JOIN dataset_ids ON dataset_ids.dataset_uuid=ds.uuid\n"
+          + "    LEFT JOIN (SELECT dataset_uuid, ARRAY_AGG(DISTINCT v.job_uuid) AS job_ids\n"
+          + "        FROM job_versions_io_mapping io2\n"
+          + "        INNER JOIN job_versions v on io2.job_version_uuid = v.uuid\n"
+          + "        WHERE io2.io_type='INPUT'\n"
+          + "        GROUP BY dataset_uuid\n"
+          + "        ) io ON io.dataset_uuid=ds.uuid\n"
+          + "    LEFT JOIN dataset_versions dv on dv.uuid = ds.current_version_uuid;")
   List<DatasetData> getInputDatasetsFromJobIds(@BindList Set<UUID> jobIds);
 
+  /**
+   * Return a list of datasets that are either inputs or outputs of the specified job ids and the
+   * <i>input</i> edges of those datasets. Jobs that have no inputs or outputs will return an empty
+   * list.
+   *
+   * @param jobIds
+   * @return
+   */
   @SqlQuery(
-      "select ds.*, ARRAY(select m.uuid) as job_ids, dv.fields\n"
-          + "from datasets ds\n"
-          + "inner join (\n"
-          + "select distinct io_out_2.job_uuid as uuid, io_out_2.dataset_uuid\n"
-          + "from jobs j\n"
-          + "inner join job_versions_io_mapping_outputs io_out on io_out.job_version_uuid = j.current_version_uuid\n"
-          + "inner join job_versions_io_mapping_outputs io_out_2 on io_out_2.dataset_uuid = io_out.dataset_uuid\n"
-          + "where j.uuid in (<jobIds>)\n"
-          + "UNION\n"
-          + "select distinct io_out.job_uuid as uuid, io_out.dataset_uuid\n"
-          + "from jobs j\n"
-          + "inner join job_versions_io_mapping_outputs io_out on io_out.job_version_uuid = j.current_version_uuid\n"
-          + "where j.uuid in (<jobIds>)\n"
-          + "UNION\n"
-          + "select distinct io_out.job_uuid as uuid, io_out.dataset_uuid\n"
-          + "from jobs j\n"
-          + "inner join job_versions_io_mapping_inputs io_in on io_in.job_version_uuid = j.current_version_uuid\n"
-          + "inner join job_versions_io_mapping_outputs io_out on io_out.dataset_uuid = io_in.dataset_uuid\n"
-          + "where j.uuid in (<jobIds>)"
-          + ") m on m.dataset_uuid = ds.uuid\n"
-          + "left outer join dataset_versions dv on dv.uuid = ds.current_version_uuid\n")
+      "WITH dataset_ids AS (\n"
+          + "    SELECT DISTINCT dataset_uuid\n"
+          + "    FROM jobs j\n"
+          + "    INNER JOIN job_versions_io_mapping io ON io.job_version_uuid=j.current_version_uuid\n"
+          + "    WHERE j.uuid IN (<jobIds>)\n"
+          + ")\n"
+          + "SELECT ds.*, COALESCE(job_ids, '{}') AS job_ids, dv.fields\n"
+          + "FROM datasets ds\n"
+          + "    INNER JOIN dataset_ids ON dataset_ids.dataset_uuid=ds.uuid\n"
+          + "    LEFT JOIN (SELECT dataset_uuid, ARRAY_AGG(DISTINCT v.job_uuid) AS job_ids\n"
+          + "        FROM job_versions_io_mapping io2\n"
+          + "        INNER JOIN job_versions v on io2.job_version_uuid = v.uuid\n"
+          + "        WHERE io2.io_type='OUTPUT'\n"
+          + "        GROUP BY dataset_uuid\n"
+          + "        ) io ON io.dataset_uuid=ds.uuid\n"
+          + "    LEFT JOIN dataset_versions dv on dv.uuid = ds.current_version_uuid;")
   List<DatasetData> getOutputDatasetsFromJobIds(@BindList Set<UUID> jobIds);
 
   @SqlQuery(

--- a/api/src/test/java/marquez/db/LineageDaoTest.java
+++ b/api/src/test/java/marquez/db/LineageDaoTest.java
@@ -1,0 +1,584 @@
+package marquez.db;
+
+import static marquez.db.LineageTestUtils.NAMESPACE;
+import static marquez.db.LineageTestUtils.newDatasetFacet;
+import static marquez.db.LineageTestUtils.writeDownstreamLineage;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import marquez.common.models.DatasetName;
+import marquez.db.LineageTestUtils.DatasetConsumerJob;
+import marquez.db.LineageTestUtils.JobLineage;
+import marquez.db.models.DatasetData;
+import marquez.db.models.JobData;
+import marquez.db.models.UpdateLineageRow;
+import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
+import marquez.service.models.LineageEvent.Dataset;
+import marquez.service.models.LineageEvent.JobFacet;
+import marquez.service.models.LineageEvent.SchemaField;
+import marquez.service.models.LineageEvent.SourceCodeLocationJobFacet;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MarquezJdbiExternalPostgresExtension.class)
+public class LineageDaoTest {
+
+  private static LineageDao lineageDao;
+  private static OpenLineageDao openLineageDao;
+  private final Dataset dataset =
+      new Dataset(
+          NAMESPACE,
+          "commonDataset",
+          newDatasetFacet(
+              new SchemaField("firstname", "string", "the first name"),
+              new SchemaField("lastname", "string", "the last name"),
+              new SchemaField("birthdate", "date", "the date of birth")));
+  private final JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+
+  static Jdbi jdbi;
+
+  @BeforeAll
+  public static void setUpOnce(Jdbi jdbi) {
+    LineageDaoTest.jdbi = jdbi;
+    lineageDao = jdbi.onDemand(LineageDao.class);
+    openLineageDao = jdbi.onDemand(OpenLineageDao.class);
+  }
+
+  @AfterEach
+  public void tearDown(Jdbi jdbi) {
+    jdbi.inTransaction(
+        handle -> {
+          handle.execute("DELETE FROM lineage_events");
+          handle.execute("DELETE FROM runs_input_mapping");
+          handle.execute("DELETE FROM dataset_versions_field_mapping");
+          handle.execute("DELETE FROM dataset_versions");
+          handle.execute("UPDATE runs SET start_run_state_uuid=NULL, end_run_state_uuid=NULL");
+          handle.execute("DELETE FROM run_states");
+          handle.execute("DELETE FROM runs");
+          handle.execute("DELETE FROM run_args");
+          handle.execute("DELETE FROM job_versions_io_mapping");
+          handle.execute("DELETE FROM job_versions");
+          handle.execute("DELETE FROM jobs");
+          handle.execute("DELETE FROM dataset_fields_tag_mapping");
+          handle.execute("DELETE FROM dataset_fields");
+          handle.execute("DELETE FROM datasets");
+          handle.execute("DELETE FROM sources");
+          handle.execute("DELETE FROM namespaces");
+          return null;
+        });
+  }
+
+  @Test
+  public void testGetLineage() {
+
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "writeJob",
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(),
+            Arrays.asList(dataset));
+    List<JobLineage> jobRows =
+        writeDownstreamLineage(
+            openLineageDao,
+            new LinkedList<>(
+                Arrays.asList(
+                    new DatasetConsumerJob("readJob", 20, Optional.of("outputData")),
+                    new DatasetConsumerJob("downstreamJob", 1, Optional.empty()))),
+            jobFacet,
+            dataset);
+
+    // don't expect a failed job job in the returned lineage
+    UpdateLineageRow failedJobRow =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "readJobFailed",
+            "FAILED",
+            jobFacet,
+            Arrays.asList(dataset),
+            Arrays.asList());
+
+    // fetch the first "readJob" lineage.
+    Set<UUID> connectedJobs =
+        lineageDao.getLineage(new HashSet<>(Arrays.asList(jobRows.get(0).getId())));
+    assertThat(connectedJobs).size().isEqualTo(22);
+
+    // expect the job that wrote "commonDataset", which is readJob0's input
+    assertThat(connectedJobs).contains(writeJob.getJob().getUuid());
+
+    // expect all jobs that read the same input dataset as readJob0
+    Set<UUID> readJobUUIDs =
+        jobRows.stream().map(LineageTestUtils.JobLineage::getId).collect(Collectors.toSet());
+    assertThat(connectedJobs).contains(readJobUUIDs.toArray(UUID[]::new));
+
+    // expect that the failed job that reads the same input dataset is not present
+    assertThat(connectedJobs).doesNotContain(failedJobRow.getJob().getUuid());
+
+    // also expect all jobs that read the output of readJob0 (downstreamJob0)
+    Optional<JobData> downstreamJob =
+        connectedJobs.stream()
+            .filter(id -> !readJobUUIDs.contains(id) && !id.equals(writeJob.getJob().getUuid()))
+            .flatMap(id -> lineageDao.getJob(Collections.singletonList(id)).stream())
+            .findAny();
+    assertThat(downstreamJob)
+        .isPresent()
+        .map(jd -> jd.getName().getValue())
+        .get()
+        .isEqualTo("downstreamJob0<-outputData<-readJob0<-commonDataset");
+  }
+
+  @Test
+  public void testGetLineageWithJobThatHasNoDownstreamConsumers() {
+
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "writeJob",
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(),
+            Arrays.asList(dataset));
+    Set<UUID> lineage = lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid()));
+    assertThat(lineage).hasSize(1).contains(writeJob.getJob().getUuid());
+  }
+
+  @Test
+  public void testGetLineageWithJobThatHasNoDatasets() {
+
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList());
+    Set<UUID> lineage = lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid()));
+    assertThat(lineage).isEmpty();
+  }
+
+  /**
+   * Test the datasets that are inputs to the specified job are returned along with their output
+   * edges.
+   */
+  @Test
+  public void testGetInputDatasetsFromJobIds() {
+
+    LineageTestUtils.createLineageRow(
+        openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList(dataset));
+
+    // create a graph starting with the commonDataset, which spawns 20 consumers.
+    // each of those spawns 3 consumers of the "intermediate" dataset
+    // each of those spawns 1 consumer of the "finalOutput" dataset
+    List<JobLineage> jobRows =
+        writeDownstreamLineage(
+            openLineageDao,
+            new LinkedList<>(
+                Arrays.asList(
+                    new DatasetConsumerJob("readJob", 20, Optional.of("intermediate")),
+                    new DatasetConsumerJob("downstreamJob", 3, Optional.of("finalOutput")),
+                    new DatasetConsumerJob("finalConsumer", 1, Optional.empty()))),
+            jobFacet,
+            dataset);
+    // sanity check
+    List<JobLineage> downstreamJobs = jobRows.get(0).getDownstreamJobs();
+    assertThat(downstreamJobs).hasSize(3);
+
+    // fetch the dataset lineage for the first "downstreamJob" job. It touches the "intermediate"
+    // dataset, which is its input, and the "finalOutput", which is its output.
+    // There are 3 "downstreamJob" instances which read the same input dataset and 1
+    // "finalConsumer" job, which reads the output. The returned datasets should have
+    // pointers to those consumers.
+    JobLineage firstDownstream = downstreamJobs.get(0);
+    List<DatasetData> inputDatasets =
+        lineageDao.getInputDatasetsFromJobIds(Collections.singleton(firstDownstream.getId()));
+
+    // two datasets- intermediate and finalOutput
+    assertThat(inputDatasets)
+        .hasSize(2)
+        .map(DatasetData::getName)
+        .map(DatasetName::getValue)
+        .containsAll(
+            Arrays.asList(
+                "finalOutput<-downstreamJob0<-intermediate<-readJob0<-commonDataset",
+                "intermediate<-readJob0<-commonDataset"));
+
+    // first has 1 consumer- the "finalConsumer"
+    List<JobLineage> finalConsumers = firstDownstream.getDownstreamJobs();
+    assertThat(inputDatasets.get(0).getJobUuids())
+        .hasSize(1)
+        .containsAll(finalConsumers.stream().map(JobLineage::getId)::iterator);
+
+    // second one has 3 consumers- the "downstreamJob"s
+    assertThat(inputDatasets.get(1).getJobUuids())
+        .hasSize(3)
+        .containsAll(downstreamJobs.stream().map(JobLineage::getId)::iterator);
+  }
+
+  /**
+   * Validate a job that consumes a dataset, but shares no datasets with any other job returns only
+   * the consumed dataset
+   */
+  @Test
+  public void testGetInputDatasetsWithJobThatSharesNoDatasets() {
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "writeJob",
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(dataset),
+            Arrays.asList());
+
+    // write a new dataset with a different name
+    Dataset anotherDataset =
+        new Dataset(
+            NAMESPACE,
+            "anUncommonDataset",
+            newDatasetFacet(
+                new SchemaField("firstname", "string", "the first name"),
+                new SchemaField("lastname", "string", "the last name"),
+                new SchemaField("birthdate", "date", "the date of birth")));
+    // write a bunch of jobs that share nothing with the writeJob
+    writeDownstreamLineage(
+        openLineageDao,
+        Arrays.asList(new DatasetConsumerJob("consumer", 5, Optional.empty())),
+        jobFacet,
+        anotherDataset);
+
+    // Validate that finalConsumer job only has a single dataset
+    Set<UUID> jobIds = Collections.singleton(writeJob.getJob().getUuid());
+    List<DatasetData> inputsForFinalConsumer = lineageDao.getInputDatasetsFromJobIds(jobIds);
+    assertThat(inputsForFinalConsumer)
+        .hasSize(1)
+        .flatMap(DatasetData::getJobUuids)
+        .hasSize(1)
+        .containsAll(jobIds);
+  }
+
+  @Test
+  public void testGetInputDatasetsWithJobThatHasNoDatasets() {
+    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList());
+    Set<UUID> jobIds = Collections.singleton(writeJob.getJob().getUuid());
+    List<DatasetData> inputDatasets = lineageDao.getInputDatasetsFromJobIds(jobIds);
+    assertThat(inputDatasets).isEmpty();
+  }
+
+  @Test
+  public void testGetInputDatasetsWithJobThatHasOnlyOutputs() {
+    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "writeJob",
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(),
+            Arrays.asList(dataset));
+    List<DatasetData> inputDatasets =
+        lineageDao.getInputDatasetsFromJobIds(Collections.singleton(writeJob.getJob().getUuid()));
+    assertThat(inputDatasets).hasSize(1).flatMap(DatasetData::getJobUuids).isEmpty();
+  }
+
+  /** A failed consumer job doesn't show up in the datasets out edges */
+  @Test
+  public void testGetInputDatasetsWithFailedConsumer() {
+    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "writeJob",
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(),
+            Arrays.asList(dataset));
+    LineageTestUtils.createLineageRow(
+        openLineageDao,
+        "failedConsumer",
+        "FAILED",
+        jobFacet,
+        Arrays.asList(dataset),
+        Arrays.asList());
+    List<DatasetData> inputDatasets =
+        lineageDao.getInputDatasetsFromJobIds(Collections.singleton(writeJob.getJob().getUuid()));
+    assertThat(inputDatasets).hasSize(1).flatMap(DatasetData::getJobUuids).isEmpty();
+  }
+
+  /**
+   * Test that a job with multiple versions will only return the datasets touched by the latest
+   * version.
+   */
+  @Test
+  public void testGetInputDatasetsWithJobThatHasMultipleVersions() {
+
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "writeJob",
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(),
+            Arrays.asList(dataset));
+
+    writeDownstreamLineage(
+        openLineageDao,
+        new LinkedList<>(
+            Arrays.asList(
+                new DatasetConsumerJob("readJob", 3, Optional.of("outputData")),
+                new DatasetConsumerJob("downstreamJob", 1, Optional.empty()))),
+        jobFacet,
+        dataset);
+
+    JobFacet newVersionFacet =
+        JobFacet.builder()
+            .sourceCodeLocation(
+                SourceCodeLocationJobFacet.builder().url("git@github:location").build())
+            .additional(LineageTestUtils.EMPTY_MAP)
+            .build();
+
+    // readJobV2 produces outputData2 and not outputData
+    List<JobLineage> newRows =
+        writeDownstreamLineage(
+            openLineageDao,
+            new LinkedList<>(
+                Arrays.asList(
+                    new DatasetConsumerJob("readJob", 3, Optional.of("outputData2")),
+                    new DatasetConsumerJob("downstreamJob", 1, Optional.empty()))),
+            newVersionFacet,
+            dataset);
+
+    List<DatasetData> inputData =
+        lineageDao.getInputDatasetsFromJobIds(Collections.singleton(newRows.get(0).getId()));
+    assertThat(inputData)
+        .hasSize(2)
+        .map(ds -> ds.getName().getValue())
+        .containsAll(Arrays.asList("outputData2<-readJob0<-commonDataset", "commonDataset"))
+        .doesNotContain("outputData<-readJob0<-commonDataset");
+
+    assertThat(inputData)
+        .filteredOn(ds -> ds.getName().getValue().equals("outputData2<-readJob0<-commonDataset"))
+        .isNotEmpty()
+        .map(DatasetData::getJobUuids)
+        .first()
+        .asList()
+        .hasSize(1)
+        .contains(newRows.get(0).getDownstreamJobs().get(0).getId());
+  }
+
+  /** */
+  @Test
+  public void testGetOutputDatasetsFromJobIds() {
+
+    LineageTestUtils.createLineageRow(
+        openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList(dataset));
+
+    // create a graph starting with the commonDataset, which spawns 20 consumers.
+    // each of those spawns 3 consumers of the "intermediate" dataset
+    // each of those spawns 1 consumer of the "finalOutput" dataset
+    List<JobLineage> jobRows =
+        writeDownstreamLineage(
+            openLineageDao,
+            new LinkedList<>(
+                Arrays.asList(
+                    new DatasetConsumerJob("readJob", 20, Optional.of("intermediate")),
+                    new DatasetConsumerJob("downstreamJob", 3, Optional.of("finalOutput")),
+                    new DatasetConsumerJob("finalConsumer", 1, Optional.empty()))),
+            jobFacet,
+            dataset);
+    // sanity check
+    List<JobLineage> downstreamJobs = jobRows.get(0).getDownstreamJobs();
+    assertThat(downstreamJobs).hasSize(3);
+
+    // fetch the dataset lineage for the first "downstreamJob" job. It touches the "intermediate"
+    // dataset, which is its input, and the "finalOutput", which is its output.
+    JobLineage firstDownstream = downstreamJobs.get(0);
+    List<DatasetData> outputDatasets =
+        lineageDao.getOutputDatasetsFromJobIds(Collections.singleton(firstDownstream.getId()));
+
+    // two datasets- intermediate and finalOutput
+    assertThat(outputDatasets)
+        .hasSize(2)
+        .map(DatasetData::getName)
+        .map(DatasetName::getValue)
+        .containsAll(
+            Arrays.asList(
+                "finalOutput<-downstreamJob0<-intermediate<-readJob0<-commonDataset",
+                "intermediate<-readJob0<-commonDataset"));
+
+    // find the jobs that output those datasets
+    assertThat(outputDatasets)
+        .map(DatasetData::getJobUuids)
+        .allMatch(l -> l.size() == 1)
+        .flatMap(Function.identity())
+        .containsAll(Arrays.asList(firstDownstream.getId(), jobRows.get(0).getId()));
+  }
+
+  /**
+   * Validate a job that consumes a dataset, but shares no datasets with any other job returns only
+   * the consumed dataset
+   */
+  @Test
+  public void testGetOutputDatasetsWithJobThatSharesNoDatasets() {
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "writeJob",
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(),
+            Arrays.asList(dataset));
+
+    // write a new dataset with a different name
+    Dataset anotherDataset =
+        new Dataset(
+            NAMESPACE,
+            "anUncommonDataset",
+            newDatasetFacet(
+                new SchemaField("firstname", "string", "the first name"),
+                new SchemaField("lastname", "string", "the last name"),
+                new SchemaField("birthdate", "date", "the date of birth")));
+    // write a bunch of jobs that share nothing with the writeJob
+    writeDownstreamLineage(
+        openLineageDao,
+        Arrays.asList(new DatasetConsumerJob("consumer", 5, Optional.empty())),
+        jobFacet,
+        anotherDataset);
+
+    Set<UUID> jobIds = Collections.singleton(writeJob.getJob().getUuid());
+    List<DatasetData> outputDatasets = lineageDao.getOutputDatasetsFromJobIds(jobIds);
+    assertThat(outputDatasets)
+        .hasSize(1)
+        .flatMap(DatasetData::getJobUuids)
+        .hasSize(1)
+        .containsAll(jobIds);
+  }
+
+  @Test
+  public void testGetOutputDatasetsWithJobThatHasNoDatasets() {
+    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList());
+    List<DatasetData> lineage =
+        lineageDao.getOutputDatasetsFromJobIds(Collections.singleton(writeJob.getJob().getUuid()));
+    assertThat(lineage).isEmpty();
+  }
+
+  @Test
+  public void testGetOutputDatasetsWithJobThatHasOnlyInputs() {
+    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "writeJob",
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(dataset),
+            Arrays.asList());
+    Set<UUID> jobIds = Collections.singleton(writeJob.getJob().getUuid());
+    List<DatasetData> outputDatasets = lineageDao.getOutputDatasetsFromJobIds(jobIds);
+    assertThat(outputDatasets).hasSize(1).flatMap(DatasetData::getJobUuids).isEmpty();
+  }
+
+  /** A failed producer job doesn't show up in the datasets in edges */
+  @Test
+  public void testGetOutputDatasetsWithFailedProducer() {
+    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "writeJob",
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(),
+            Arrays.asList(dataset));
+    LineageTestUtils.createLineageRow(
+        openLineageDao,
+        "failedProducer",
+        "FAILED",
+        jobFacet,
+        Arrays.asList(),
+        Arrays.asList(dataset));
+    List<DatasetData> inputDatasets =
+        lineageDao.getOutputDatasetsFromJobIds(Collections.singleton(writeJob.getJob().getUuid()));
+    assertThat(inputDatasets)
+        .hasSize(1)
+        .flatMap(DatasetData::getJobUuids)
+        .hasSize(1)
+        .contains(writeJob.getJob().getUuid());
+  }
+
+  @Test
+  public void testGetOuptutDatasetsWithJobThatHasMultipleVersions() {
+
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "writeJob",
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(),
+            Arrays.asList(dataset));
+
+    writeDownstreamLineage(
+        openLineageDao,
+        new LinkedList<>(
+            Arrays.asList(
+                new DatasetConsumerJob("readJob", 3, Optional.of("outputData")),
+                new DatasetConsumerJob("downstreamJob", 1, Optional.empty()))),
+        jobFacet,
+        dataset);
+
+    JobFacet newVersionFacet =
+        JobFacet.builder()
+            .sourceCodeLocation(
+                SourceCodeLocationJobFacet.builder().url("git@github:location").build())
+            .additional(LineageTestUtils.EMPTY_MAP)
+            .build();
+
+    // readJobV2 produces outputData2 and not outputData
+    List<JobLineage> newRows =
+        writeDownstreamLineage(
+            openLineageDao,
+            new LinkedList<>(
+                Arrays.asList(
+                    new DatasetConsumerJob("readJob", 3, Optional.of("outputData2")),
+                    new DatasetConsumerJob("downstreamJob", 1, Optional.empty()))),
+            newVersionFacet,
+            dataset);
+
+    List<DatasetData> inputData =
+        lineageDao.getOutputDatasetsFromJobIds(Collections.singleton(newRows.get(0).getId()));
+    assertThat(inputData)
+        .hasSize(2)
+        .map(ds -> ds.getName().getValue())
+        .containsAll(Arrays.asList("outputData2<-readJob0<-commonDataset", "commonDataset"))
+        .doesNotContain("outputData<-readJob0<-commonDataset");
+
+    assertThat(inputData)
+        .filteredOn(ds -> ds.getName().getValue().equals("outputData2<-readJob0<-commonDataset"))
+        .isNotEmpty()
+        .map(DatasetData::getJobUuids)
+        .first()
+        .asList()
+        .hasSize(1)
+        .contains(newRows.get(0).getId());
+  }
+}

--- a/api/src/test/java/marquez/db/LineageTestUtils.java
+++ b/api/src/test/java/marquez/db/LineageTestUtils.java
@@ -1,0 +1,182 @@
+package marquez.db;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import lombok.Value;
+import marquez.common.Utils;
+import marquez.db.models.UpdateLineageRow;
+import marquez.db.models.UpdateLineageRow.DatasetRecord;
+import marquez.service.models.LineageEvent;
+import marquez.service.models.LineageEvent.Dataset;
+import marquez.service.models.LineageEvent.DatasetFacet;
+import marquez.service.models.LineageEvent.DatasourceDatasetFacet;
+import marquez.service.models.LineageEvent.DocumentationDatasetFacet;
+import marquez.service.models.LineageEvent.Job;
+import marquez.service.models.LineageEvent.JobFacet;
+import marquez.service.models.LineageEvent.NominalTimeRunFacet;
+import marquez.service.models.LineageEvent.Run;
+import marquez.service.models.LineageEvent.RunFacet;
+import marquez.service.models.LineageEvent.SchemaDatasetFacet;
+import marquez.service.models.LineageEvent.SchemaField;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+public class LineageTestUtils {
+
+  public static final ZoneId LOCAL_ZONE = ZoneId.of("America/Los_Angeles");
+  public static final ImmutableMap<String, Object> EMPTY_MAP = ImmutableMap.of();
+  public static final URI PRODUCER_URL = URI.create("http://test.producer/");
+  public static final URI SCHEMA_URL = URI.create("http://test.schema/");
+  public static final String NAMESPACE = "namespace";
+
+  /**
+   * Create an {@link UpdateLineageRow} from the input job details and datasets.
+   *
+   * @param dao
+   * @param jobName
+   * @param status
+   * @param jobFacet
+   * @param inputs
+   * @param outputs
+   * @return
+   */
+  static UpdateLineageRow createLineageRow(
+      OpenLineageDao dao,
+      String jobName,
+      String status,
+      JobFacet jobFacet,
+      List<Dataset> inputs,
+      List<Dataset> outputs) {
+    NominalTimeRunFacet nominalTimeRunFacet = new NominalTimeRunFacet();
+    nominalTimeRunFacet.setNominalStartTime(
+        Instant.now().atZone(LOCAL_ZONE).truncatedTo(ChronoUnit.HOURS));
+    nominalTimeRunFacet.setNominalEndTime(
+        nominalTimeRunFacet.getNominalStartTime().plus(1, ChronoUnit.HOURS));
+
+    return dao.updateMarquezModel(
+        new LineageEvent(
+            status,
+            Instant.now().atZone(LOCAL_ZONE),
+            new Run(
+                UUID.randomUUID().toString(),
+                new RunFacet(nominalTimeRunFacet, null, ImmutableMap.of())),
+            new Job(NAMESPACE, jobName, jobFacet),
+            inputs,
+            outputs,
+            PRODUCER_URL.toString()),
+        Utils.getMapper());
+  }
+
+  static DatasetFacet newDatasetFacet(SchemaField... fields) {
+    return DatasetFacet.builder()
+        .documentation(
+            new DocumentationDatasetFacet(PRODUCER_URL, SCHEMA_URL, "the dataset documentation"))
+        .schema(new SchemaDatasetFacet(PRODUCER_URL, SCHEMA_URL, Arrays.asList(fields)))
+        .dataSource(
+            new DatasourceDatasetFacet(
+                PRODUCER_URL, SCHEMA_URL, "the source", "http://thesource.com"))
+        .description("the dataset description")
+        .additional(EMPTY_MAP)
+        .build();
+  }
+
+  /**
+   * Recursive function which supports writing a lineage graph by supplying an input dataset and a
+   * list of {@link DatasetConsumerJob}s. Each consumer may output up to one dataset, which will be
+   * consumed by the number of consumers specified by the {@link DatasetConsumerJob#numConsumers}
+   * property.
+   *
+   * @param openLineageDao
+   * @param downstream
+   * @param jobFacet
+   * @param dataset
+   * @return
+   */
+  static List<JobLineage> writeDownstreamLineage(
+      OpenLineageDao openLineageDao,
+      List<DatasetConsumerJob> downstream,
+      JobFacet jobFacet,
+      Dataset dataset) {
+    DatasetConsumerJob consumer = downstream.get(0);
+    return IntStream.range(0, consumer.getNumConsumers())
+        .mapToObj(
+            i -> {
+              String jobName = consumer.getName() + i + "<-" + dataset.getName();
+              Optional<Dataset> outputs =
+                  consumer
+                      .getOutputDatasetName()
+                      .map(
+                          dsName ->
+                              new Dataset(
+                                  NAMESPACE,
+                                  dsName + "<-" + jobName,
+                                  newDatasetFacet(
+                                      new SchemaField("afield", "string", "a string field"),
+                                      new SchemaField("anotherField", "string", "a string field"),
+                                      new SchemaField("anInteger", "int", "an integer field"))));
+              UpdateLineageRow row =
+                  createLineageRow(
+                      openLineageDao,
+                      jobName,
+                      "COMPLETE",
+                      jobFacet,
+                      Collections.singletonList(dataset),
+                      outputs.stream().collect(Collectors.toList()));
+              List<JobLineage> downstreamLineage =
+                  outputs.stream()
+                      .flatMap(
+                          out -> {
+                            if (consumer.numConsumers > 0) {
+                              return writeDownstreamLineage(
+                                  openLineageDao,
+                                  downstream.subList(1, downstream.size()),
+                                  jobFacet,
+                                  out)
+                                  .stream();
+                            } else {
+                              return Stream.empty();
+                            }
+                          })
+                      .collect(Collectors.toList());
+              return new JobLineage(
+                  row.getJob().getUuid(),
+                  row.getJob().getName(),
+                  row.getInputs().filter(l -> !l.isEmpty()).map(l -> l.get(0)),
+                  row.getOutputs().filter(l -> !l.isEmpty()).map(l -> l.get(0)),
+                  downstreamLineage);
+            })
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Entity that encapsulates an existing job lineage- a job id, name, its input and output dataset
+   * (if any) and a list of downstream jobs.
+   */
+  @Value
+  static class JobLineage {
+
+    UUID id;
+    String name;
+    Optional<DatasetRecord> input;
+    Optional<DatasetRecord> output;
+    List<JobLineage> downstreamJobs;
+  }
+
+  /** Entity that encapsulates a dataset's consumer jobs and their output dataset names (if any). */
+  @Value
+  static class DatasetConsumerJob {
+
+    String name;
+    int numConsumers;
+    Optional<String> outputDatasetName;
+  }
+}

--- a/api/src/test/java/marquez/db/OpenLineageDaoTest.java
+++ b/api/src/test/java/marquez/db/OpenLineageDaoTest.java
@@ -2,60 +2,30 @@ package marquez.db;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.URI;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-import marquez.common.Utils;
 import marquez.db.models.UpdateLineageRow;
 import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
-import marquez.service.models.LineageEvent;
 import marquez.service.models.LineageEvent.Dataset;
 import marquez.service.models.LineageEvent.DatasetFacet;
-import marquez.service.models.LineageEvent.DatasourceDatasetFacet;
-import marquez.service.models.LineageEvent.DocumentationDatasetFacet;
-import marquez.service.models.LineageEvent.Job;
 import marquez.service.models.LineageEvent.JobFacet;
-import marquez.service.models.LineageEvent.NominalTimeRunFacet;
-import marquez.service.models.LineageEvent.Run;
-import marquez.service.models.LineageEvent.RunFacet;
 import marquez.service.models.LineageEvent.SchemaDatasetFacet;
 import marquez.service.models.LineageEvent.SchemaField;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 @ExtendWith(MarquezJdbiExternalPostgresExtension.class)
 class OpenLineageDaoTest {
 
-  public static final ZoneId LOCAL_ZONE = ZoneId.of("America/Los_Angeles");
-  public static final ImmutableMap<String, Object> EMPTY_MAP = ImmutableMap.of();
-  public static final URI PRODUCER_URL = URI.create("http://test.producer/");
-  public static final URI SCHEMA_URL = URI.create("http://test.schema/");
-  public static final String NAMESPACE = "namespace";
   public static final String WRITE_JOB_NAME = "writeJobName";
   public static final String READ_JOB_NAME = "readJobName";
   public static final String DATASET_NAME = "theDataset";
 
   private static OpenLineageDao dao;
   private final DatasetFacet datasetFacet =
-      new DatasetFacet(
-          new DocumentationDatasetFacet(PRODUCER_URL, SCHEMA_URL, "the dataset documentation"),
-          new SchemaDatasetFacet(
-              PRODUCER_URL,
-              SCHEMA_URL,
-              Arrays.asList(
-                  new SchemaField("name", "STRING", "my name"),
-                  new SchemaField("age", "INT", "my age"))),
-          new DatasourceDatasetFacet(
-              PRODUCER_URL, SCHEMA_URL, "the source", "http://thesource.com"),
-          "the dataset description",
-          EMPTY_MAP);
+      LineageTestUtils.newDatasetFacet(
+          new SchemaField("name", "STRING", "my name"), new SchemaField("age", "INT", "my age"));
 
   @BeforeAll
   public static void setUpOnce(Jdbi jdbi) {
@@ -65,19 +35,23 @@ class OpenLineageDaoTest {
   /** When reading a dataset, the version is assumed to be the version last written */
   @Test
   void testUpdateMarquezModel() {
-    JobFacet jobFacet = new JobFacet(null, null, null, EMPTY_MAP);
+    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
     UpdateLineageRow writeJob =
-        createLineageRow(
+        LineageTestUtils.createLineageRow(
+            dao,
             WRITE_JOB_NAME,
+            "COMPLETE",
             jobFacet,
             Arrays.asList(),
-            Arrays.asList(new Dataset(NAMESPACE, DATASET_NAME, datasetFacet)));
+            Arrays.asList(new Dataset(LineageTestUtils.NAMESPACE, DATASET_NAME, datasetFacet)));
 
     UpdateLineageRow readJob =
-        createLineageRow(
+        LineageTestUtils.createLineageRow(
+            dao,
             READ_JOB_NAME,
+            "COMPLETE",
             jobFacet,
-            Arrays.asList(new Dataset(NAMESPACE, DATASET_NAME, datasetFacet)),
+            Arrays.asList(new Dataset(LineageTestUtils.NAMESPACE, DATASET_NAME, datasetFacet)),
             Arrays.asList());
 
     assertThat(writeJob.getOutputs()).isPresent().get().asList().size().isEqualTo(1);
@@ -92,20 +66,22 @@ class OpenLineageDaoTest {
    */
   @Test
   void testUpdateMarquezModelWithNonMatchingReadSchema() {
-    JobFacet jobFacet = new JobFacet(null, null, null, EMPTY_MAP);
+    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
     UpdateLineageRow writeJob =
-        createLineageRow(
+        LineageTestUtils.createLineageRow(
+            dao,
             WRITE_JOB_NAME,
+            "COMPLETE",
             jobFacet,
             Arrays.asList(),
-            Arrays.asList(new Dataset(NAMESPACE, DATASET_NAME, datasetFacet)));
+            Arrays.asList(new Dataset(LineageTestUtils.NAMESPACE, DATASET_NAME, datasetFacet)));
 
     DatasetFacet overrideFacet =
         new DatasetFacet(
             this.datasetFacet.getDocumentation(),
             new SchemaDatasetFacet(
-                PRODUCER_URL,
-                SCHEMA_URL,
+                LineageTestUtils.PRODUCER_URL,
+                LineageTestUtils.SCHEMA_URL,
                 Arrays.asList(
                     new SchemaField("name", "STRING", "my name"),
                     new SchemaField("age", "INT", "my age"),
@@ -114,10 +90,12 @@ class OpenLineageDaoTest {
             this.datasetFacet.getDescription(),
             this.datasetFacet.getAdditionalFacets());
     UpdateLineageRow readJob =
-        createLineageRow(
+        LineageTestUtils.createLineageRow(
+            dao,
             READ_JOB_NAME,
+            "COMPLETE",
             jobFacet,
-            Arrays.asList(new Dataset(NAMESPACE, DATASET_NAME, overrideFacet)),
+            Arrays.asList(new Dataset(LineageTestUtils.NAMESPACE, DATASET_NAME, overrideFacet)),
             Arrays.asList());
 
     assertThat(writeJob.getOutputs()).isPresent().get().asList().size().isEqualTo(1);
@@ -132,38 +110,48 @@ class OpenLineageDaoTest {
    */
   @Test
   void testUpdateMarquezModelWithPriorWrites() {
-    JobFacet jobFacet = new JobFacet(null, null, null, EMPTY_MAP);
+    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
     UpdateLineageRow writeJob1 =
-        createLineageRow(
+        LineageTestUtils.createLineageRow(
+            dao,
             WRITE_JOB_NAME,
+            "COMPLETE",
             jobFacet,
             Arrays.asList(),
-            Arrays.asList(new Dataset(NAMESPACE, DATASET_NAME, datasetFacet)));
+            Arrays.asList(new Dataset(LineageTestUtils.NAMESPACE, DATASET_NAME, datasetFacet)));
     UpdateLineageRow readJob1 =
-        createLineageRow(
+        LineageTestUtils.createLineageRow(
+            dao,
             READ_JOB_NAME,
+            "COMPLETE",
             jobFacet,
-            Arrays.asList(new Dataset(NAMESPACE, DATASET_NAME, datasetFacet)),
+            Arrays.asList(new Dataset(LineageTestUtils.NAMESPACE, DATASET_NAME, datasetFacet)),
             Arrays.asList());
 
     UpdateLineageRow writeJob2 =
-        createLineageRow(
+        LineageTestUtils.createLineageRow(
+            dao,
             WRITE_JOB_NAME,
+            "COMPLETE",
             jobFacet,
             Arrays.asList(),
-            Arrays.asList(new Dataset(NAMESPACE, DATASET_NAME, datasetFacet)));
+            Arrays.asList(new Dataset(LineageTestUtils.NAMESPACE, DATASET_NAME, datasetFacet)));
     UpdateLineageRow writeJob3 =
-        createLineageRow(
+        LineageTestUtils.createLineageRow(
+            dao,
             WRITE_JOB_NAME,
+            "COMPLETE",
             jobFacet,
             Arrays.asList(),
-            Arrays.asList(new Dataset(NAMESPACE, DATASET_NAME, datasetFacet)));
+            Arrays.asList(new Dataset(LineageTestUtils.NAMESPACE, DATASET_NAME, datasetFacet)));
 
     UpdateLineageRow readJob2 =
-        createLineageRow(
+        LineageTestUtils.createLineageRow(
+            dao,
             READ_JOB_NAME,
+            "COMPLETE",
             jobFacet,
-            Arrays.asList(new Dataset(NAMESPACE, DATASET_NAME, datasetFacet)),
+            Arrays.asList(new Dataset(LineageTestUtils.NAMESPACE, DATASET_NAME, datasetFacet)),
             Arrays.asList());
 
     // verify readJob1 read the version written by writeJob1
@@ -191,27 +179,5 @@ class OpenLineageDaoTest {
 
     assertThat(readJob2.getInputs().get().get(0).getDatasetVersionRow())
         .isEqualTo(writeJob3.getOutputs().get().get(0).getDatasetVersionRow());
-  }
-
-  private UpdateLineageRow createLineageRow(
-      String jobName, JobFacet jobFacet, List<Dataset> inputs, List<Dataset> outputs) {
-    NominalTimeRunFacet nominalTimeRunFacet = new NominalTimeRunFacet();
-    nominalTimeRunFacet.setNominalStartTime(
-        Instant.now().atZone(LOCAL_ZONE).truncatedTo(ChronoUnit.HOURS));
-    nominalTimeRunFacet.setNominalEndTime(
-        nominalTimeRunFacet.getNominalStartTime().plus(1, ChronoUnit.HOURS));
-
-    return dao.updateMarquezModel(
-        new LineageEvent(
-            "COMPLETE",
-            Instant.now().atZone(LOCAL_ZONE),
-            new Run(
-                UUID.randomUUID().toString(),
-                new RunFacet(nominalTimeRunFacet, null, ImmutableMap.of())),
-            new Job(NAMESPACE, jobName, jobFacet),
-            inputs, // no input
-            outputs,
-            PRODUCER_URL.toString()),
-        Utils.getMapper());
   }
 }


### PR DESCRIPTION
Simplify the SQL queries that read the job and dataset lineage for the `LineageService`. This eliminates the reads from the `job_versions_io_mapping_outputs` and `job_versions_io_mapping_inputs` tables and reads all the IO from the `job_versions_io_mapping` table only. It also adds some pretty comprehensive test coverage for the lineage queries to verify we're returning the right jobs and datasets in different cases. 