### PR TITLE
Added filters to input/output dataset lineage queries to improve perf

### DIFF
--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -89,7 +89,7 @@ public interface LineageDao {
           + "    LEFT JOIN (SELECT dataset_uuid, ARRAY_AGG(DISTINCT v.job_uuid) AS job_ids\n"
           + "        FROM job_versions_io_mapping io2\n"
           + "        INNER JOIN job_versions v on io2.job_version_uuid = v.uuid\n"
-          + "        WHERE io2.io_type='INPUT'\n"
+          + "        WHERE io2.io_type='INPUT' AND v.job_uuid IN (<jobIds>)\n"
           + "        GROUP BY dataset_uuid\n"
           + "        ) io ON io.dataset_uuid=ds.uuid\n"
           + "    LEFT JOIN dataset_versions dv on dv.uuid = ds.current_version_uuid;")
@@ -116,7 +116,7 @@ public interface LineageDao {
           + "    LEFT JOIN (SELECT dataset_uuid, ARRAY_AGG(DISTINCT v.job_uuid) AS job_ids\n"
           + "        FROM job_versions_io_mapping io2\n"
           + "        INNER JOIN job_versions v on io2.job_version_uuid = v.uuid\n"
-          + "        WHERE io2.io_type='OUTPUT'\n"
+          + "        WHERE io2.io_type='OUTPUT' AND v.job_uuid IN (<jobIds>)\n"
           + "        GROUP BY dataset_uuid\n"
           + "        ) io ON io.dataset_uuid=ds.uuid\n"
           + "    LEFT JOIN dataset_versions dv on dv.uuid = ds.current_version_uuid;")


