### PR TITLE
Pin http-proxy-middleware to 0.20.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1719,14 +1719,6 @@
         "hoist-non-react-statics": "^3.3.0"
       }
     },
-    "@types/http-proxy": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.5.tgz",
-      "integrity": "sha512-GNkDE7bTv6Sf8JbV2GksknKOsk7OznNYHSdrtvPJXO0qJ9odZig6IZKUi5RFGi6d1bf6dgIAe4uXi3DBc7069Q==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -7941,22 +7933,14 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.6.tgz",
-      "integrity": "sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.20.0.tgz",
+      "integrity": "sha512-dNJAk71nEJhPiAczQH9hGvE/MT9kEs+zn2Dh+Hi94PGZe1GluQirC7mw5rdREUtWx6qGS1Gu0bZd4qEAg+REgw==",
       "requires": {
-        "@types/http-proxy": "^1.17.4",
-        "http-proxy": "^1.18.1",
+        "http-proxy": "^1.17.0",
         "is-glob": "^4.0.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.14",
         "micromatch": "^4.0.2"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
       }
     },
     "http-signature": {

--- a/web/package.json
+++ b/web/package.json
@@ -43,7 +43,7 @@
     "d3-scale": "^3.2.1",
     "d3-selection": "^1.4.1",
     "dagre": "^0.8.5",
-    "http-proxy-middleware": "^1.0.0",
+    "http-proxy-middleware": "^0.20.0",
     "jest": "26.6.3",
     "lodash": "^4.17.19",
     "postcss-loader": "^3.0.0",


### PR DESCRIPTION
Pin `http-proxy-middleware` to 0.20.0 to fix running UI in docker