### PR TITLE
Add release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,11 +100,12 @@ jobs:
       - image: circleci/python:3.6
     steps:
       - *checkout_project_root
-      - run: python setup.py bdist_wheel
+      - run: python setup.py sdist bdist_wheel
       - persist_to_workspace:
-          root: python/dist/
+          root: .
           paths:
-            - ./*
+            - ./dist/*.whl
+            - ./dist/*.tar.gz
 
   build-integration-spark:
     working_directory: ~/marquez/integrations/spark
@@ -150,11 +151,12 @@ jobs:
       - image: circleci/python:3.6
     steps:
       - *checkout_project_root
-      - run: python setup.py bdist_wheel
+      - run: python setup.py sdist bdist_wheel
       - persist_to_workspace:
-          root: python/dist/
+          root: .
           paths:
-            - ./*
+            - ./dist/*.whl
+            - ./dist/*.tar.gz
 
   integration-test-airflow:
     working_directory: ~/marquez/integrations/airflow
@@ -207,6 +209,8 @@ workflows:
       - integration-test-airflow:
           requires:
             - test-integration-airflow
+      - build-client-python
+      - build-integration-airflow
   release:
     jobs:
       - build-client-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,8 +195,7 @@ jobs:
       - attach_workspace:
           at: .
       - run: pip install wheel twine
-      - run: ls dist
-      #- run: python -m twine upload --non-interactive --repository pypi /tmp/workspace/python/*
+      - run: python -m twine upload --non-interactive --verbose --repository pypi dist/*
 
 workflows:
   marquez:
@@ -210,13 +209,6 @@ workflows:
       - integration-test-airflow:
           requires:
             - test-integration-airflow
-      - build-client-python
-      - build-integration-airflow
-      - release-python:
-          context: release
-          requires:
-            - build-client-python
-            - build-integration-airflow
   release:
     jobs:
       - build-client-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
       - attach_workspace:
           at: .
       - run: pip install wheel twine
-      - run: ls
+      - run: ls dist
       #- run: python -m twine upload --non-interactive --repository pypi /tmp/workspace/python/*
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,9 +193,10 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: /tmp/workspace
+          at: .
       - run: pip install wheel twine
-      - run: python -m twine upload --non-interactive --repository pypi /tmp/workspace/python/*
+      - run: ls
+      #- run: python -m twine upload --non-interactive --repository pypi /tmp/workspace/python/*
 
 workflows:
   marquez:
@@ -211,6 +212,11 @@ workflows:
             - test-integration-airflow
       - build-client-python
       - build-integration-airflow
+      - release-python:
+          context: release
+          requires:
+            - build-client-python
+            - build-integration-airflow
   release:
     jobs:
       - build-client-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,12 +203,14 @@ workflows:
       - build-client-java
       - build-integration-spark
       - test-client-python
-      - build-client-python:
-          <<: *only-on-release
       - test-integration-airflow
       - integration-test-airflow:
           requires:
             - test-integration-airflow
+  release:
+    jobs:
+      - build-client-python:
+          <<: *only-on-release
       - build-integration-airflow:
           <<: *only-on-release
       - release-java:


### PR DESCRIPTION
This PR adds the workflow `release` to group CI jobs when releasing Marquez. This PR also fixes the paths for the python dist used in `release-python`