### PR TITLE
Add ssl context

### DIFF
--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -36,3 +36,20 @@ NamespaceMeta meta = NamespaceMeta().builder()
 // Create namespace
 Namespace namespace = client.createNamespace("my-namespace", meta);
 ```
+
+### Supply an SSLContext to enable TLS
+```java
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import marquez.client.MarquezClient;
+...
+KeyManager[] keyManager = setUpKeyManagers();
+TrustManager[] trustManager = setUpTrustManagers();
+SSLContext sslContext = SSLContext.getInstance("TLS");
+sslContext.init(keyManager, trustManager, null);
+MarquezClient client = MarquezClient.builder()
+        .sslContext(sslContext)
+        .baseUrl("https://localhost:5000")
+        .build();
+```

--- a/clients/java/src/main/java/marquez/client/MarquezClient.java
+++ b/clients/java/src/main/java/marquez/client/MarquezClient.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Value;
@@ -292,6 +293,7 @@ public class MarquezClient {
   public static final class Builder {
     @VisibleForTesting URL baseUrl;
     @VisibleForTesting @Nullable String apiKey;
+    @VisibleForTesting @Nullable SSLContext sslContext;
 
     private Builder() {
       this.baseUrl = DEFAULT_BASE_URL;
@@ -311,9 +313,15 @@ public class MarquezClient {
       return this;
     }
 
+    public Builder sslContext(@Nullable SSLContext sslContext) {
+      this.sslContext = sslContext;
+      return this;
+    }
+
     public MarquezClient build() {
       return new MarquezClient(
-          MarquezUrl.create(baseUrl), MarquezHttp.create(MarquezClient.Version.get(), apiKey));
+          MarquezUrl.create(baseUrl),
+          MarquezHttp.create(sslContext, MarquezClient.Version.get(), apiKey));
     }
   }
 

--- a/clients/java/src/main/java/marquez/client/MarquezHttp.java
+++ b/clients/java/src/main/java/marquez/client/MarquezHttp.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Value;
@@ -61,6 +62,19 @@ class MarquezHttp implements Closeable {
     final UserAgent userAgent = UserAgent.of(version);
     final CloseableHttpClient http =
         HttpClientBuilder.create().setUserAgent(userAgent.getValue()).build();
+    return new MarquezHttp(http, apiKey);
+  }
+
+  static MarquezHttp create(
+      @Nullable SSLContext sslContext,
+      @NonNull final MarquezClient.Version version,
+      @Nullable final String apiKey) {
+    final UserAgent userAgent = UserAgent.of(version);
+    final CloseableHttpClient http =
+        HttpClientBuilder.create()
+            .setUserAgent(userAgent.getValue())
+            .setSSLContext(sslContext)
+            .build();
     return new MarquezHttp(http, apiKey);
   }
 

--- a/clients/java/src/test/java/marquez/client/MarquezClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezClientTest.java
@@ -49,11 +49,16 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.net.URI;
 import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
 import marquez.client.MarquezClient.DatasetVersions;
 import marquez.client.MarquezClient.Datasets;
 import marquez.client.MarquezClient.Jobs;
@@ -372,6 +377,21 @@ public class MarquezClientTest {
     final String badUrlString = "test.com/api/v1";
     assertThatExceptionOfType(AssertionError.class)
         .isThrownBy(() -> MarquezClient.builder().baseUrl(badUrlString).build());
+  }
+
+  @Test
+  public void testClientBuilder_sslContext()
+      throws NoSuchAlgorithmException, KeyManagementException {
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(new KeyManager[0], new TrustManager[0], null);
+
+    MarquezClient.Builder builder = MarquezClient.builder();
+    assertThat(builder.sslContext == null);
+
+    builder.sslContext(sslContext);
+    assertThat(builder.sslContext != null);
+
+    builder.build();
   }
 
   @Test

--- a/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.net.URL;
 import java.time.Instant;
+import javax.net.ssl.SSLContext;
 import marquez.client.models.JsonGenerator;
 import marquez.client.models.Namespace;
 import marquez.client.models.NamespaceMeta;
@@ -90,6 +91,9 @@ public class MarquezHttpTest {
     assertThatNullPointerException().isThrownBy(() -> MarquezHttp.create(null));
     assertThatNullPointerException().isThrownBy(() -> MarquezHttp.create(null, API_KEY));
     assertThatNullPointerException().isThrownBy(() -> MarquezHttp.create(null, null));
+    assertThatNullPointerException().isThrownBy(() -> MarquezHttp.create(null, null, null));
+    assertThatNullPointerException()
+        .isThrownBy(() -> MarquezHttp.create(SSLContext.getDefault(), null, API_KEY));
   }
 
   @Test


### PR DESCRIPTION
Add SSLContext argument to MarquezClient create method to allow for SSL configurations

Replaces #1305 with a fresh start after feedback.