### PR TITLE
Rewrite correlated subqueries

### DIFF
--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -62,15 +62,17 @@ public interface OpenLineageDao extends BaseDao {
           + "event_type, "
           + "event_time, "
           + "run_id, "
+          + "run_uuid, "
           + "job_name, "
           + "job_namespace, "
           + "event, "
           + "producer) "
-          + "VALUES (?, ?, ?, ?, ?, ?, ?)")
+          + "VALUES (?, ?, ?, ?, ?, ?, ?, ?)")
   void createLineageEvent(
       String eventType,
       Instant eventTime,
-      String runId,
+      UUID runId,
+      UUID runUuid,
       String jobName,
       String jobNamespace,
       PGobject event,

--- a/api/src/main/java/marquez/db/RunDao.java
+++ b/api/src/main/java/marquez/db/RunDao.java
@@ -79,25 +79,48 @@ public interface RunDao extends BaseDao {
           + "WHERE uuid = :rowUuid")
   void updateEndState(UUID rowUuid, Instant transitionedAt, UUID endRunStateUuid);
 
-  String BASE_RUN_SELECT =
+  @SqlQuery(
       "SELECT r.*, ra.args, ra.args, ctx.context, f.facets\n"
-          + "FROM runs AS r "
-          + "LEFT OUTER JOIN "
-          + "(SELECT le.run_id, JSON_AGG(event->'run'->'facets') AS facets\n"
-          + "   FROM lineage_events le\n"
-          + "   GROUP BY le.run_id\n"
-          + ") AS f ON r.uuid::text=f.run_id\n"
+          + "FROM runs AS r\n"
+          + "LEFT OUTER JOIN\n"
+          + "(\n"
+          + "    SELECT le.run_uuid, JSON_AGG(event->'run'->'facets') AS facets\n"
+          + "    FROM lineage_events le\n"
+          + "    WHERE le.run_uuid=:runUuid\n"
+          + "    GROUP BY le.run_uuid\n"
+          + ") AS f ON r.uuid=f.run_uuid\n"
           + "LEFT OUTER JOIN run_args AS ra ON ra.uuid = r.run_args_uuid\n"
-          + "LEFT OUTER JOIN job_contexts AS ctx ON r.job_context_uuid = ctx.uuid \n";
-
-  @SqlQuery(BASE_RUN_SELECT + " WHERE r.uuid = :runUuid")
+          + "LEFT OUTER JOIN job_contexts AS ctx ON r.job_context_uuid = ctx.uuid\n"
+          + "WHERE r.uuid = :runUuid")
   Optional<Run> findRunByUuid(UUID runUuid);
 
-  @SqlQuery(BASE_RUN_SELECT + " WHERE r.uuid = :runUuid")
+  @SqlQuery(
+      "SELECT r.*, ra.args, ra.args, ctx.context, f.facets\n"
+          + "FROM runs AS r\n"
+          + "LEFT OUTER JOIN\n"
+          + "(\n"
+          + "    SELECT le.run_uuid, JSON_AGG(event->'run'->'facets') AS facets\n"
+          + "    FROM lineage_events le\n"
+          + "    WHERE le.run_uuid=:runUuid\n"
+          + "    GROUP BY le.run_uuid\n"
+          + ") AS f ON r.uuid=f.run_uuid\n"
+          + "LEFT OUTER JOIN run_args AS ra ON ra.uuid = r.run_args_uuid\n"
+          + "LEFT OUTER JOIN job_contexts AS ctx ON r.job_context_uuid = ctx.uuid\n"
+          + "WHERE r.uuid = :runUuid")
   Optional<ExtendedRunRow> findRunByUuidAsRow(UUID runUuid);
 
   @SqlQuery(
-      BASE_RUN_SELECT
+      "SELECT r.*, ra.args, ra.args, ctx.context, f.facets\n"
+          + "FROM runs AS r\n"
+          + "LEFT OUTER JOIN\n"
+          + "(\n"
+          + "    SELECT le.run_uuid, JSON_AGG(event->'run'->'facets') AS facets\n"
+          + "    FROM lineage_events le\n"
+          + "    WHERE le.job_name=:jobName AND le.job_namespace=:namespace\n"
+          + "    GROUP BY le.run_uuid\n"
+          + ") AS f ON r.uuid=f.run_uuid\n"
+          + "LEFT OUTER JOIN run_args AS ra ON ra.uuid = r.run_args_uuid\n"
+          + "LEFT OUTER JOIN job_contexts AS ctx ON r.job_context_uuid = ctx.uuid\n"
           + "WHERE r.namespace_name = :namespace and r.job_name = :jobName "
           + "ORDER BY STARTED_AT DESC NULLS LAST "
           + "LIMIT :limit OFFSET :offset")
@@ -344,8 +367,18 @@ public interface RunDao extends BaseDao {
   void updateJobVersion(UUID runUuid, UUID jobVersionUuid);
 
   @SqlQuery(
-      BASE_RUN_SELECT
-          + "where r.job_name = :jobName and r.namespace_name = :namespaceName "
+      "SELECT r.*, ra.args, ra.args, ctx.context, f.facets\n"
+          + "FROM runs AS r\n"
+          + "LEFT OUTER JOIN\n"
+          + "(\n"
+          + "    SELECT le.run_uuid, JSON_AGG(event->'run'->'facets' ORDER BY event_time) AS facets\n"
+          + "    FROM lineage_events le\n"
+          + "    WHERE le.job_name=:jobName AND le.job_namespace=:namespaceName\n"
+          + "    GROUP BY le.run_uuid\n"
+          + ") AS f ON r.uuid=f.run_uuid\n"
+          + "LEFT OUTER JOIN run_args AS ra ON ra.uuid = r.run_args_uuid\n"
+          + "LEFT OUTER JOIN job_contexts AS ctx ON r.job_context_uuid = ctx.uuid\n"
+          + "WHERE r.job_name = :jobName AND r.namespace_name = :namespaceName "
           + "order by transitioned_at desc limit 1")
   Optional<Run> findByLatestJob(String namespaceName, String jobName);
 }

--- a/api/src/main/resources/marquez/db/migration/V33__index_lineage_events_run_id.sql
+++ b/api/src/main/resources/marquez/db/migration/V33__index_lineage_events_run_id.sql
@@ -1,0 +1,26 @@
+ALTER TABLE lineage_events
+    ADD run_uuid uuid;
+
+CREATE INDEX lineage_events_run_id_index
+    on lineage_events(run_uuid);
+
+CREATE INDEX lineage_events_job_name_index
+    on lineage_events(job_name, job_namespace);
+
+CREATE OR REPLACE FUNCTION write_run_uuid()
+RETURNS trigger
+LANGUAGE plpgsql AS
+$func$
+BEGIN
+    NEW.run_uuid := NEW.run_id::uuid;
+    RETURN NEW;
+END
+$func$;
+
+CREATE TRIGGER lineage_events_run_uuid
+    BEFORE INSERT ON lineage_events
+    FOR EACH ROW
+    WHEN (NEW.run_uuid IS NULL AND NEW.run_id IS NOT NULL)
+EXECUTE PROCEDURE write_run_uuid();
+
+UPDATE lineage_events SET run_uuid=run_id::uuid;


### PR DESCRIPTION
Updated facet queries to avoid correlated subqueries. I also introduced an index on the lineage_events table with a new `run_uuid` column, that is explicitly a UUID type (open lineage spec should be updated to make the run id a UUID).

For testing, I generated a query plan with some production data, both before and after the change:
## Before
```sql
EXPLAIN SELECT d.*, dv.fields, sv.schema_location,
  ARRAY(SELECT t.name FROM tags AS t
         INNER JOIN datasets_tag_mapping AS m ON m.tag_uuid = t.uuid
         WHERE d.uuid = m.dataset_uuid) AS tags,
  (SELECT JSON_AGG(facets_by_event.facets)
     FROM (
        (SELECT JSONB_ARRAY_ELEMENTS(event->'inputs')->'facets' AS facets
           FROM lineage_events AS le
          WHERE le.run_id = dv.run_uuid
          ORDER BY event_time ASC)
        UNION
        (SELECT JSONB_ARRAY_ELEMENTS(event->'outputs')->'facets' AS facets
           FROM lineage_events AS le
          WHERE le.run_id = dv.run_uuid
          ORDER BY event_time ASC)
     ) AS facets_by_event
  ) AS facets
  FROM datasets AS d
  LEFT OUTER JOIN stream_versions AS sv ON sv.dataset_version_uuid = d.current_version_uuid
  LEFT OUTER JOIN dataset_versions AS dv ON dv.uuid = d.current_version_uuid
  WHERE d.name = :datasetName
  AND d.namespace_name = :namespaceName
```
```
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                                                                               |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|Limit  (cost=11289633.12..11289635.42 rows=20 width=1103)                                                                                                                                                |
|  ->  Gather Merge  (cost=11289633.12..11291490.25 rows=16149 width=1103)                                                                                                                                |
|        Workers Planned: 1                                                                                                                                                                               |
|        ->  Sort  (cost=11288633.11..11288673.48 rows=16149 width=1103)                                                                                                                                  |
|              Sort Key: r.started_at DESC NULLS LAST                                                                                                                                                     |
|              ->  Hash Left Join  (cost=11277217.87..11288203.39 rows=16149 width=1103)                                                                                                                  |
|                    Hash Cond: ((r.uuid)::text = f.run_id)                                                                                                                                               |
|                    ->  Nested Loop Left Join  (cost=944.63..11927.43 rows=922 width=954)                                                                                                                |
|                          ->  Hash Left Join  (cost=944.21..5251.91 rows=922 width=420)                                                                                                                  |
|                                Hash Cond: (r.run_args_uuid = ra.uuid)                                                                                                                                   |
|                                ->  Parallel Bitmap Heap Scan on runs r  (cost=520.61..4825.89 rows=922 width=303)                                                                                       |
|                                      Recheck Cond: (((job_name)::text = 'recs-ai-user-events-update.bq_merge_home_page_view_events'::text) AND ((namespace_name)::text = :namespaceName::text))    |
|                                      ->  Bitmap Index Scan on runs_created_at_by_name_index  (cost=0.00..520.22 rows=1567 width=0)                                                                      |
|                                            Index Cond: (((job_name)::text = :datasetName::text) AND ((namespace_name)::text = :namespaceName::text))|
|                                ->  Hash  (cost=342.71..342.71 rows=6471 width=133)                                                                                                                      |
|                                      ->  Seq Scan on run_args ra  (cost=0.00..342.71 rows=6471 width=133)                                                                                               |
|                          ->  Index Scan using job_contexts_pkey on job_contexts ctx  (cost=0.42..7.24 rows=1 width=550)                                                                                 |
|                                Index Cond: (r.job_context_uuid = uuid)                                                                                                                                  |
|                    ->  Hash  (cost=11276229.44..11276229.44 rows=3504 width=69)                                                                                                                         |
|                          ->  Subquery Scan on f  (cost=11119763.23..11276229.44 rows=3504 width=69)                                                                                                     |
|                                ->  GroupAggregate  (cost=11119763.23..11276194.40 rows=3504 width=69)                                                                                                   |
|                                      Group Key: le.run_id                                                                                                                                               |
|                                      ->  Sort  (cost=11119763.23..11151040.70 rows=12510990 width=499)                                                                                                  |
|                                            Sort Key: le.run_id                                                                                                                                          |
|                                            ->  Seq Scan on lineage_events le  (cost=0.00..1178007.90 rows=12510990 width=499)                                                                           |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

## After
```sql
EXPLAIN SELECT d.*, dv.fields, sv.schema_location, facets, t.tags
          FROM datasets d
          LEFT JOIN dataset_versions dv on d.current_version_uuid = dv.uuid
          LEFT JOIN stream_versions AS sv ON sv.dataset_version_uuid = dv.uuid
          LEFT JOIN (
              SELECT ARRAY_AGG(t.name) AS tags, m.dataset_uuid
              FROM tags AS t
              INNER JOIN datasets_tag_mapping AS m ON m.tag_uuid = t.uuid
              GROUP BY m.dataset_uuid, t.name
          ) t ON t.dataset_uuid=d.uuid
          LEFT JOIN (
              SELECT d2.uuid, jsonb_agg(ds->'facets') AS facets
              FROM datasets d2
              INNER JOIN runs_input_mapping ri ON ri.dataset_version_uuid=d2.current_version_uuid
              INNER JOIN (
                  SELECT run_uuid, ds
                  FROM lineage_events AS le,
                       jsonb_array_elements(event -> 'inputs' || event -> 'outputs') as ds
                  WHERE ds -> 'facets' IS NOT NULL
              ) i ON ri.run_uuid = i.run_uuid AND ds->>'name'=d2.name
              WHERE d2.name = :datasetName
              AND d2.namespace_name = :namespaceName
              GROUP BY d2.uuid
          ) f ON f.uuid=d.uuid
          WHERE d.name = :datasetName
          AND d.namespace_name = :namespaceName;
```
```
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                                                                                                                                                           |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|Nested Loop Left Join  (cost=1047714.17..1047777.32 rows=1 width=1990)                                                                                                                                                                                                               |
|  Join Filter: (d2.uuid = d.uuid)                                                                                                                                                                                                                                                    |
|  ->  Nested Loop Left Join  (cost=108.65..158.71 rows=1 width=1958)                                                                                                                                                                                                                 |
|        ->  Nested Loop Left Join  (cost=108.51..158.54 rows=1 width=1458)                                                                                                                                                                                                           |
|              ->  Merge Right Join  (cost=108.09..150.10 rows=1 width=425)                                                                                                                                                                                                           |
|                    Merge Cond: (m.dataset_uuid = d.uuid)                                                                                                                                                                                                                            |
|                    ->  GroupAggregate  (cost=99.51..126.51 rows=1200 width=564)                                                                                                                                                                                                     |
|                          Group Key: m.dataset_uuid, t.name                                                                                                                                                                                                                          |
|                          ->  Sort  (cost=99.51..102.51 rows=1200 width=532)                                                                                                                                                                                                         |
|                                Sort Key: m.dataset_uuid, t.name                                                                                                                                                                                                                     |
|                                ->  Hash Join  (cost=12.93..38.14 rows=1200 width=532)                                                                                                                                                                                               |
|                                      Hash Cond: (m.tag_uuid = t.uuid)                                                                                                                                                                                                               |
|                                      ->  Seq Scan on datasets_tag_mapping m  (cost=0.00..22.00 rows=1200 width=32)                                                                                                                                                                  |
|                                      ->  Hash  (cost=11.30..11.30 rows=130 width=532)                                                                                                                                                                                               |
|                                            ->  Seq Scan on tags t  (cost=0.00..11.30 rows=130 width=532)                                                                                                                                                                            |
|                    ->  Sort  (cost=8.57..8.58 rows=1 width=393)                                                                                                                                                                                                                     |
|                          Sort Key: d.uuid                                                                                                                                                                                                                                           |
|                          ->  Index Scan using dataset_name_index on datasets d  (cost=0.54..8.56 rows=1 width=393)                                                                                                                                                                  |
|                                Index Cond: (((name)::text =:datasetName::text) AND ((namespace_name)::text = :namespaceName::text))                  |
|              ->  Index Scan using dataset_versions_pkey on dataset_versions dv  (cost=0.42..8.44 rows=1 width=1033)                                                                                                                                                                 |
|                    Index Cond: (d.current_version_uuid = uuid)                                                                                                                                                                                                                      |
|        ->  Index Scan using stream_versions_dataset_version_index on stream_versions sv  (cost=0.14..0.16 rows=1 width=532)                                                                                                                                                         |
|              Index Cond: (dataset_version_uuid = dv.uuid)                                                                                                                                                                                                                           |
|  ->  GroupAggregate  (cost=1047605.52..1047618.59 rows=1 width=48)                                                                                                                                                                                                                  |
|        Group Key: d2.uuid                                                                                                                                                                                                                                                           |
|        ->  Sort  (cost=1047605.52..1047608.78 rows=1306 width=48)                                                                                                                                                                                                                   |
|              Sort Key: d2.uuid                                                                                                                                                                                                                                                      |
|              ->  Gather  (cost=1009.15..1047537.93 rows=1306 width=48)                                                                                                                                                                                                              |
|                    Workers Planned: 2                                                                                                                                                                                                                                               |
|                    ->  Nested Loop  (cost=9.15..1046407.33 rows=544 width=48)                                                                                                                                                                                                       |
|                          ->  Nested Loop  (cost=9.14..1045449.88 rows=544 width=589)                                                                                                                                                                                                |
|                                ->  Hash Join  (cost=8.57..6693.81 rows=3 width=144)                                                                                                                                                                                                 |
|                                      Hash Cond: (ri.dataset_version_uuid = d2.current_version_uuid)                                                                                                                                                                                 |
|                                      ->  Parallel Seq Scan on runs_input_mapping ri  (cost=0.00..6146.02 rows=205402 width=32)                                                                                                                                                      |
|                                      ->  Hash  (cost=8.56..8.56 rows=1 width=144)                                                                                                                                                                                                   |
|                                            ->  Index Scan using dataset_name_index on datasets d2  (cost=0.54..8.56 rows=1 width=144)                                                                                                                                               |
|                                                  Index Cond: (((name)::text = :datasetName::text) AND ((namespace_name)::text = :namespaceName::text))|
|                                ->  Index Scan using lineage_events_run_id_index on lineage_events le  (cost=0.56..345330.53 rows=92149 width=477)                                                                                                                                   |
|                                      Index Cond: (run_uuid = ri.run_uuid)                                                                                                                                                                                                           |
|                          ->  Function Scan on jsonb_array_elements ds  (cost=0.01..1.76 rows=1 width=32)                                                                                                                                                                            |
|                                Filter: (((value -> 'facets'::text) IS NOT NULL) AND ((value ->> 'name'::text) = :datasetName::text))                                       |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

Note the cost went from 11,289,635 to 1,047,777 - roughly an order of magnitude improvement. The other queries in the change saw similar improvements. 

For backward compatibility, the migration adds a new `run_uuid` column, rather than changing the type of the existing column. This enables existing code to continue running while the migration happens. It also makes rollback possible. The old column can be dropped in a future migration.