### PR TITLE
Unpin requests dep in airflow integration

### DIFF
--- a/integrations/airflow/setup.py
+++ b/integrations/airflow/setup.py
@@ -21,7 +21,7 @@ with open("README.md") as readme_file:
 
 requirements = [
     "attrs==19.3",
-    "requests==2.25.1",
+    "requests>=2.25.1",
     "sqlparse==0.4.1",
 ]
 

--- a/integrations/airflow/setup.py
+++ b/integrations/airflow/setup.py
@@ -21,7 +21,7 @@ with open("README.md") as readme_file:
 
 requirements = [
     "attrs==19.3",
-    "requests>=2.25.1",
+    "requests>=2.24.0",
     "sqlparse==0.4.1",
 ]
 


### PR DESCRIPTION
Only Airflow `1.10.15` has `2.25.1` of `requests` installed, unpinning to fix broken integration for later versions of Airflow. 