### PR TITLE
Rewrote LineageDao queries and LineageService for performance

### DIFF
--- a/api/src/main/java/marquez/db/Columns.java
+++ b/api/src/main/java/marquez/db/Columns.java
@@ -25,6 +25,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import lombok.NonNull;
@@ -188,6 +189,14 @@ public final class Columns {
       throws SQLException {
     if (results.getObject(column) == null) {
       throw new IllegalArgumentException();
+    }
+    return Arrays.asList((UUID[]) results.getArray(column).getArray());
+  }
+
+  public static List<UUID> uuidArrayOrEmpty(final ResultSet results, final String column)
+      throws SQLException {
+    if (results.getObject(column) == null) {
+      return Collections.emptyList();
     }
     return Arrays.asList((UUID[]) results.getArray(column).getArray());
   }

--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.UUID;
 import marquez.db.mappers.DatasetDataMapper;
 import marquez.db.mappers.JobDataMapper;
+import marquez.db.mappers.JobRowMapper;
 import marquez.db.mappers.RunMapper;
 import marquez.db.models.DatasetData;
 import marquez.db.models.JobData;
@@ -32,6 +33,7 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 @RegisterRowMapper(DatasetDataMapper.class)
 @RegisterRowMapper(JobDataMapper.class)
 @RegisterRowMapper(RunMapper.class)
+@RegisterRowMapper(JobRowMapper.class)
 public interface LineageDao {
 
   /**
@@ -45,89 +47,40 @@ public interface LineageDao {
    */
   @SqlQuery(
       // dataset_ids: all the input and output datasets of the current version of the specified jobs
-      "WITH dataset_ids AS (\n"
-          + "    SELECT DISTINCT dataset_uuid\n"
+      "WITH RECURSIVE\n"
+          + "    job_io AS (\n"
+          + "        SELECT job_uuid,\n"
+          + "        ARRAY_AGG(DISTINCT io.dataset_uuid) FILTER (WHERE io_type='INPUT') AS inputs,\n"
+          + "        ARRAY_AGG(DISTINCT io.dataset_uuid) FILTER (WHERE io_type='OUTPUT') AS outputs\n"
           + "        FROM jobs j\n"
-          + "        INNER JOIN job_versions_io_mapping io ON io.job_version_uuid=j.current_version_uuid\n"
-          + "        WHERE j.uuid IN (<jobIds>)\n"
-          + ")\n"
-          // SELECT DISTINCT j.uuid:
-          // all the jobs that have ever read from or written to those datasets.
-          // note that this includes previous versions of jobs that no longer interact with those
-          // datasets
-          + "SELECT DISTINCT j.uuid\n"
-          + "    FROM job_versions_io_mapping io\n"
-          + "    INNER JOIN dataset_ids ON io.dataset_uuid=dataset_ids.dataset_uuid\n"
-          + "    INNER JOIN job_versions jv ON jv.uuid=io.job_version_uuid\n"
-          + "    INNER JOIN jobs j ON j.uuid=jv.job_uuid")
-  Set<UUID> getLineage(@BindList Set<UUID> jobIds);
+          + "        INNER JOIN job_versions v on j.current_version_uuid = v.uuid\n"
+          + "        LEFT JOIN job_versions_io_mapping io on v.uuid = io.job_version_uuid\n"
+          + "        GROUP BY v.job_uuid\n"
+          + "    ),\n"
+          + "    lineage AS (\n"
+          + "        SELECT job_uuid, inputs, outputs\n"
+          + "        FROM job_io\n"
+          + "        WHERE job_uuid IN (<jobIds>)\n"
+          + "        UNION\n"
+          + "        SELECT io.job_uuid, io.inputs, io.outputs\n"
+          + "        FROM job_io io\n"
+          + "        INNER JOIN lineage l ON array_cat(io.inputs, io.outputs) && array_cat(l.inputs, l.outputs)\n"
+          + "    )\n"
+          + "SELECT j.*, inputs AS input_uuids, outputs AS output_uuids, jc.context\n"
+          + "FROM lineage l2\n"
+          + "INNER JOIN jobs j ON j.uuid=l2.job_uuid\n"
+          + "LEFT JOIN job_contexts jc on jc.uuid = j.current_job_context_uuid")
+  Set<JobData> getLineage(@BindList Set<UUID> jobIds);
 
   @SqlQuery("SELECT uuid from jobs where name = :jobName and namespace_name = :namespace")
   Optional<UUID> getJobUuid(String jobName, String namespace);
 
-  // TODO- the input and output dataset methods below can be combined into a single SQL query
-  // that fetches input and output edges for the returned datasets all at once.
-
-  /**
-   * Return a list of datasets that are either inputs or outputs of the specified job ids and the
-   * <i>output</i> edges of those datasets. Jobs that have no inputs or outputs will return an empty
-   * list.
-   *
-   * @param jobIds
-   * @return
-   */
   @SqlQuery(
-      "WITH dataset_ids AS (\n"
-          + "    SELECT DISTINCT dataset_uuid\n"
-          + "    FROM jobs j\n"
-          + "    INNER JOIN job_versions_io_mapping io ON io.job_version_uuid=j.current_version_uuid\n"
-          + "    WHERE j.uuid IN (<jobIds>)\n"
-          + ")\n"
-          + "SELECT ds.*, COALESCE(job_ids, '{}') AS job_ids, dv.fields\n"
+      "SELECT ds.*, dv.fields\n"
           + "FROM datasets ds\n"
-          + "    INNER JOIN dataset_ids ON dataset_ids.dataset_uuid=ds.uuid\n"
-          + "    LEFT JOIN (SELECT dataset_uuid, ARRAY_AGG(DISTINCT v.job_uuid) AS job_ids\n"
-          + "        FROM job_versions_io_mapping io2\n"
-          + "        INNER JOIN job_versions v on io2.job_version_uuid = v.uuid\n"
-          + "        WHERE io2.io_type='INPUT'\n"
-          + "        GROUP BY dataset_uuid\n"
-          + "        ) io ON io.dataset_uuid=ds.uuid\n"
-          + "    LEFT JOIN dataset_versions dv on dv.uuid = ds.current_version_uuid;")
-  List<DatasetData> getInputDatasetsFromJobIds(@BindList Set<UUID> jobIds);
-
-  /**
-   * Return a list of datasets that are either inputs or outputs of the specified job ids and the
-   * <i>input</i> edges of those datasets. Jobs that have no inputs or outputs will return an empty
-   * list.
-   *
-   * @param jobIds
-   * @return
-   */
-  @SqlQuery(
-      "WITH dataset_ids AS (\n"
-          + "    SELECT DISTINCT dataset_uuid\n"
-          + "    FROM jobs j\n"
-          + "    INNER JOIN job_versions_io_mapping io ON io.job_version_uuid=j.current_version_uuid\n"
-          + "    WHERE j.uuid IN (<jobIds>)\n"
-          + ")\n"
-          + "SELECT ds.*, COALESCE(job_ids, '{}') AS job_ids, dv.fields\n"
-          + "FROM datasets ds\n"
-          + "    INNER JOIN dataset_ids ON dataset_ids.dataset_uuid=ds.uuid\n"
-          + "    LEFT JOIN (SELECT dataset_uuid, ARRAY_AGG(DISTINCT v.job_uuid) AS job_ids\n"
-          + "        FROM job_versions_io_mapping io2\n"
-          + "        INNER JOIN job_versions v on io2.job_version_uuid = v.uuid\n"
-          + "        WHERE io2.io_type='OUTPUT'\n"
-          + "        GROUP BY dataset_uuid\n"
-          + "        ) io ON io.dataset_uuid=ds.uuid\n"
-          + "    LEFT JOIN dataset_versions dv on dv.uuid = ds.current_version_uuid;")
-  List<DatasetData> getOutputDatasetsFromJobIds(@BindList Set<UUID> jobIds);
-
-  @SqlQuery(
-      "select j.*, jc.context\n"
-          + "from jobs j\n"
-          + "left outer join job_contexts jc on jc.uuid = j.current_job_context_uuid\n"
-          + "where j.uuid in (<uuid>)")
-  List<JobData> getJob(@BindList Collection<UUID> uuid);
+          + "LEFT JOIN dataset_versions dv on dv.uuid = ds.current_version_uuid\n"
+          + "WHERE ds.uuid IN (<dsUuids>);")
+  Set<DatasetData> getDatasetData(@BindList Set<UUID> dsUuids);
 
   @SqlQuery(
       "select j.uuid from jobs j\n"

--- a/api/src/main/java/marquez/db/mappers/DatasetDataMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetDataMapper.java
@@ -4,7 +4,7 @@ import static marquez.db.Columns.stringOrNull;
 import static marquez.db.Columns.stringOrThrow;
 import static marquez.db.Columns.timestampOrNull;
 import static marquez.db.Columns.timestampOrThrow;
-import static marquez.db.Columns.uuidOrNull;
+import static marquez.db.Columns.uuidOrThrow;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -36,7 +36,7 @@ public class DatasetDataMapper implements RowMapper<DatasetData> {
   public DatasetData map(@NonNull ResultSet results, @NonNull StatementContext context)
       throws SQLException {
     return new DatasetData(
-        uuidOrNull(results, Columns.ROW_UUID),
+        uuidOrThrow(results, Columns.ROW_UUID),
         new DatasetId(
             NamespaceName.of(stringOrThrow(results, Columns.NAMESPACE_NAME)),
             DatasetName.of(stringOrThrow(results, Columns.NAME))),

--- a/api/src/main/java/marquez/db/mappers/DatasetDataMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetDataMapper.java
@@ -4,7 +4,7 @@ import static marquez.db.Columns.stringOrNull;
 import static marquez.db.Columns.stringOrThrow;
 import static marquez.db.Columns.timestampOrNull;
 import static marquez.db.Columns.timestampOrThrow;
-import static marquez.db.Columns.uuidArrayOrThrow;
+import static marquez.db.Columns.uuidOrNull;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -36,6 +36,7 @@ public class DatasetDataMapper implements RowMapper<DatasetData> {
   public DatasetData map(@NonNull ResultSet results, @NonNull StatementContext context)
       throws SQLException {
     return new DatasetData(
+        uuidOrNull(results, Columns.ROW_UUID),
         new DatasetId(
             NamespaceName.of(stringOrThrow(results, Columns.NAMESPACE_NAME)),
             DatasetName.of(stringOrThrow(results, Columns.NAME))),
@@ -49,8 +50,7 @@ public class DatasetDataMapper implements RowMapper<DatasetData> {
         toFields(results, "fields"),
         ImmutableSet.of(),
         timestampOrNull(results, Columns.LAST_MODIFIED_AT),
-        stringOrNull(results, Columns.DESCRIPTION),
-        uuidArrayOrThrow(results, "job_ids"));
+        stringOrNull(results, Columns.DESCRIPTION));
   }
 
   public static ImmutableList<Field> toFields(ResultSet results, String column)

--- a/api/src/main/java/marquez/db/mappers/JobDataMapper.java
+++ b/api/src/main/java/marquez/db/mappers/JobDataMapper.java
@@ -4,6 +4,7 @@ import static marquez.db.Columns.stringOrNull;
 import static marquez.db.Columns.stringOrThrow;
 import static marquez.db.Columns.timestampOrThrow;
 import static marquez.db.Columns.urlOrNull;
+import static marquez.db.Columns.uuidArrayOrEmpty;
 import static marquez.db.Columns.uuidOrThrow;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -38,7 +39,9 @@ public class JobDataMapper implements RowMapper<JobData> {
         timestampOrThrow(results, Columns.UPDATED_AT),
         NamespaceName.of(stringOrThrow(results, Columns.NAMESPACE_NAME)),
         ImmutableSet.<DatasetId>of(),
+        ImmutableSet.copyOf(uuidArrayOrEmpty(results, Columns.INPUT_UUIDS)),
         ImmutableSet.<DatasetId>of(),
+        ImmutableSet.copyOf(uuidArrayOrEmpty(results, Columns.OUTPUT_UUIDS)),
         urlOrNull(results, "current_location"),
         toContext(results, Columns.CONTEXT),
         stringOrNull(results, Columns.DESCRIPTION),

--- a/api/src/main/java/marquez/db/models/DatasetData.java
+++ b/api/src/main/java/marquez/db/models/DatasetData.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -22,6 +21,7 @@ import marquez.common.models.TagName;
 @Value
 @EqualsAndHashCode(of = "id")
 public class DatasetData implements NodeData {
+  UUID uuid;
   @NonNull DatasetId id;
   @NonNull DatasetType type;
   @NonNull DatasetName name;
@@ -34,7 +34,6 @@ public class DatasetData implements NodeData {
   @NonNull ImmutableSet<TagName> tags;
   @Nullable Instant lastModifiedAt;
   @Nullable String description;
-  List<UUID> jobUuids;
 
   public Optional<Instant> getLastModifiedAt() {
     return Optional.ofNullable(lastModifiedAt);
@@ -45,7 +44,7 @@ public class DatasetData implements NodeData {
   }
 
   @JsonIgnore
-  public List<UUID> getJobUuids() {
-    return jobUuids;
+  public UUID getUuid() {
+    return uuid;
   }
 }

--- a/api/src/main/java/marquez/db/models/JobData.java
+++ b/api/src/main/java/marquez/db/models/JobData.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableSet;
 import java.net.URL;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
@@ -30,7 +31,9 @@ public class JobData implements NodeData {
   @NonNull Instant updatedAt;
   @NonNull NamespaceName namespace;
   @NonNull @Setter ImmutableSet<DatasetId> inputs;
+  @NonNull @Setter ImmutableSet<UUID> inputUuids;
   @NonNull @Setter ImmutableSet<DatasetId> outputs;
+  @NonNull @Setter ImmutableSet<UUID> outputUuids;
   @Nullable URL location;
   @NonNull ImmutableMap<String, String> context;
   @Nullable String description;
@@ -51,5 +54,15 @@ public class JobData implements NodeData {
   @JsonIgnore
   public UUID getUuid() {
     return uuid;
+  }
+
+  @JsonIgnore
+  public Set<UUID> getInputUuids() {
+    return inputUuids;
+  }
+
+  @JsonIgnore
+  public Set<UUID> getOutputUuids() {
+    return outputUuids;
   }
 }

--- a/api/src/main/java/marquez/db/models/JobData.java
+++ b/api/src/main/java/marquez/db/models/JobData.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.ToString;
 import marquez.common.models.DatasetId;
 import marquez.common.models.JobId;
 import marquez.common.models.JobName;
@@ -22,6 +23,7 @@ import marquez.service.models.Run;
 
 @Getter
 @AllArgsConstructor
+@ToString(of = {"namespace", "name", "type"})
 public class JobData implements NodeData {
   UUID uuid;
   @NonNull JobId id;

--- a/api/src/main/java/marquez/service/LineageService.java
+++ b/api/src/main/java/marquez/service/LineageService.java
@@ -1,9 +1,10 @@
 package marquez.service;
 
-import static marquez.tracing.SentryPropagating.withSentry;
-
+import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -13,8 +14,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import marquez.common.models.DatasetId;
 import marquez.common.models.JobId;
@@ -43,29 +45,10 @@ public class LineageService extends DelegatingLineageDao {
     }
     UUID job = optionalUUID.get();
 
-    Set<UUID> seen = new LinkedHashSet<>();
-    Set<UUID> cur = new HashSet<>();
-    cur.add(job);
+    Set<JobData> jobData = getLineage(Collections.singleton(job));
 
-    int i = 0;
-    do {
-      cur = getLineage(cur);
-      cur = new HashSet<UUID>(cur); // allow it to be mutable
-      cur.removeAll(seen); // remove any dupes from current
-      seen.addAll(cur); // add to seen list
-    } while (i++ < depth && !cur.isEmpty()); // working set is empty or depth is reached
-    seen.add(job); // include the base job
-
-    CompletableFuture<List<JobData>> jobFuture =
-        CompletableFuture.supplyAsync(withSentry(() -> getJob(seen)));
-    CompletableFuture<List<DatasetData>> inFuture =
-        CompletableFuture.supplyAsync(withSentry(() -> getInputDatasetsFromJobIds(seen)));
-    CompletableFuture<List<DatasetData>> outFuture =
-        CompletableFuture.supplyAsync(withSentry(() -> getOutputDatasetsFromJobIds(seen)));
-    CompletableFuture.allOf(jobFuture, inFuture, outFuture).get();
-
-    List<Run> runs = getCurrentRuns(seen);
-    List<JobData> jobData = jobFuture.get();
+    List<Run> runs =
+        getCurrentRuns(jobData.stream().map(JobData::getUuid).collect(Collectors.toSet()));
     // todo fix runtime
     for (JobData j : jobData) {
       if (j.getLatestRun().isEmpty()) {
@@ -78,42 +61,51 @@ public class LineageService extends DelegatingLineageDao {
         }
       }
     }
+    Set<DatasetData> datasets =
+        getDatasetData(
+            jobData.stream()
+                .flatMap(
+                    jd -> Stream.concat(jd.getInputUuids().stream(), jd.getOutputUuids().stream()))
+                .collect(Collectors.toSet()));
 
-    return toLineage(seen, jobData, inFuture.get(), outFuture.get());
+    return toLineage(jobData, datasets);
   }
 
-  private Lineage toLineage(
-      Set<UUID> seen, List<JobData> jobData, List<DatasetData> input, List<DatasetData> output) {
+  private URL jobLocation(String location) {
+    try {
+      return new URL(location);
+    } catch (Exception e) {
+      log.warn("Invalid URL for job row {}", location, e);
+      return null;
+    }
+  }
+
+  private Lineage toLineage(Set<JobData> jobData, Set<DatasetData> datasets) {
     Set<Node> nodes = new LinkedHashSet<>();
     // build mapping for later
-    Map<UUID, Set<DatasetData>> jobToDsInput = new HashMap<>();
+    Map<UUID, DatasetData> datasetById =
+        datasets.stream().collect(Collectors.toMap(DatasetData::getUuid, Functions.identity()));
+
     Map<DatasetData, Set<UUID>> dsInputToJob = new HashMap<>();
-    for (DatasetData data : input) {
-      for (UUID jobUuid : data.getJobUuids()) {
-        jobToDsInput.computeIfAbsent(jobUuid, e -> new HashSet<>()).add(data);
-      }
-      dsInputToJob.computeIfAbsent(data, e -> new HashSet<>()).addAll(data.getJobUuids());
-    }
-
-    Map<UUID, Set<DatasetData>> jobToDsOutput = new HashMap<>();
     Map<DatasetData, Set<UUID>> dsOutputToJob = new HashMap<>();
-    for (DatasetData data : output) {
-      for (UUID jobUuid : data.getJobUuids()) {
-        jobToDsOutput.computeIfAbsent(jobUuid, e -> new HashSet<>()).add(data);
-      }
-      dsOutputToJob.computeIfAbsent(data, e -> new HashSet<>()).addAll(data.getJobUuids());
-    }
-
     // build jobs
     Map<UUID, JobData> jobDataMap = Maps.uniqueIndex(jobData, JobData::getUuid);
-    for (UUID jobUuid : seen) {
-      JobData data = jobDataMap.get(jobUuid);
+    for (JobData data : jobData) {
       if (data == null) {
         log.error("Could not find job node for {}", jobData);
         continue;
       }
-      data.setInputs(buildDatasetId(jobToDsInput.get(jobUuid)));
-      data.setOutputs(buildDatasetId(jobToDsOutput.get(jobUuid)));
+      Set<DatasetData> inputs =
+          data.getInputUuids().stream().map(datasetById::get).collect(Collectors.toSet());
+      Set<DatasetData> outputs =
+          data.getOutputUuids().stream().map(datasetById::get).collect(Collectors.toSet());
+      data.setInputs(buildDatasetId(inputs));
+      data.setOutputs(buildDatasetId(outputs));
+
+      inputs.forEach(
+          ds -> dsInputToJob.computeIfAbsent(ds, e -> new HashSet<>()).add(data.getUuid()));
+      outputs.forEach(
+          ds -> dsOutputToJob.computeIfAbsent(ds, e -> new HashSet<>()).add(data.getUuid()));
 
       NodeId origin = NodeId.of(new JobId(data.getNamespace(), data.getName()));
       Node node =
@@ -121,14 +113,11 @@ public class LineageService extends DelegatingLineageDao {
               origin,
               NodeType.JOB,
               data,
-              buildDatasetEdge(jobToDsInput.get(jobUuid), origin),
-              buildDatasetEdge(origin, jobToDsOutput.get(jobUuid)));
+              buildDatasetEdge(inputs, origin),
+              buildDatasetEdge(origin, outputs));
       nodes.add(node);
     }
 
-    Set<DatasetData> datasets = new LinkedHashSet<>();
-    datasets.addAll(input);
-    datasets.addAll(output);
     for (DatasetData dataset : datasets) {
       NodeId origin = NodeId.of(new DatasetId(dataset.getNamespace(), dataset.getName()));
       Node node =

--- a/api/src/test/java/marquez/db/LineageDaoTest.java
+++ b/api/src/test/java/marquez/db/LineageDaoTest.java
@@ -5,17 +5,18 @@ import static marquez.db.LineageTestUtils.newDatasetFacet;
 import static marquez.db.LineageTestUtils.writeDownstreamLineage;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.base.Functions;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-import marquez.common.models.DatasetName;
+import java.util.stream.Stream;
 import marquez.db.LineageTestUtils.DatasetConsumerJob;
 import marquez.db.LineageTestUtils.JobLineage;
 import marquez.db.models.DatasetData;
@@ -26,6 +27,7 @@ import marquez.service.models.LineageEvent.Dataset;
 import marquez.service.models.LineageEvent.JobFacet;
 import marquez.service.models.LineageEvent.SchemaField;
 import marquez.service.models.LineageEvent.SourceCodeLocationJobFacet;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -101,7 +103,7 @@ public class LineageDaoTest {
             jobFacet,
             dataset);
 
-    // don't expect a failed job job in the returned lineage
+    // don't expect a failed job in the returned lineage
     UpdateLineageRow failedJobRow =
         LineageTestUtils.createLineageRow(
             openLineageDao,
@@ -111,33 +113,57 @@ public class LineageDaoTest {
             Arrays.asList(dataset),
             Arrays.asList());
 
+    // don't expect a disjoint job in the returned lineage
+    UpdateLineageRow disjointJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "writeRandomDataset",
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(
+                new Dataset(
+                    NAMESPACE,
+                    "randomDataset",
+                    newDatasetFacet(
+                        new SchemaField("firstname", "string", "the first name"),
+                        new SchemaField("lastname", "string", "the last name")))),
+            Arrays.asList());
     // fetch the first "readJob" lineage.
-    Set<UUID> connectedJobs =
+    Set<JobData> connectedJobs =
         lineageDao.getLineage(new HashSet<>(Arrays.asList(jobRows.get(0).getId())));
-    assertThat(connectedJobs).size().isEqualTo(22);
 
+    // 20 readJobs + 1 downstreamJob for each (20) + 1 write job = 41
+    assertThat(connectedJobs).size().isEqualTo(41);
+
+    Set<UUID> jobIds = connectedJobs.stream().map(JobData::getUuid).collect(Collectors.toSet());
     // expect the job that wrote "commonDataset", which is readJob0's input
-    assertThat(connectedJobs).contains(writeJob.getJob().getUuid());
+    assertThat(jobIds).contains(writeJob.getJob().getUuid());
 
-    // expect all jobs that read the same input dataset as readJob0
+    // expect all downstream jobs
     Set<UUID> readJobUUIDs =
-        jobRows.stream().map(LineageTestUtils.JobLineage::getId).collect(Collectors.toSet());
-    assertThat(connectedJobs).contains(readJobUUIDs.toArray(UUID[]::new));
+        jobRows.stream()
+            .flatMap(row -> Stream.concat(Stream.of(row), row.getDownstreamJobs().stream()))
+            .map(JobLineage::getId)
+            .collect(Collectors.toSet());
+    assertThat(jobIds).containsAll(readJobUUIDs);
 
     // expect that the failed job that reads the same input dataset is not present
-    assertThat(connectedJobs).doesNotContain(failedJobRow.getJob().getUuid());
+    assertThat(jobIds).doesNotContain(failedJobRow.getJob().getUuid());
 
-    // also expect all jobs that read the output of readJob0 (downstreamJob0)
-    Optional<JobData> downstreamJob =
-        connectedJobs.stream()
-            .filter(id -> !readJobUUIDs.contains(id) && !id.equals(writeJob.getJob().getUuid()))
-            .flatMap(id -> lineageDao.getJob(Collections.singletonList(id)).stream())
-            .findAny();
-    assertThat(downstreamJob)
-        .isPresent()
-        .map(jd -> jd.getName().getValue())
-        .get()
-        .isEqualTo("downstreamJob0<-outputData<-readJob0<-commonDataset");
+    // expect that the disjoint job that reads a random dataset is not present
+    assertThat(jobIds).doesNotContain(disjointJob.getJob().getUuid());
+
+    Map<UUID, JobData> actualJobRows =
+        connectedJobs.stream().collect(Collectors.toMap(JobData::getUuid, Functions.identity()));
+    for (JobLineage expected : jobRows) {
+      JobData job = actualJobRows.get(expected.getId());
+      assertThat(job.getInputUuids())
+          .containsAll(
+              expected.getInput().map(ds -> ds.getDatasetRow().getUuid()).stream()::iterator);
+      assertThat(job.getOutputUuids())
+          .containsAll(
+              expected.getOutput().map(ds -> ds.getDatasetRow().getUuid()).stream()::iterator);
+    }
   }
 
   @Test
@@ -151,7 +177,10 @@ public class LineageDaoTest {
             jobFacet,
             Arrays.asList(),
             Arrays.asList(dataset));
-    Set<UUID> lineage = lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid()));
+    Set<UUID> lineage =
+        lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid())).stream()
+            .map(JobData::getUuid)
+            .collect(Collectors.toSet());
     assertThat(lineage).hasSize(1).contains(writeJob.getJob().getUuid());
   }
 
@@ -161,66 +190,12 @@ public class LineageDaoTest {
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
             openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList());
-    Set<UUID> lineage = lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid()));
-    assertThat(lineage).isEmpty();
-  }
+    Set<UUID> lineage =
+        lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid())).stream()
+            .map(JobData::getUuid)
+            .collect(Collectors.toSet());
 
-  /**
-   * Test the datasets that are inputs to the specified job are returned along with their output
-   * edges.
-   */
-  @Test
-  public void testGetInputDatasetsFromJobIds() {
-
-    LineageTestUtils.createLineageRow(
-        openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList(dataset));
-
-    // create a graph starting with the commonDataset, which spawns 20 consumers.
-    // each of those spawns 3 consumers of the "intermediate" dataset
-    // each of those spawns 1 consumer of the "finalOutput" dataset
-    List<JobLineage> jobRows =
-        writeDownstreamLineage(
-            openLineageDao,
-            new LinkedList<>(
-                Arrays.asList(
-                    new DatasetConsumerJob("readJob", 20, Optional.of("intermediate")),
-                    new DatasetConsumerJob("downstreamJob", 3, Optional.of("finalOutput")),
-                    new DatasetConsumerJob("finalConsumer", 1, Optional.empty()))),
-            jobFacet,
-            dataset);
-    // sanity check
-    List<JobLineage> downstreamJobs = jobRows.get(0).getDownstreamJobs();
-    assertThat(downstreamJobs).hasSize(3);
-
-    // fetch the dataset lineage for the first "downstreamJob" job. It touches the "intermediate"
-    // dataset, which is its input, and the "finalOutput", which is its output.
-    // There are 3 "downstreamJob" instances which read the same input dataset and 1
-    // "finalConsumer" job, which reads the output. The returned datasets should have
-    // pointers to those consumers.
-    JobLineage firstDownstream = downstreamJobs.get(0);
-    List<DatasetData> inputDatasets =
-        lineageDao.getInputDatasetsFromJobIds(Collections.singleton(firstDownstream.getId()));
-
-    // two datasets- intermediate and finalOutput
-    assertThat(inputDatasets)
-        .hasSize(2)
-        .map(DatasetData::getName)
-        .map(DatasetName::getValue)
-        .containsAll(
-            Arrays.asList(
-                "finalOutput<-downstreamJob0<-intermediate<-readJob0<-commonDataset",
-                "intermediate<-readJob0<-commonDataset"));
-
-    // first has 1 consumer- the "finalConsumer"
-    List<JobLineage> finalConsumers = firstDownstream.getDownstreamJobs();
-    assertThat(inputDatasets.get(0).getJobUuids())
-        .hasSize(1)
-        .containsAll(finalConsumers.stream().map(JobLineage::getId)::iterator);
-
-    // second one has 3 consumers- the "downstreamJob"s
-    assertThat(inputDatasets.get(1).getJobUuids())
-        .hasSize(3)
-        .containsAll(downstreamJobs.stream().map(JobLineage::getId)::iterator);
+    assertThat(lineage).hasSize(1).first().isEqualTo(writeJob.getJob().getUuid());
   }
 
   /**
@@ -228,7 +203,7 @@ public class LineageDaoTest {
    * the consumed dataset
    */
   @Test
-  public void testGetInputDatasetsWithJobThatSharesNoDatasets() {
+  public void testGetLineageWithJobThatSharesNoDatasets() {
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
             openLineageDao,
@@ -256,46 +231,13 @@ public class LineageDaoTest {
 
     // Validate that finalConsumer job only has a single dataset
     Set<UUID> jobIds = Collections.singleton(writeJob.getJob().getUuid());
-    List<DatasetData> inputsForFinalConsumer = lineageDao.getInputDatasetsFromJobIds(jobIds);
-    assertThat(inputsForFinalConsumer)
-        .hasSize(1)
-        .flatMap(DatasetData::getJobUuids)
-        .hasSize(1)
-        .containsAll(jobIds);
-  }
-
-  @Test
-  public void testGetInputDatasetsWithJobThatHasNoDatasets() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
-
-    UpdateLineageRow writeJob =
-        LineageTestUtils.createLineageRow(
-            openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList());
-    Set<UUID> jobIds = Collections.singleton(writeJob.getJob().getUuid());
-    List<DatasetData> inputDatasets = lineageDao.getInputDatasetsFromJobIds(jobIds);
-    assertThat(inputDatasets).isEmpty();
-  }
-
-  @Test
-  public void testGetInputDatasetsWithJobThatHasOnlyOutputs() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
-
-    UpdateLineageRow writeJob =
-        LineageTestUtils.createLineageRow(
-            openLineageDao,
-            "writeJob",
-            "COMPLETE",
-            jobFacet,
-            Arrays.asList(),
-            Arrays.asList(dataset));
-    List<DatasetData> inputDatasets =
-        lineageDao.getInputDatasetsFromJobIds(Collections.singleton(writeJob.getJob().getUuid()));
-    assertThat(inputDatasets).hasSize(1).flatMap(DatasetData::getJobUuids).isEmpty();
+    Set<JobData> finalConsumer = lineageDao.getLineage(jobIds);
+    assertThat(finalConsumer).hasSize(1).flatMap(JobData::getUuid).hasSize(1).containsAll(jobIds);
   }
 
   /** A failed consumer job doesn't show up in the datasets out edges */
   @Test
-  public void testGetInputDatasetsWithFailedConsumer() {
+  public void testGetLineageWithFailedConsumer() {
     JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
 
     UpdateLineageRow writeJob =
@@ -313,9 +255,13 @@ public class LineageDaoTest {
         jobFacet,
         Arrays.asList(dataset),
         Arrays.asList());
-    List<DatasetData> inputDatasets =
-        lineageDao.getInputDatasetsFromJobIds(Collections.singleton(writeJob.getJob().getUuid()));
-    assertThat(inputDatasets).hasSize(1).flatMap(DatasetData::getJobUuids).isEmpty();
+    Set<JobData> lineage =
+        lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid()));
+
+    assertThat(lineage)
+        .hasSize(1)
+        .extracting(JobData::getUuid)
+        .contains(writeJob.getJob().getUuid());
   }
 
   /**
@@ -361,144 +307,56 @@ public class LineageDaoTest {
             newVersionFacet,
             dataset);
 
-    List<DatasetData> inputData =
-        lineageDao.getInputDatasetsFromJobIds(Collections.singleton(newRows.get(0).getId()));
-    assertThat(inputData)
-        .hasSize(2)
-        .map(ds -> ds.getName().getValue())
-        .containsAll(Arrays.asList("outputData2<-readJob0<-commonDataset", "commonDataset"))
-        .doesNotContain("outputData<-readJob0<-commonDataset");
-
-    assertThat(inputData)
-        .filteredOn(ds -> ds.getName().getValue().equals("outputData2<-readJob0<-commonDataset"))
-        .isNotEmpty()
-        .map(DatasetData::getJobUuids)
-        .first()
-        .asList()
-        .hasSize(1)
-        .contains(newRows.get(0).getDownstreamJobs().get(0).getId());
-  }
-
-  /** */
-  @Test
-  public void testGetOutputDatasetsFromJobIds() {
-
-    LineageTestUtils.createLineageRow(
-        openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList(dataset));
-
-    // create a graph starting with the commonDataset, which spawns 20 consumers.
-    // each of those spawns 3 consumers of the "intermediate" dataset
-    // each of those spawns 1 consumer of the "finalOutput" dataset
-    List<JobLineage> jobRows =
-        writeDownstreamLineage(
-            openLineageDao,
-            new LinkedList<>(
+    Set<JobData> lineage =
+        lineageDao.getLineage(
+            new HashSet<>(
                 Arrays.asList(
-                    new DatasetConsumerJob("readJob", 20, Optional.of("intermediate")),
-                    new DatasetConsumerJob("downstreamJob", 3, Optional.of("finalOutput")),
-                    new DatasetConsumerJob("finalConsumer", 1, Optional.empty()))),
-            jobFacet,
-            dataset);
-    // sanity check
-    List<JobLineage> downstreamJobs = jobRows.get(0).getDownstreamJobs();
-    assertThat(downstreamJobs).hasSize(3);
-
-    // fetch the dataset lineage for the first "downstreamJob" job. It touches the "intermediate"
-    // dataset, which is its input, and the "finalOutput", which is its output.
-    JobLineage firstDownstream = downstreamJobs.get(0);
-    List<DatasetData> outputDatasets =
-        lineageDao.getOutputDatasetsFromJobIds(Collections.singleton(firstDownstream.getId()));
-
-    // two datasets- intermediate and finalOutput
-    assertThat(outputDatasets)
-        .hasSize(2)
-        .map(DatasetData::getName)
-        .map(DatasetName::getValue)
+                    newRows.get(0).getId(), newRows.get(0).getDownstreamJobs().get(0).getId())));
+    assertThat(lineage)
+        .hasSize(7)
+        .extracting(JobData::getUuid)
         .containsAll(
-            Arrays.asList(
-                "finalOutput<-downstreamJob0<-intermediate<-readJob0<-commonDataset",
-                "intermediate<-readJob0<-commonDataset"));
-
-    // find the jobs that output those datasets
-    assertThat(outputDatasets)
-        .map(DatasetData::getJobUuids)
-        .allMatch(l -> l.size() == 1)
-        .flatMap(Function.identity())
-        .containsAll(Arrays.asList(firstDownstream.getId(), jobRows.get(0).getId()));
-  }
-
-  /**
-   * Validate a job that consumes a dataset, but shares no datasets with any other job returns only
-   * the consumed dataset
-   */
-  @Test
-  public void testGetOutputDatasetsWithJobThatSharesNoDatasets() {
-    UpdateLineageRow writeJob =
-        LineageTestUtils.createLineageRow(
-            openLineageDao,
-            "writeJob",
-            "COMPLETE",
-            jobFacet,
-            Arrays.asList(),
-            Arrays.asList(dataset));
-
-    // write a new dataset with a different name
-    Dataset anotherDataset =
-        new Dataset(
-            NAMESPACE,
-            "anUncommonDataset",
-            newDatasetFacet(
-                new SchemaField("firstname", "string", "the first name"),
-                new SchemaField("lastname", "string", "the last name"),
-                new SchemaField("birthdate", "date", "the date of birth")));
-    // write a bunch of jobs that share nothing with the writeJob
-    writeDownstreamLineage(
-        openLineageDao,
-        Arrays.asList(new DatasetConsumerJob("consumer", 5, Optional.empty())),
-        jobFacet,
-        anotherDataset);
-
-    Set<UUID> jobIds = Collections.singleton(writeJob.getJob().getUuid());
-    List<DatasetData> outputDatasets = lineageDao.getOutputDatasetsFromJobIds(jobIds);
-    assertThat(outputDatasets)
+            newRows.stream()
+                    .flatMap(r -> Stream.concat(Stream.of(r), r.getDownstreamJobs().stream()))
+                    .map(JobLineage::getId)
+                ::iterator);
+    assertThat(lineage)
+        .filteredOn(r -> r.getName().getValue().equals("readJob0<-commonDataset"))
         .hasSize(1)