### PR DESCRIPTION
Added jobId filters to the subquery in the input/output dataset queries in the lineage dao. The change in the filtering alters the behavior of the query so that only job ids referenced in the input arguments are returned, even if the datasets consumed have other consumer/producer job ids. But the `LineageService`, where these are called, actually expects only job ids that have already been fetched by the `getLineage` query, so all jobIds will be in the input arguments (see https://github.com/MarquezProject/marquez/blob/main/api/src/main/java/marquez/service/LineageService.java#L108-L114 ). This change did introduce a substantial change in the performance of the query.

### Original
```
Nested Loop Left Join  (cost=1301672.75..1357341.30 rows=3315 width=1426)
  CTE dataset_ids
    ->  Nested Loop  (cost=48.89..13576.01 rows=3315 width=16)
          ->  Bitmap Heap Scan on jobs j  (cost=39.29..117.40 rows=26 width=16)
                Recheck Cond: (uuid = ANY ('{...}'::uuid[]))
                ->  Bitmap Index Scan on jobs_pkey  (cost=0.00..39.28 rows=26 width=0)
                      Index Cond: (uuid = ANY ('{...}'::uuid[]))
          ->  Bitmap Heap Scan on job_versions_io_mapping io  (cost=9.60..516.29 rows=135 width=32)
                Recheck Cond: (job_version_uuid = j.current_version_uuid)
                ->  Bitmap Index Scan on job_versions_io_mapping_pkey  (cost=0.00..9.57 rows=135 width=0)
                      Index Cond: (job_version_uuid = j.current_version_uuid)
  ->  Hash Right Join  (cost=1288096.31..1334896.01 rows=3315 width=425)
        Hash Cond: (io2.dataset_uuid = ds.uuid)
        ->  GroupAggregate  (cost=1275090.55..1321868.07 rows=1566 width=48)
              Group Key: io2.dataset_uuid
              ->  Sort  (cost=1275090.55..1290676.53 rows=6234392 width=32)
                    Sort Key: io2.dataset_uuid
                    ->  Hash Join  (cost=29225.62..273156.76 rows=6234392 width=32)
                          Hash Cond: (io2.job_version_uuid = v.uuid)
                          ->  Seq Scan on job_versions_io_mapping io2  (cost=0.00..139010.71 rows=6234392 width=32)
                                Filter: ((io_type)::text = 'OUTPUT'::text)
                          ->  Hash  (cost=19838.50..19838.50 rows=485450 width=32)
                                ->  Seq Scan on job_versions v  (cost=0.00..19838.50 rows=485450 width=32)
        ->  Hash  (cost=12964.33..12964.33 rows=3315 width=393)
              ->  Nested Loop  (cost=0.42..12964.33 rows=3315 width=393)
                    ->  CTE Scan on dataset_ids  (cost=0.00..66.30 rows=3315 width=16)
                    ->  Index Scan using datasets_pkey on datasets ds  (cost=0.42..3.89 rows=1 width=393)
                          Index Cond: (uuid = dataset_ids.dataset_uuid)
  ->  Index Scan using dataset_versions_pkey on dataset_versions dv  (cost=0.42..2.68 rows=1 width=1017)
        Index Cond: (uuid = ds.current_version_uuid)
```

### New
```
Nested Loop Left Join  (cost=133137.20..154978.66 rows=3315 width=1426)
  CTE dataset_ids
    ->  Nested Loop  (cost=48.89..13576.01 rows=3315 width=16)
          ->  Bitmap Heap Scan on jobs j  (cost=39.29..117.40 rows=26 width=16)
                Recheck Cond: (uuid = ANY ('{...}'::uuid[]))
                ->  Bitmap Index Scan on jobs_pkey  (cost=0.00..39.28 rows=26 width=0)
                      Index Cond: (uuid = ANY ('{...}'::uuid[]))
          ->  Bitmap Heap Scan on job_versions_io_mapping io_1  (cost=9.60..516.29 rows=135 width=32)
                Recheck Cond: (job_version_uuid = j.current_version_uuid)
                ->  Bitmap Index Scan on job_versions_io_mapping_pkey  (cost=0.00..9.57 rows=135 width=0)
                      Index Cond: (job_version_uuid = j.current_version_uuid)
  ->  Hash Left Join  (cost=119560.77..132533.38 rows=3315 width=425)
        Hash Cond: (ds.uuid = io.dataset_uuid)
        ->  Nested Loop  (cost=0.42..12964.33 rows=3315 width=393)
              ->  CTE Scan on dataset_ids  (cost=0.00..66.30 rows=3315 width=16)
              ->  Index Scan using datasets_pkey on datasets ds  (cost=0.42..3.89 rows=1 width=393)
                    Index Cond: (uuid = dataset_ids.dataset_uuid)
        ->  Hash  (cost=119540.78..119540.78 rows=1566 width=48)
              ->  Subquery Scan on io  (cost=119067.48..119540.78 rows=1566 width=48)
                    ->  GroupAggregate  (cost=119067.48..119525.12 rows=1566 width=48)
                          Group Key: io2.dataset_uuid
                          ->  Sort  (cost=119067.48..119213.50 rows=58408 width=32)
                                Sort Key: io2.dataset_uuid
                                ->  Gather  (cost=11176.59..114443.36 rows=58408 width=32)
                                      Workers Planned: 2
                                      ->  Parallel Hash Join  (cost=10176.59..107602.56 rows=24337 width=32)
                                            Hash Cond: (io2.job_version_uuid = v.uuid)
                                            ->  Parallel Seq Scan on job_versions_io_mapping io2  (cost=0.00..90607.05 rows=2597663 width=32)
                                                  Filter: ((io_type)::text = 'OUTPUT'::text)
                                            ->  Parallel Hash  (cost=10152.90..10152.90 rows=1895 width=32)
                                                  ->  Parallel Bitmap Heap Scan on job_versions v  (cost=358.25..10152.90 rows=1895 width=32)
                                                        Recheck Cond: (job_uuid = ANY ('{...}'::uuid[]))
                                                        ->  Bitmap Index Scan on job_versions_job_uuid_version_key  (cost=0.00..357.11 rows=4548 width=0)
                                                              Index Cond: (job_uuid = ANY ('{...}'::uuid[]))
  ->  Index Scan using dataset_versions_pkey on dataset_versions dv  (cost=0.42..2.68 rows=1 width=1017)
        Index Cond: (uuid = ds.current_version_uuid)
```