### PR TITLE
Updated dataset lineage query to find most recent job that wrote to it

### DIFF
--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -135,6 +135,7 @@ public interface LineageDao {
           + "inner join job_versions_io_mapping io on io.job_version_uuid = jv.uuid\n"
           + "inner join datasets ds on ds.uuid = io.dataset_uuid\n"
           + "where ds.name = :datasetName and ds.namespace_name = :namespaceName\n"
+          + "order by io_type DESC, jv.created_at DESC\n"
           + "limit 1")
   Optional<UUID> getJobFromInputOrOutput(String datasetName, String namespaceName);
 


### PR DESCRIPTION
Currently, the dataset lineage query ends up picking the first job that touched the dataset- in some cases, this includes jobs that queried the dataset a long time ago and have never run since or have changed their input/output lineage. This changes the query to prefer the most recent job that wrote to a dataset, so that upstream lineage is visible. 