### PR TITLE
Updated OpenLineage impl to only update dataset version on run completion

### DIFF
--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -401,7 +401,6 @@ public interface OpenLineageDao extends BaseDao {
                           dsNamespace.getName(),
                           ds.getName());
 
-                  datasetDao.updateVersion(datasetRow.getUuid(), now, row.getUuid());
                   return row;
                 });
     List<DatasetFieldMapping> datasetFieldMappings = new ArrayList<>();

--- a/api/src/main/java/marquez/service/OpenLineageService.java
+++ b/api/src/main/java/marquez/service/OpenLineageService.java
@@ -2,6 +2,7 @@ package marquez.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
@@ -19,6 +20,7 @@ import marquez.common.models.JobVersionId;
 import marquez.common.models.NamespaceName;
 import marquez.common.models.RunId;
 import marquez.db.BaseDao;
+import marquez.db.DatasetDao;
 import marquez.db.DatasetVersionDao;
 import marquez.db.models.ExtendedDatasetVersionRow;
 import marquez.db.models.RunArgsRow;
@@ -100,6 +102,11 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
     // We query for all datasets since they can come in slowly over time
     List<ExtendedDatasetVersionRow> datasets =
         datasetVersionDao.findOutputsByRunId(record.getRun().getUuid());
+    DatasetDao datasetDao = createDatasetDao();
+    datasets.forEach(
+        versionRow ->
+            datasetDao.updateVersion(
+                versionRow.getDatasetUuid(), Instant.now(), versionRow.getUuid()));
 
     // Do not trigger a JobOutput event if there are no new datasets
     if (datasets.isEmpty() && record.getOutputs().isEmpty()) {

--- a/api/src/test/java/marquez/service/OpenLineageServiceTest.java
+++ b/api/src/test/java/marquez/service/OpenLineageServiceTest.java
@@ -1,5 +1,6 @@
 package marquez.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 
@@ -10,25 +11,37 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import marquez.common.Utils;
+import marquez.db.DatasetDao;
 import marquez.db.DatasetVersionDao;
 import marquez.db.OpenLineageDao;
+import marquez.db.models.DatasetVersionRow;
+import marquez.db.models.ExtendedDatasetVersionRow;
 import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
 import marquez.service.RunTransitionListener.JobInputUpdate;
 import marquez.service.RunTransitionListener.JobOutputUpdate;
 import marquez.service.models.Dataset;
 import marquez.service.models.Job;
 import marquez.service.models.LineageEvent;
+import marquez.service.models.LineageEvent.DatasetFacet;
+import marquez.service.models.LineageEvent.DatasourceDatasetFacet;
+import marquez.service.models.LineageEvent.RunFacet;
 import marquez.service.models.Run;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -37,8 +50,14 @@ import org.mockito.ArgumentCaptor;
 @org.junit.jupiter.api.Tag("IntegrationTests")
 @ExtendWith(MarquezJdbiExternalPostgresExtension.class)
 public class OpenLineageServiceTest {
+
+  public static final String NAMESPACE = "theNamespace";
+  public static final String JOB_NAME = "theJob";
+  public static final ZoneId TIMEZONE = ZoneId.of("America/Los_Angeles");
+  public static final String DATASET_NAME = "theDataset";
   private RunService runService;
   private OpenLineageDao openLineageDao;
+  private DatasetDao datasetDao;
   private DatasetVersionDao datasetVersionDao;
   private ArgumentCaptor<JobInputUpdate> runInputListener;
   private ArgumentCaptor<JobOutputUpdate> runOutputListener;
@@ -113,6 +132,7 @@ public class OpenLineageServiceTest {
     runOutputListener = ArgumentCaptor.forClass(JobOutputUpdate.class);
     doNothing().when(runService).notify(runOutputListener.capture());
     lineageService = new OpenLineageService(openLineageDao, runService);
+    datasetDao = jdbi.onDemand(DatasetDao.class);
   }
 
   private List<LineageEvent> initEvents(List<URI> uris) {
@@ -194,6 +214,118 @@ public class OpenLineageServiceTest {
         checkExists(ds);
       }
     }
+  }
+
+  @Test
+  public void testDatasetVersionUpdatedOnRunCompletion()
+      throws ExecutionException, InterruptedException {
+    LineageEvent.Dataset dataset =
+        LineageEvent.Dataset.builder()
+            .name(DATASET_NAME)
+            .namespace(NAMESPACE)
+            .facets(
+                DatasetFacet.builder()
+                    .dataSource(
+                        DatasourceDatasetFacet.builder()
+                            .name("theDatasource")
+                            .uri("http://thedatasource")
+                            .build())
+                    .build())
+            .build();
+
+    // First run creates the dataset without a currentVersionUuid
+    UUID firstRunId = UUID.randomUUID();
+    lineageService
+        .createAsync(
+            LineageEvent.builder()
+                .eventType("RUNNING")
+                .run(new LineageEvent.Run(firstRunId.toString(), RunFacet.builder().build()))
+                .job(LineageEvent.Job.builder().name(JOB_NAME).namespace(NAMESPACE).build())
+                .eventTime(Instant.now().atZone(TIMEZONE))
+                .inputs(new ArrayList<>())
+                .outputs(Collections.singletonList(dataset))
+                .build())
+        .get();
+    Optional<Dataset> datasetRow = datasetDao.find(NAMESPACE, DATASET_NAME);
+    assertThat(datasetRow).isPresent().flatMap(Dataset::getCurrentVersionUuid).isNotPresent();
+
+    // On complete, the currentVersionUuid is updated
+    lineageService
+        .createAsync(
+            LineageEvent.builder()
+                .eventType("COMPLETE")
+                .run(new LineageEvent.Run(firstRunId.toString(), RunFacet.builder().build()))
+                .job(LineageEvent.Job.builder().name(JOB_NAME).namespace(NAMESPACE).build())
+                .eventTime(Instant.now().atZone(TIMEZONE))
+                .inputs(new ArrayList<>())
+                .outputs(Collections.singletonList(dataset))
+                .build())
+        .get();
+    datasetRow = datasetDao.find(NAMESPACE, DATASET_NAME);
+    assertThat(datasetRow).isPresent().flatMap(Dataset::getCurrentVersionUuid).isPresent();
+
+    List<ExtendedDatasetVersionRow> outputs = datasetVersionDao.findOutputsByRunId(firstRunId);
+    assertThat(outputs).hasSize(1).map(DatasetVersionRow::getVersion).isNotNull();
+
+    UUID dsVersion1Id = outputs.get(0).getVersion();
+
+    // A consumer gets the currentVersionUuid as its input version
+    UUID secondRunId = UUID.randomUUID();
+    lineageService
+        .createAsync(
+            LineageEvent.builder()
+                .eventType("COMPLETE")
+                .run(new LineageEvent.Run(secondRunId.toString(), RunFacet.builder().build()))
+                .job(LineageEvent.Job.builder().name("AnInputJob").namespace(NAMESPACE).build())
+                .eventTime(Instant.now().atZone(TIMEZONE))
+                .inputs(Collections.singletonList(dataset))
+                .outputs(new ArrayList<>())
+                .build())
+        .get();
+    List<ExtendedDatasetVersionRow> inputs = datasetVersionDao.findInputsByRunId(secondRunId);
+    assertThat(inputs).hasSize(1).map(DatasetVersionRow::getVersion).contains(dsVersion1Id);
+
+    // fail to write the dataset - the currentVersionUuid is not updated
+    UUID failedRunId = UUID.randomUUID();
+    lineageService
+        .createAsync(
+            LineageEvent.builder()
+                .eventType("FAILED")
+                .run(new LineageEvent.Run(failedRunId.toString(), RunFacet.builder().build()))
+                .job(LineageEvent.Job.builder().name(JOB_NAME).namespace(NAMESPACE).build())
+                .eventTime(Instant.now().atZone(TIMEZONE))
+                .inputs(new ArrayList<>())
+                .outputs(Collections.singletonList(dataset))
+                .build())
+        .get();
+
+    Optional<Dataset> afterFailureDataset = datasetDao.find(NAMESPACE, DATASET_NAME);
+    assertThat(afterFailureDataset)
+        .isPresent()
+        .flatMap(Dataset::getCurrentVersionUuid)
+        .isPresent()
+        .get()
+        .isEqualTo(datasetRow.get().getCurrentVersionUuid().get());
+
+    // A new consumer job run only sees the first dataset version
+    UUID fourthRunId = UUID.randomUUID();
+    lineageService
+        .createAsync(
+            LineageEvent.builder()
+                .eventType("COMPLETE")
+                .run(new LineageEvent.Run(fourthRunId.toString(), RunFacet.builder().build()))
+                .job(LineageEvent.Job.builder().name("AnInputJob").namespace(NAMESPACE).build())
+                .eventTime(Instant.now().atZone(TIMEZONE))
+                .inputs(Collections.singletonList(dataset))
+                .outputs(new ArrayList<>())
+                .build())
+        .get();
+
+    // still version 1 is consumed since the second producer job run failed
+    assertThat(datasetVersionDao.findInputsByRunId(secondRunId))
+        .hasSize(1)
+        .map(DatasetVersionRow::getVersion)
+        .contains(dsVersion1Id);
   }
 
   private void checkExists(LineageEvent.Dataset ds) {


### PR DESCRIPTION
This addresses the issue of dataset versions being created and updated when Job Runs fail. This breaks the lineage for a downstream run, since a consumer job will see the latest dataset version created, but the output of a job run is only updated if the job run completes. Thus, the consumed dataset version will have no upstream producer, so the consumer's lineage isn't tied to anything. 

I think we established in an offline discussion that we'd allow the dataset version creation to continue in the OpenLineageDao, as it is now, but that the dataset `currentVersionUuid` change will only happen on run completion. This means that we get a record of a dataset version being created, but downstream consumers won't see the new version unless the run that created it completes.

Added a test case that illustrates the new behavior.

Signed-off-by: Michael Collado <mike@datakin.com>