-        .flatMap(DatasetData::getJobUuids)
+        .first()
+        .extracting(JobData::getOutputUuids, InstanceOfAssertFactories.iterable(UUID.class))
         .hasSize(1)
-        .containsAll(jobIds);
+        .first()
+        .isEqualTo(newRows.get(0).getOutput().get().getDatasetRow().getUuid());
+
+    assertThat(lineage)
+        .filteredOn(
+            r ->
+                r.getName()
+                    .getValue()
+                    .equals("downstreamJob0<-outputData2<-readJob0<-commonDataset"))
+        .hasSize(1)
+        .first()
+        .extracting(JobData::getInputUuids, InstanceOfAssertFactories.iterable(UUID.class))
+        .hasSize(1)
+        .first()
+        .isEqualTo(
+            newRows.get(0).getDownstreamJobs().get(0).getInput().get().getDatasetRow().getUuid());
+    assertThat(lineage)
+        .filteredOn(
+            r ->
+                r.getName()
+                    .getValue()
+                    .equals("downstreamJob0<-outputData2<-readJob0<-commonDataset"))
+        .hasSize(1)
+        .first()
+        .extracting(JobData::getOutputUuids, InstanceOfAssertFactories.iterable(UUID.class))
+        .isEmpty();
   }
 
+  /** A failed producer job doesn't show up in the lineage */
   @Test
