### PR TITLE
Add client and airflow build jobs as dep for python release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,9 @@ workflows:
       - release-python:
           <<: *only-on-release
           context: release
+          requires:
+            - build-client-python
+            - build-integration-airflow
       - release-docker:
           <<: *only-on-release
           context: release


### PR DESCRIPTION
Add jobs `build-client-python` and `build-integration-airflow` as a dependencies for the `release-python` job. The jobs build the python distribution needed for the python release.