### PR TITLE
Set ORG_GRADLE_PROJECT_signingKey before publishing *.jar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,11 @@ jobs:
     steps:
       - checkout
       - run: ./.circleci/get-jdk11.sh
-      - run: ./gradlew publish
+      - run: |
+          # Get, then decode the GPG private key used to sign *.jar
+          export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
+          # Publish *.jar
+          ./gradlew publish
 
 
   release-docker:


### PR DESCRIPTION
This PR fixes the `release-java` CI job by add `GPG_SIGNING_KEY` to the CI `release` context as a base64 encoded string. The `ORG_GRADLE_PROJECT_signingKey` is set to the decoded private key before running the cmd to publish `*.jar` to maven. 