-  public void testGetOutputDatasetsWithJobThatHasNoDatasets() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
-
-    UpdateLineageRow writeJob =
-        LineageTestUtils.createLineageRow(
-            openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList());
-    List<DatasetData> lineage =
-        lineageDao.getOutputDatasetsFromJobIds(Collections.singleton(writeJob.getJob().getUuid()));
-    assertThat(lineage).isEmpty();
-  }
-
-  @Test
-  public void testGetOutputDatasetsWithJobThatHasOnlyInputs() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
-
-    UpdateLineageRow writeJob =
-        LineageTestUtils.createLineageRow(
-            openLineageDao,
-            "writeJob",
-            "COMPLETE",
-            jobFacet,
-            Arrays.asList(dataset),
-            Arrays.asList());
-    Set<UUID> jobIds = Collections.singleton(writeJob.getJob().getUuid());
-    List<DatasetData> outputDatasets = lineageDao.getOutputDatasetsFromJobIds(jobIds);
-    assertThat(outputDatasets).hasSize(1).flatMap(DatasetData::getJobUuids).isEmpty();
-  }
-
-  /** A failed producer job doesn't show up in the datasets in edges */
-  @Test
-  public void testGetOutputDatasetsWithFailedProducer() {
+  public void testGetLineageWithFailedProducer() {
     JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
 
     UpdateLineageRow writeJob =
@@ -516,17 +374,19 @@ public class LineageDaoTest {
         jobFacet,
         Arrays.asList(),
         Arrays.asList(dataset));
-    List<DatasetData> inputDatasets =
-        lineageDao.getOutputDatasetsFromJobIds(Collections.singleton(writeJob.getJob().getUuid()));
+    Set<JobData> inputDatasets =
+        lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid()));
     assertThat(inputDatasets)
         .hasSize(1)
