### PR TITLE
Revert drop of io mapping tables

### DIFF
--- a/api/src/main/resources/marquez/db/migration/V33__drop_job_io_mappings.sql
+++ b/api/src/main/resources/marquez/db/migration/V33__drop_job_io_mappings.sql
@@ -1,2 +1,0 @@
-DROP TABLE job_versions_io_mapping_inputs;
-DROP TABLE job_versions_io_mapping_outputs;


### PR DESCRIPTION
This PR reverts dropping of the tables `job_versions_io_mapping_inputs` and `job_versions_io_mapping_outputs` no longer in use. The tables will be dropped in the [`0.15.0` release](https://github.com/MarquezProject/marquez/issues/1280) instead to avoid any downtime as the tables will still be used by a running instance of Marquez.