### PR TITLE
Improve Renovate Dependency Management Configurations

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,14 @@
   "extends": [
     "config:base",
     "docker:disable",
-    ":gitSignOff"
+    ":gitSignOff",
+    ":separateMultipleMajorReleases",
+    ":automergePatch"
   ],
   "baseBranches": ["update-deps"],
   "lockFileMaintenance": { "enabled": true },
-  "schedule": ["every weekend"]
+  "schedule": ["every weekend"],
+  "npm": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
Changes renovate dependency management settings to automatically merge patches, requires explicit upgrades for each major version (no skipping), and disables renovate completely for the NPM managed javascript within the web project. Changes to the website dependency versions require manual validation and automating these via renovate has proven to be dangerous.