-        .flatMap(DatasetData::getJobUuids)
+        .flatMap(JobData::getUuid)
         .hasSize(1)
         .contains(writeJob.getJob().getUuid());
   }
 
+  /** A failed producer job doesn't show up in the lineage */
   @Test
-  public void testGetOuptutDatasetsWithJobThatHasMultipleVersions() {
+  public void testGetLineageChangedJobVersion() {
+    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
 
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
@@ -536,50 +396,18 @@ public class LineageDaoTest {
             jobFacet,
             Arrays.asList(),
             Arrays.asList(dataset));
+    LineageTestUtils.createLineageRow(
+        openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList());
 
-    writeDownstreamLineage(
-        openLineageDao,
-        new LinkedList<>(
-            Arrays.asList(
-                new DatasetConsumerJob("readJob", 3, Optional.of("outputData")),
-                new DatasetConsumerJob("downstreamJob", 1, Optional.empty()))),
-        jobFacet,
-        dataset);
-
-    JobFacet newVersionFacet =
-        JobFacet.builder()
-            .sourceCodeLocation(
-                SourceCodeLocationJobFacet.builder().url("git@github:location").build())
-            .additional(LineageTestUtils.EMPTY_MAP)
-            .build();
-
-    // readJobV2 produces outputData2 and not outputData
-    List<JobLineage> newRows =
-        writeDownstreamLineage(
-            openLineageDao,
-            new LinkedList<>(
-                Arrays.asList(
-                    new DatasetConsumerJob("readJob", 3, Optional.of("outputData2")),
-                    new DatasetConsumerJob("downstreamJob", 1, Optional.empty()))),
-            newVersionFacet,
-            dataset);
-
-    List<DatasetData> inputData =
-        lineageDao.getOutputDatasetsFromJobIds(Collections.singleton(newRows.get(0).getId()));
-    assertThat(inputData)
-        .hasSize(2)
-        .map(ds -> ds.getName().getValue())
-        .containsAll(Arrays.asList("outputData2<-readJob0<-commonDataset", "commonDataset"))
-        .doesNotContain("outputData<-readJob0<-commonDataset");
-
-    assertThat(inputData)
-        .filteredOn(ds -> ds.getName().getValue().equals("outputData2<-readJob0<-commonDataset"))
-        .isNotEmpty()
-        .map(DatasetData::getJobUuids)
-        .first()
-        .asList()
+    // the new job is still returned, even though it isn't connected
+    Set<JobData> jobData =
+        lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid()));
+    assertThat(jobData)
         .hasSize(1)
-        .contains(newRows.get(0).getId());
+        .first()
+        .matches(jd -> jd.getUuid().equals(writeJob.getJob().getUuid()))
+        .extracting(JobData::getOutputUuids, InstanceOfAssertFactories.iterable(UUID.class))
+        .isEmpty();
   }
 
   @Test
@@ -648,5 +476,29 @@ public class LineageDaoTest {
     Optional<UUID> jobNode =
         lineageDao.getJobFromInputOrOutput(dataset.getName(), dataset.getNamespace());
     assertThat(jobNode).isPresent().get().isEqualTo(writeJob.getJob().getUuid());
+  }
+
+  @Test
+  public void testGetDatasetData() {
+    LineageTestUtils.createLineageRow(
+        openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList(dataset));
+    List<JobLineage> newRows =
+        writeDownstreamLineage(
+            openLineageDao,
+            new LinkedList<>(
+                Arrays.asList(
+                    new DatasetConsumerJob("readJob", 3, Optional.of("outputData2")),
+                    new DatasetConsumerJob("downstreamJob", 1, Optional.empty()))),
+            jobFacet,
+            dataset);
+    Set<DatasetData> datasetData =
+        lineageDao.getDatasetData(
+            newRows.stream()
+                .map(j -> j.getOutput().get().getDatasetRow().getUuid())
+                .collect(Collectors.toSet()));
+    assertThat(datasetData)
+        .hasSize(3)
+        .extracting(ds -> ds.getName().getValue())
+        .allMatch(str -> str.contains("outputData2"));
   }
 }

--- a/api/src/test/java/marquez/db/LineageDaoTest.java
+++ b/api/src/test/java/marquez/db/LineageDaoTest.java
@@ -130,7 +130,7 @@ public class LineageDaoTest {
             Arrays.asList());
     // fetch the first "readJob" lineage.
     Set<JobData> connectedJobs =
-        lineageDao.getLineage(new HashSet<>(Arrays.asList(jobRows.get(0).getId())));
+        lineageDao.getLineage(new HashSet<>(Arrays.asList(jobRows.get(0).getId())), 2);
 
     // 20 readJobs + 1 downstreamJob for each (20) + 1 write job = 41
     assertThat(connectedJobs).size().isEqualTo(41);
@@ -178,7 +178,7 @@ public class LineageDaoTest {
             Arrays.asList(),
             Arrays.asList(dataset));
     Set<UUID> lineage =
-        lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid())).stream()
+        lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid()), 2).stream()
             .map(JobData::getUuid)
             .collect(Collectors.toSet());
     assertThat(lineage).hasSize(1).contains(writeJob.getJob().getUuid());
@@ -191,7 +191,7 @@ public class LineageDaoTest {
         LineageTestUtils.createLineageRow(
             openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList());
     Set<UUID> lineage =
-        lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid())).stream()
+        lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid()), 2).stream()
             .map(JobData::getUuid)
             .collect(Collectors.toSet());
 
@@ -231,7 +231,7 @@ public class LineageDaoTest {
 
     // Validate that finalConsumer job only has a single dataset
     Set<UUID> jobIds = Collections.singleton(writeJob.getJob().getUuid());
-    Set<JobData> finalConsumer = lineageDao.getLineage(jobIds);
+    Set<JobData> finalConsumer = lineageDao.getLineage(jobIds, 2);
     assertThat(finalConsumer).hasSize(1).flatMap(JobData::getUuid).hasSize(1).containsAll(jobIds);
   }
 
@@ -256,7 +256,7 @@ public class LineageDaoTest {
         Arrays.asList(dataset),
         Arrays.asList());
     Set<JobData> lineage =
-        lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid()));
+        lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid()), 2);
 
     assertThat(lineage)
         .hasSize(1)
@@ -311,7 +311,8 @@ public class LineageDaoTest {
         lineageDao.getLineage(
             new HashSet<>(
                 Arrays.asList(
-                    newRows.get(0).getId(), newRows.get(0).getDownstreamJobs().get(0).getId())));
+                    newRows.get(0).getId(), newRows.get(0).getDownstreamJobs().get(0).getId())),
+            2);
     assertThat(lineage)
         .hasSize(7)
         .extracting(JobData::getUuid)
@@ -375,7 +376,7 @@ public class LineageDaoTest {
         Arrays.asList(),
         Arrays.asList(dataset));
     Set<JobData> inputDatasets =
-        lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid()));
+        lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid()), 2);
     assertThat(inputDatasets)
         .hasSize(1)
         .flatMap(JobData::getUuid)
@@ -401,7 +402,7 @@ public class LineageDaoTest {
 
     // the new job is still returned, even though it isn't connected
     Set<JobData> jobData =
-        lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid()));
+        lineageDao.getLineage(Collections.singleton(writeJob.getJob().getUuid()), 2);
     assertThat(jobData)
         .hasSize(1)
         .first()

--- a/api/src/test/java/marquez/db/LineageTestUtils.java
+++ b/api/src/test/java/marquez/db/LineageTestUtils.java
@@ -49,7 +49,7 @@ public class LineageTestUtils {
    * @param outputs
    * @return
    */
-  static UpdateLineageRow createLineageRow(
+  public static UpdateLineageRow createLineageRow(
       OpenLineageDao dao,
       String jobName,
       String status,
@@ -92,7 +92,7 @@ public class LineageTestUtils {
     return updateLineageRow;
   }
 
-  static DatasetFacets newDatasetFacet(SchemaField... fields) {
+  public static DatasetFacets newDatasetFacet(SchemaField... fields) {
     return DatasetFacets.builder()
         .documentation(
             new DocumentationDatasetFacet(PRODUCER_URL, SCHEMA_URL, "the dataset documentation"))
@@ -117,7 +117,7 @@ public class LineageTestUtils {
    * @param dataset
    * @return
    */
-  static List<JobLineage> writeDownstreamLineage(
+  public static List<JobLineage> writeDownstreamLineage(
       OpenLineageDao openLineageDao,
       List<DatasetConsumerJob> downstream,
       JobFacet jobFacet,
@@ -178,7 +178,7 @@ public class LineageTestUtils {
    * (if any) and a list of downstream jobs.
    */
   @Value
-  static class JobLineage {
+  public static class JobLineage {
 
     UUID id;
     String name;
@@ -189,7 +189,7 @@ public class LineageTestUtils {
 
   /** Entity that encapsulates a dataset's consumer jobs and their output dataset names (if any). */
   @Value
-  static class DatasetConsumerJob {
+  public static class DatasetConsumerJob {
 
     String name;
     int numConsumers;

--- a/api/src/test/java/marquez/service/LineageServiceTest.java
+++ b/api/src/test/java/marquez/service/LineageServiceTest.java
@@ -1,0 +1,276 @@
+package marquez.service;
+
+import static marquez.db.LineageTestUtils.NAMESPACE;
+import static marquez.db.LineageTestUtils.newDatasetFacet;
+import static marquez.db.LineageTestUtils.writeDownstreamLineage;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import marquez.common.models.DatasetName;
+import marquez.common.models.JobName;
+import marquez.common.models.NamespaceName;
+import marquez.db.LineageDao;
+import marquez.db.LineageTestUtils;
+import marquez.db.LineageTestUtils.DatasetConsumerJob;
+import marquez.db.LineageTestUtils.JobLineage;
+import marquez.db.OpenLineageDao;
+import marquez.db.models.JobData;
+import marquez.db.models.UpdateLineageRow;
+import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
+import marquez.service.models.Edge;
+import marquez.service.models.Lineage;
+import marquez.service.models.LineageEvent.Dataset;
+import marquez.service.models.LineageEvent.JobFacet;
+import marquez.service.models.LineageEvent.SchemaField;
+import marquez.service.models.Node;
+import marquez.service.models.NodeId;
+import marquez.service.models.NodeType;
+import marquez.service.models.Run;
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.ObjectAssert;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MarquezJdbiExternalPostgresExtension.class)
+public class LineageServiceTest {
+
+  private static LineageDao lineageDao;
+  private static LineageService lineageService;
+  private static OpenLineageDao openLineageDao;
+  private final Dataset dataset =
+      new Dataset(
+          NAMESPACE,
+          "commonDataset",
+          newDatasetFacet(
+              new SchemaField("firstname", "string", "the first name"),
+              new SchemaField("lastname", "string", "the last name"),
+              new SchemaField("birthdate", "date", "the date of birth")));
+  private final JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+
+  static Jdbi jdbi;
+
+  @BeforeAll
+  public static void setUpOnce(Jdbi jdbi) {
+    LineageServiceTest.jdbi = jdbi;
+    lineageDao = jdbi.onDemand(LineageDao.class);
+    lineageService = new LineageService(lineageDao);
+    openLineageDao = jdbi.onDemand(OpenLineageDao.class);
+  }
+
+  @AfterEach
+  public void tearDown(Jdbi jdbi) {
+    jdbi.inTransaction(
+        handle -> {
+          handle.execute("DELETE FROM lineage_events");
+          handle.execute("DELETE FROM runs_input_mapping");
+          handle.execute("DELETE FROM dataset_versions_field_mapping");
+          handle.execute("DELETE FROM dataset_versions");
+          handle.execute("UPDATE runs SET start_run_state_uuid=NULL, end_run_state_uuid=NULL");
+          handle.execute("DELETE FROM run_states");
+          handle.execute("DELETE FROM runs");
+          handle.execute("DELETE FROM run_args");
+          handle.execute("DELETE FROM job_versions_io_mapping");
+          handle.execute("DELETE FROM job_versions");
+          handle.execute("DELETE FROM jobs");
+          handle.execute("DELETE FROM dataset_fields_tag_mapping");
+          handle.execute("DELETE FROM dataset_fields");
+          handle.execute("DELETE FROM datasets");
+          handle.execute("DELETE FROM sources");
+          handle.execute("DELETE FROM namespaces");
+          return null;
+        });
+  }
+
+  @Test
+  public void testLineage() {
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "writeJob",
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(),
+            Arrays.asList(dataset));
+    List<JobLineage> jobRows =
+        writeDownstreamLineage(
+            openLineageDao,
+            new LinkedList<>(
+                Arrays.asList(
+                    new DatasetConsumerJob("readJob", 20, Optional.of("outputData")),
+                    new DatasetConsumerJob("downstreamJob", 1, Optional.of("outputData2")),
+                    new DatasetConsumerJob("finalConsumer", 1, Optional.empty()))),
+            jobFacet,
+            dataset);
+
+    UpdateLineageRow secondRun =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "writeJob",
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(),
+            Arrays.asList(dataset));
+    writeDownstreamLineage(
+        openLineageDao,
+        new LinkedList<>(
+            Arrays.asList(
+                new DatasetConsumerJob("newReadJob", 5, Optional.of("outputData3")),
+                new DatasetConsumerJob("newDownstreamJob", 1, Optional.empty()))),
+        jobFacet,
+        dataset);
+    String jobName = writeJob.getJob().getName();
+    Lineage lineage =
+        lineageService.lineage(NodeId.of(new NamespaceName(NAMESPACE), new JobName(jobName)), 2);
+
+    // 1 writeJob           + 1 commonDataset
+    // 20 readJob           + 20 outputData
+    // 20 downstreamJob     + 20 outputData2
+    // 5 newReadJob         + 5 outputData3
+    // 5 newDownstreamJob   + 0
+    assertThat(lineage.getGraph())
+        .hasSize(97) // 51 jobs + 46 datasets
+        .areExactly(51, new Condition<>(n -> n.getType().equals(NodeType.JOB), "job"))
+        .areExactly(46, new Condition<>(n -> n.getType().equals(NodeType.DATASET), "dataset"))
+        // finalConsumer job is out of the depth range
+        .filteredOn(
+            node ->
+                node.getType().equals(NodeType.JOB)
+                    && node.getId().asJobId().getName().getValue().contains("finalConsumer"))
+        .isEmpty();
+
+    // assert the second run of writeJob is returned
+    assertThat(lineage.getGraph())
+        .filteredOn(node -> node.getType().equals(NodeType.JOB) && jobNameEquals(node, "writeJob"))
+        .hasSize(1)
+        .first()
+        .extracting(
+            n -> ((JobData) n.getData()).getLatestRun(),
+            InstanceOfAssertFactories.optional(Run.class))
+        .isPresent()
+        .get()
+        .extracting(r -> r.getId().getValue())
+        .isEqualTo(secondRun.getRun().getUuid());
+
+    // check the output edges for the commonDataset node
+    assertThat(lineage.getGraph())
+        .filteredOn(
+            node ->
+                node.getType().equals(NodeType.DATASET)
+                    && node.getId().asDatasetId().getName().getValue().equals("commonDataset"))
+        .first()
+        .extracting(Node::getOutEdges, InstanceOfAssertFactories.iterable(Edge.class))
+        .hasSize(25)
+        .extracting(e -> e.getDestination().asJobId().getName())
+        .allMatch(n -> n.getValue().matches(".*eadJob\\d+<-commonDataset"));
+
+    assertThat(lineage.getGraph())
+        .filteredOn(
+            n ->
+                n.getType().equals(NodeType.JOB)
+                    && jobNameEquals(n, "downstreamJob0<-outputData<-readJob0<-commonDataset"))
+        .hasSize(1)
+        .first()
+        .extracting(Node::getInEdges, InstanceOfAssertFactories.iterable(Edge.class))
+        .hasSize(1)
+        .first()
+        .extracting(Edge::getOrigin)
+        .isEqualTo(
+            NodeId.of(
+                new NamespaceName(NAMESPACE),
+                new DatasetName("outputData<-readJob0<-commonDataset")));
+  }
+
+  @Test
+  public void testLineageWithNoDatasets() {
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList());
+    Lineage lineage =
+        lineageService.lineage(
+            NodeId.of(new NamespaceName(NAMESPACE), new JobName(writeJob.getJob().getName())), 5);
+    assertThat(lineage.getGraph())
+        .hasSize(1)
+        .first()
+        .satisfies(n -> n.getId().asJobId().getName().getValue().equals("writeJob"));
+  }
+
+  @Test
+  public void testLineageWithWithCycle() {
+    Dataset intermediateDataset =
+        new Dataset(
+            NAMESPACE,
+            "intermediateDataset",
+            newDatasetFacet(
+                new SchemaField("firstname", "string", "the first name"),
+                new SchemaField("birthdate", "date", "the date of birth")));
+    LineageTestUtils.createLineageRow(
+        openLineageDao,
+        "writeJob",
+        "COMPLETE",
+        jobFacet,
+        Arrays.asList(dataset),
+        Arrays.asList(intermediateDataset));
+
+    Dataset finalDataset =
+        new Dataset(
+            NAMESPACE,
+            "finalDataset",
+            newDatasetFacet(
+                new SchemaField("firstname", "string", "the first name"),
+                new SchemaField("lastname", "string", "the last name")));
+    UpdateLineageRow intermediateJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "intermediateJob",
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(intermediateDataset),
+            Arrays.asList(finalDataset));
+
+    LineageTestUtils.createLineageRow(
+        openLineageDao,
+        "cycleJob",
+        "COMPLETE",
+        jobFacet,
+        Arrays.asList(finalDataset),
+        Arrays.asList(dataset));
+    Lineage lineage =
+        lineageService.lineage(
+            NodeId.of(
+                new NamespaceName(NAMESPACE), new JobName(intermediateJob.getJob().getName())),
+            5);
+    assertThat(lineage.getGraph()).extracting(Node::getId).hasSize(6);
+    ObjectAssert<Node> datasetNode =
+        assertThat(lineage.getGraph())
+            .filteredOn(
+                n1 ->
+                    n1.getId().isDatasetType()
+                        && n1.getId().asDatasetId().getName().getValue().equals("commonDataset"))
+            .hasSize(1)
+            .first();
+    datasetNode
+        .extracting(Node::getInEdges, InstanceOfAssertFactories.iterable(Edge.class))
+        .hasSize(1)
+        .first()
+        .extracting(Edge::getOrigin)
+        .matches(n -> n.isJobType() && n.asJobId().getName().getValue().equals("cycleJob"));
+
+    datasetNode
+        .extracting(Node::getOutEdges, InstanceOfAssertFactories.iterable(Edge.class))
+        .hasSize(1)
+        .first()
+        .extracting(Edge::getDestination)
+        .matches(n -> n.isJobType() && n.asJobId().getName().getValue().equals("writeJob"));
+  }
+
+  private boolean jobNameEquals(Node node, String writeJob) {
+    return node.getId().asJobId().getName().getValue().equals(writeJob);
+  }
+}

--- a/api/src/test/java/marquez/service/OpenLineageServiceIntegrationTest.java
+++ b/api/src/test/java/marquez/service/OpenLineageServiceIntegrationTest.java
@@ -49,7 +49,7 @@ import org.mockito.ArgumentCaptor;
 
 @org.junit.jupiter.api.Tag("IntegrationTests")
 @ExtendWith(MarquezJdbiExternalPostgresExtension.class)
-public class OpenLineageServiceTest {
+public class OpenLineageServiceIntegrationTest {
 
   public static final String NAMESPACE = "theNamespace";
   public static final String JOB_NAME = "theJob";


### PR DESCRIPTION
Replaces https://github.com/MarquezProject/marquez/pull/1357

This PR changes the query and logic for fetching lineage so that the job nodes and input/output edges are all fetched in a single query. As described in https://github.com/MarquezProject/marquez/pull/1357 , the queries for fetching input/output datasets are very expensive on a table with many input/output mappings. In addition, the lineage query that fetches jobs is also pretty expensive and has to be done recursively- sometimes upwards of 5 queries in a single `/lineage` API call.

This change updates the `getLineage` query to build a temp table with job -> dataset mappings, then recursively builds lineage, including jobs and dataset ids, obviating the separate dataset input/output edge queries.

**Note- there is a behavior change**- only the current version of a job is considered when evaluating input/output edges. The original query returned a graph of all jobs that had ever touched a dataset, even if later versions of that job no longer wrote/read the dataset. In this query, a job is only connected to a dataset if its current version reads or writes that dataset. This lets the database construct a very small table, as the total number of jobs is generally very small (hundreds in our case), whereas the total number of job versions can be thousands of times that number.

Here's the explain plan for the original `getLineage` query

### Original Plan
```
HashAggregate  (cost=195455.44..195458.32 rows=288 width=16)
  Group Key: j.uuid
  CTE dataset_ids
    ->  Unique  (cost=545.53..546.17 rows=128 width=16)
          ->  Sort  (cost=545.53..545.85 rows=128 width=16)
                Sort Key: io_1.dataset_uuid
                ->  Nested Loop  (cost=9.88..541.05 rows=128 width=16)
                      ->  Index Scan using jobs_pkey on jobs j_1  (cost=0.27..8.29 rows=1 width=16)
                            Index Cond: (uuid = 'ed9edb70-7a33-4449-9880-3a51b72143e4'::uuid)
                      ->  Bitmap Heap Scan on job_versions_io_mapping io_1  (cost=9.60..531.41 rows=135 width=32)
                            Recheck Cond: (job_version_uuid = j_1.current_version_uuid)
                            ->  Bitmap Index Scan on job_versions_io_mapping_pkey  (cost=0.00..9.57 rows=135 width=0)
                                  Index Cond: (job_version_uuid = j_1.current_version_uuid)
  ->  Hash Join  (cost=29329.89..193552.80 rows=542587 width=16)
        Hash Cond: (jv.job_uuid = j.uuid)
        ->  Hash Join  (cost=29229.78..192007.44 rows=542587 width=16)
              Hash Cond: (io.job_version_uuid = jv.uuid)
              ->  Hash Join  (cost=4.16..152738.51 rows=542587 width=16)
                    Hash Cond: (io.dataset_uuid = dataset_ids.dataset_uuid)
                    ->  Seq Scan on job_versions_io_mapping io  (cost=0.00..122415.17 rows=6638217 width=32)
                    ->  Hash  (cost=2.56..2.56 rows=128 width=16)
                          ->  CTE Scan on dataset_ids  (cost=0.00..2.56 rows=128 width=16)
              ->  Hash  (cost=19838.50..19838.50 rows=485450 width=32)
                    ->  Seq Scan on job_versions jv  (cost=0.00..19838.50 rows=485450 width=32)
        ->  Hash  (cost=96.51..96.51 rows=288 width=16)
              ->  Index Only Scan using jobs_pkey on jobs j  (cost=0.27..96.51 rows=288 width=16)
```

Between the lineage query and the two input/output dataset queries, a single call to the `/lineage` API can take well over 30 seconds.

The new query returns input and output edges for each job, obviating the need to do extra input/output edge queries. Overall, the `/lineage` endpoint can now return in ~200ms rather than 30 seconds.

### Optimized Plan
```
Hash Join  (cost=5264.02..5268.81 rows=211 width=374)
  Hash Cond: (l2.job_uuid = j.uuid)
  CTE job_io
    ->  GroupAggregate  (cost=4311.40..4370.61 rows=214 width=96)
          Group Key: v.job_uuid
          ->  Sort  (cost=4311.40..4320.73 rows=3733 width=38)
                Sort Key: v.job_uuid
                ->  Nested Loop Left Join  (cost=0.98..4089.92 rows=3733 width=38)
                      ->  Nested Loop  (cost=0.42..2643.60 rows=273 width=32)
                            ->  Seq Scan on jobs j_1  (cost=0.00..268.88 rows=288 width=16)
                            ->  Index Scan using job_versions_pkey on job_versions v  (cost=0.42..8.25 rows=1 width=32)
                                  Index Cond: (uuid = j_1.current_version_uuid)
                      ->  Index Only Scan using job_versions_io_mapping_pkey on job_versions_io_mapping io  (cost=0.56..3.95 rows=135 width=38)
                            Index Cond: (job_version_uuid = v.uuid)
  CTE lineage
    ->  Recursive Union  (cost=0.00..620.94 rows=211 width=80)
          ->  CTE Scan on job_io  (cost=0.00..4.81 rows=1 width=80)
                Filter: (job_uuid = 'ed9edb70-7a33-4449-9880-3a51b72143e4'::uuid)
          ->  Nested Loop  (cost=0.00..61.19 rows=21 width=80)
"                Join Filter: (array_cat(io_1.inputs, io_1.outputs) && array_cat(l.inputs, l.outputs))"
                ->  WorkTable Scan on lineage l  (cost=0.00..0.20 rows=10 width=64)
                ->  CTE Scan on job_io io_1  (cost=0.00..4.28 rows=214 width=80)
  ->  CTE Scan on lineage l2  (cost=0.00..4.22 rows=211 width=80)
  ->  Hash  (cost=268.88..268.88 rows=288 width=310)
        ->  Seq Scan on jobs j  (cost=0.00..268.88 rows=288 width=310)
```