### PR TITLE
api, client: Allow slashes in URLs in both encoded and raw form

### DIFF
--- a/api/src/main/java/marquez/api/DatasetResource.java
+++ b/api/src/main/java/marquez/api/DatasetResource.java
@@ -68,7 +68,6 @@ public class DatasetResource extends BaseResource {
       @PathParam("namespace") NamespaceName namespaceName,
       @PathParam("dataset") DatasetName datasetName,
       @Valid DatasetMeta datasetMeta) {
-    log.info("asdf");
     throwIfNotExists(namespaceName);
     datasetMeta.getRunId().ifPresent(this::throwIfNotExists);
     throwIfSourceNotExists(datasetMeta.getSourceName());

--- a/api/src/main/java/marquez/api/DatasetResource.java
+++ b/api/src/main/java/marquez/api/DatasetResource.java
@@ -68,6 +68,7 @@ public class DatasetResource extends BaseResource {
       @PathParam("namespace") NamespaceName namespaceName,
       @PathParam("dataset") DatasetName datasetName,
       @Valid DatasetMeta datasetMeta) {
+    log.info("asdf");
     throwIfNotExists(namespaceName);
     datasetMeta.getRunId().ifPresent(this::throwIfNotExists);
     throwIfSourceNotExists(datasetMeta.getSourceName());

--- a/api/src/main/java/marquez/api/JobResource.java
+++ b/api/src/main/java/marquez/api/JobResource.java
@@ -61,7 +61,7 @@ public class JobResource extends BaseResource {
   @ResponseMetered
   @ExceptionMetered
   @PUT
-  @Path("/namespaces/{namespace}/jobs/{job}")
+  @Path("/namespaces/{namespace: [a-zA-Z0-9_\\-:/.%]*}/jobs/{job}")
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
   public Response createOrUpdate(
@@ -84,7 +84,7 @@ public class JobResource extends BaseResource {
   @ResponseMetered
   @ExceptionMetered
   @GET
-  @Path("/namespaces/{namespace}/jobs/{job}")
+  @Path("/namespaces/{namespace: [a-zA-Z0-9_\\-:/.%]*}/jobs/{job}")
   @Produces(APPLICATION_JSON)
   public Response getJob(
       @PathParam("namespace") NamespaceName namespaceName, @PathParam("job") JobName jobName) {
@@ -101,7 +101,7 @@ public class JobResource extends BaseResource {
   @ResponseMetered
   @ExceptionMetered
   @GET
-  @Path("/namespaces/{namespace}/jobs")
+  @Path("/namespaces/{namespace: [a-zA-Z0-9_\\-:/.%]*}/jobs")
   @Produces(APPLICATION_JSON)
   public Response list(
       @PathParam("namespace") NamespaceName namespaceName,
@@ -117,7 +117,7 @@ public class JobResource extends BaseResource {
   @ResponseMetered
   @ExceptionMetered
   @POST
-  @Path("namespaces/{namespace}/jobs/{job}/runs")
+  @Path("namespaces/{namespace: [a-zA-Z0-9_\\-:/.%]*}/jobs/{job}/runs")
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
   public Response createRun(
@@ -138,7 +138,7 @@ public class JobResource extends BaseResource {
   @ResponseMetered
   @ExceptionMetered
   @GET
-  @Path("/namespaces/{namespace}/jobs/{job}/runs")
+  @Path("/namespaces/{namespace: [a-zA-Z0-9_\\-:/.%]*}/jobs/{job}/runs")
   @Produces(APPLICATION_JSON)
   public Response listRuns(
       @PathParam("namespace") NamespaceName namespaceName,

--- a/api/src/main/java/marquez/api/NamespaceResource.java
+++ b/api/src/main/java/marquez/api/NamespaceResource.java
@@ -34,12 +34,14 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import lombok.NonNull;
 import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
 import marquez.api.exceptions.NamespaceNotFoundException;
 import marquez.common.models.NamespaceName;
 import marquez.service.ServiceFactory;
 import marquez.service.models.Namespace;
 import marquez.service.models.NamespaceMeta;
 
+@Slf4j
 @Path("/api/v1")
 public class NamespaceResource extends BaseResource {
   public NamespaceResource(@NonNull final ServiceFactory serviceFactory) {
@@ -50,11 +52,12 @@ public class NamespaceResource extends BaseResource {
   @ResponseMetered
   @ExceptionMetered
   @PUT
-  @Path("/namespaces/{namespace}")
+  @Path("/namespaces/{namespace: [a-zA-Z0-9_\\-:/.%]*}")
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
   public Response createOrUpdate(
       @PathParam("namespace") NamespaceName name, @Valid NamespaceMeta meta) {
+    log.info("PutNamespace {}", name);
     final Namespace namespace = namespaceService.createOrUpdate(name, meta);
     return Response.ok(namespace).build();
   }
@@ -63,9 +66,10 @@ public class NamespaceResource extends BaseResource {
   @ResponseMetered
   @ExceptionMetered
   @GET
-  @Path("/namespaces/{namespace}")
+  @Path("/namespaces/{namespace: [a-zA-Z0-9_\\-:/.%]*}")
   @Produces(APPLICATION_JSON)
   public Response get(@PathParam("namespace") NamespaceName name) {
+    log.info("GetNamespace {}", name);
     final Namespace namespace =
         namespaceService
             .findBy(name.getValue())

--- a/api/src/main/java/marquez/api/NamespaceResource.java
+++ b/api/src/main/java/marquez/api/NamespaceResource.java
@@ -57,7 +57,6 @@ public class NamespaceResource extends BaseResource {
   @Produces(APPLICATION_JSON)
   public Response createOrUpdate(
       @PathParam("namespace") NamespaceName name, @Valid NamespaceMeta meta) {
-    log.info("PutNamespace {}", name);
     final Namespace namespace = namespaceService.createOrUpdate(name, meta);
     return Response.ok(namespace).build();
   }
@@ -69,7 +68,6 @@ public class NamespaceResource extends BaseResource {
   @Path("/namespaces/{namespace: [a-zA-Z0-9_\\-:/.%]*}")
   @Produces(APPLICATION_JSON)
   public Response get(@PathParam("namespace") NamespaceName name) {
-    log.info("GetNamespace {}", name);
     final Namespace namespace =
         namespaceService
             .findBy(name.getValue())

--- a/api/src/main/java/marquez/api/SourceResource.java
+++ b/api/src/main/java/marquez/api/SourceResource.java
@@ -50,7 +50,7 @@ public class SourceResource extends BaseResource {
   @ResponseMetered
   @ExceptionMetered
   @PUT
-  @Path("{source}")
+  @Path("{source: [a-zA-Z0-9_\\-:/.%]*}")
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
   public Response createOrUpdate(@PathParam("source") SourceName name, @Valid SourceMeta meta) {
@@ -62,7 +62,7 @@ public class SourceResource extends BaseResource {
   @ResponseMetered
   @ExceptionMetered
   @GET
-  @Path("{source}")
+  @Path("{source: [a-zA-Z0-9_\\-:/.%]*}")
   @Produces(APPLICATION_JSON)
   public Response get(@PathParam("source") SourceName name) {
     final Source source =

--- a/api/src/main/java/marquez/common/models/NamespaceName.java
+++ b/api/src/main/java/marquez/common/models/NamespaceName.java
@@ -41,7 +41,8 @@ public final class NamespaceName {
     checkArgument(
         PATTERN.matcher(value).matches(),
         "namespace '%s' must contain only letters (a-z, A-Z), numbers (0-9), "
-            + "underscores (_), dashes (-), or dots (.) with a maximum length of %s characters.",
+            + "underscores (_), dashes (-), colons (:), slashes (/) or dots (.) with a maximum "
+            + "length of %s characters.",
         value,
         MAX_SIZE);
     this.value = value;

--- a/api/src/main/java/marquez/db/NamespaceDao.java
+++ b/api/src/main/java/marquez/db/NamespaceDao.java
@@ -28,6 +28,7 @@ import marquez.db.models.OwnerRow;
 import marquez.service.models.Namespace;
 import marquez.service.models.NamespaceMeta;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transaction;

--- a/api/src/main/java/marquez/db/NamespaceDao.java
+++ b/api/src/main/java/marquez/db/NamespaceDao.java
@@ -28,7 +28,6 @@ import marquez.db.models.OwnerRow;
 import marquez.service.models.Namespace;
 import marquez.service.models.NamespaceMeta;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
-import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transaction;

--- a/api/src/test/java/marquez/BaseIntegrationTest.java
+++ b/api/src/test/java/marquez/BaseIntegrationTest.java
@@ -12,6 +12,7 @@ import static marquez.common.models.CommonModelGenerator.newFieldType;
 import static marquez.common.models.CommonModelGenerator.newJobName;
 import static marquez.common.models.CommonModelGenerator.newLocation;
 import static marquez.common.models.CommonModelGenerator.newNamespaceName;
+import static marquez.common.models.CommonModelGenerator.newDatasetNamespaceName;
 import static marquez.common.models.CommonModelGenerator.newOwnerName;
 import static marquez.common.models.CommonModelGenerator.newSchemaLocation;
 import static marquez.common.models.CommonModelGenerator.newSourceName;
@@ -24,12 +25,14 @@ import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import marquez.client.MarquezClient;
@@ -64,6 +67,7 @@ public abstract class BaseIntegrationTest {
 
   // NAMESPACE
   protected static String NAMESPACE_NAME;
+  protected static String DATASET_NAMESPACE_NAME;
   protected static String OWNER_NAME;
   protected static String NAMESPACE_DESCRIPTION;
 
@@ -115,6 +119,11 @@ public abstract class BaseIntegrationTest {
   @BeforeAll
   protected static void setupAll() throws Exception {
     NAMESPACE_NAME = newNamespaceName().getValue();
+    DATASET_NAMESPACE_NAME = newDatasetNamespaceName().getValue();
+//    ENCODED_DATASET_NAMESPACE_NAME = URLEncoder.encode(
+//      newDatasetNamespaceName().getValue(),
+//      StandardCharsets.UTF_8.toString()
+//    );
     OWNER_NAME = newOwnerName().getValue();
     NAMESPACE_DESCRIPTION = newDescription();
 

--- a/api/src/test/java/marquez/BaseIntegrationTest.java
+++ b/api/src/test/java/marquez/BaseIntegrationTest.java
@@ -5,6 +5,7 @@ import static marquez.common.models.CommonModelGenerator.newConnectionUrl;
 import static marquez.common.models.CommonModelGenerator.newConnectionUrlFor;
 import static marquez.common.models.CommonModelGenerator.newContext;
 import static marquez.common.models.CommonModelGenerator.newDatasetName;
+import static marquez.common.models.CommonModelGenerator.newDatasetNamespaceName;
 import static marquez.common.models.CommonModelGenerator.newDbSourceType;
 import static marquez.common.models.CommonModelGenerator.newDescription;
 import static marquez.common.models.CommonModelGenerator.newFieldName;
@@ -12,7 +13,6 @@ import static marquez.common.models.CommonModelGenerator.newFieldType;
 import static marquez.common.models.CommonModelGenerator.newJobName;
 import static marquez.common.models.CommonModelGenerator.newLocation;
 import static marquez.common.models.CommonModelGenerator.newNamespaceName;
-import static marquez.common.models.CommonModelGenerator.newDatasetNamespaceName;
 import static marquez.common.models.CommonModelGenerator.newOwnerName;
 import static marquez.common.models.CommonModelGenerator.newSchemaLocation;
 import static marquez.common.models.CommonModelGenerator.newSourceName;
@@ -25,14 +25,12 @@ import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import java.net.URI;
 import java.net.URL;
-import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
-import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import marquez.client.MarquezClient;
@@ -120,10 +118,6 @@ public abstract class BaseIntegrationTest {
   protected static void setupAll() throws Exception {
     NAMESPACE_NAME = newNamespaceName().getValue();
     DATASET_NAMESPACE_NAME = newDatasetNamespaceName().getValue();
-//    ENCODED_DATASET_NAMESPACE_NAME = URLEncoder.encode(
-//      newDatasetNamespaceName().getValue(),
-//      StandardCharsets.UTF_8.toString()
-//    );
     OWNER_NAME = newOwnerName().getValue();
     NAMESPACE_DESCRIPTION = newDescription();
 

--- a/api/src/test/java/marquez/MarquezAppIntegrationTest.java
+++ b/api/src/test/java/marquez/MarquezAppIntegrationTest.java
@@ -17,6 +17,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
+import lombok.Value;
 import marquez.client.models.Dataset;
 import marquez.client.models.DatasetId;
 import marquez.client.models.DbTable;
@@ -35,17 +37,20 @@ import marquez.client.models.Stream;
 import marquez.client.models.StreamMeta;
 import marquez.client.models.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @org.junit.jupiter.api.Tag("IntegrationTests")
 public class MarquezAppIntegrationTest extends BaseIntegrationTest {
 
-  @Test
-  public void testApp_createNamespace() {
+  @ParameterizedTest
+  @ValueSource(strings={"DEFAULT", "database://localhost:1234", "s3://bucket", "bigquery:"})
+  public void testApp_createNamespace(String namespaceName) {
     final NamespaceMeta namespaceMeta =
         NamespaceMeta.builder().ownerName(OWNER_NAME).description(NAMESPACE_DESCRIPTION).build();
 
-    final Namespace namespace = client.createNamespace(NAMESPACE_NAME, namespaceMeta);
-    assertThat(namespace.getName()).isEqualTo(NAMESPACE_NAME);
+    final Namespace namespace = client.createNamespace(namespaceName, namespaceMeta);
+    assertThat(namespace.getName()).isEqualTo(namespaceName);
     assertThat(namespace.getCreatedAt()).isAfter(EPOCH);
     assertThat(namespace.getUpdatedAt()).isAfter(EPOCH);
     assertThat(namespace.getOwnerName()).isEqualTo(OWNER_NAME);
@@ -53,7 +58,7 @@ public class MarquezAppIntegrationTest extends BaseIntegrationTest {
 
     assertThat(
             client.listNamespaces().stream()
-                .filter(other -> other.getName().equals(NAMESPACE_NAME))
+                .filter(other -> other.getName().equals(namespaceName))
                 .count())
         .isEqualTo(1);
   }
@@ -104,6 +109,11 @@ public class MarquezAppIntegrationTest extends BaseIntegrationTest {
     assertThat(dataset.getFields().get(0).getTags()).isEqualTo(fieldTag);
   }
 
+  @Test
+  public void testDatasetWithSlashesInNamespace() {
+    createNamespace(NAMESPACE_NAME+"23");
+  }
+  
   @Test
   public void testDatasetFieldChange() {
     createNamespace(NAMESPACE_NAME);

--- a/api/src/test/java/marquez/MarquezAppIntegrationTest.java
+++ b/api/src/test/java/marquez/MarquezAppIntegrationTest.java
@@ -17,8 +17,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
-import lombok.Value;
 import marquez.client.models.Dataset;
 import marquez.client.models.DatasetId;
 import marquez.client.models.DbTable;
@@ -44,7 +42,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class MarquezAppIntegrationTest extends BaseIntegrationTest {
 
   @ParameterizedTest
-  @ValueSource(strings={"DEFAULT", "database://localhost:1234", "s3://bucket", "bigquery:"})
+  @ValueSource(strings = {"DEFAULT", "database://localhost:1234", "s3://bucket", "bigquery:"})
   public void testApp_createNamespace(String namespaceName) {
     final NamespaceMeta namespaceMeta =
         NamespaceMeta.builder().ownerName(OWNER_NAME).description(NAMESPACE_DESCRIPTION).build();
@@ -111,9 +109,9 @@ public class MarquezAppIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void testDatasetWithSlashesInNamespace() {
-    createNamespace(NAMESPACE_NAME+"23");
+    createNamespace(NAMESPACE_NAME + "23");
   }
-  
+
   @Test
   public void testDatasetFieldChange() {
     createNamespace(NAMESPACE_NAME);

--- a/api/src/test/java/marquez/MarquezAppIntegrationTest.java
+++ b/api/src/test/java/marquez/MarquezAppIntegrationTest.java
@@ -61,8 +61,9 @@ public class MarquezAppIntegrationTest extends BaseIntegrationTest {
         .isEqualTo(1);
   }
 
-  @Test
-  public void testApp_createSource() {
+  @ParameterizedTest
+  @ValueSource(strings = {"test_source312", "s3://bucket", "asdf", "bigquery:"})
+  public void testApp_createSource(String sourceName) {
     final SourceMeta sourceMeta =
         SourceMeta.builder()
             .type(SOURCE_TYPE)
@@ -70,9 +71,9 @@ public class MarquezAppIntegrationTest extends BaseIntegrationTest {
             .description(SOURCE_DESCRIPTION)
             .build();
 
-    final Source source = client.createSource(SOURCE_NAME, sourceMeta);
+    final Source source = client.createSource(sourceName, sourceMeta);
     assertThat(source.getType()).isEqualTo(SOURCE_TYPE);
-    assertThat(source.getName()).isEqualTo(SOURCE_NAME);
+    assertThat(source.getName()).isEqualTo(sourceName);
     assertThat(source.getCreatedAt()).isAfter(EPOCH);
     assertThat(source.getUpdatedAt()).isAfter(EPOCH);
     assertThat(source.getConnectionUrl()).isEqualTo(CONNECTION_URL);
@@ -80,7 +81,7 @@ public class MarquezAppIntegrationTest extends BaseIntegrationTest {
 
     assertThat(
             client.listSources().stream()
-                .filter(other -> other.getName().equals(SOURCE_NAME))
+                .filter(other -> other.getName().equals(sourceName))
                 .count())
         .isEqualTo(1);
   }

--- a/api/src/test/java/marquez/OpenLineageIntegrationTest.java
+++ b/api/src/test/java/marquez/OpenLineageIntegrationTest.java
@@ -34,6 +34,7 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
   public static String EVENT_UNICODE = "open_lineage/event_unicode.json";
   public static String EVENT_LARGE = "open_lineage/event_large.json";
   public static String NULL_NOMINAL_END_TIME = "open_lineage/null_nominal_end_time.json";
+  public static String EVENT_NAMESPACE_NAMING = "open_lineage/event_namespace_naming.json";
 
   public static List<String> data() {
     return Arrays.asList(
@@ -43,7 +44,8 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
         EVENT_UNICODE,
         // FIXME: A very large event fails the test.
         // EVENT_LARGE,
-        NULL_NOMINAL_END_TIME);
+        NULL_NOMINAL_END_TIME,
+        EVENT_NAMESPACE_NAMING);
   }
 
   @ParameterizedTest

--- a/api/src/test/java/marquez/common/models/CommonModelGenerator.java
+++ b/api/src/test/java/marquez/common/models/CommonModelGenerator.java
@@ -33,6 +33,10 @@ public final class CommonModelGenerator extends Generator {
   public static NamespaceName newNamespaceName() {
     return NamespaceName.of("test_namespace" + newId());
   }
+  
+  public static NamespaceName newDatasetNamespaceName() {
+    return NamespaceName.of("database://" + newId());
+  }
 
   public static OwnerName newOwnerName() {
     return OwnerName.of("test_owner" + newId());

--- a/api/src/test/java/marquez/common/models/CommonModelGenerator.java
+++ b/api/src/test/java/marquez/common/models/CommonModelGenerator.java
@@ -33,7 +33,7 @@ public final class CommonModelGenerator extends Generator {
   public static NamespaceName newNamespaceName() {
     return NamespaceName.of("test_namespace" + newId());
   }
-  
+
   public static NamespaceName newDatasetNamespaceName() {
     return NamespaceName.of("database://" + newId());
   }

--- a/api/src/test/java/marquez/db/NamespaceDaoTest.java
+++ b/api/src/test/java/marquez/db/NamespaceDaoTest.java
@@ -1,7 +1,7 @@
 package marquez.db;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import marquez.common.models.NamespaceName;
 import marquez.common.models.OwnerName;
 import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
@@ -10,9 +10,6 @@ import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 
 @ExtendWith(MarquezJdbiExternalPostgresExtension.class)
 public class NamespaceDaoTest {
@@ -23,15 +20,12 @@ public class NamespaceDaoTest {
   public static void setUpOnce(Jdbi jdbi) {
     namespaceDao = jdbi.onDemand(NamespaceDao.class);
   }
-  
+
   @Test
   void testWriteAndReadNamespace() {
     var namespaceName = NamespaceName.of("postgres://localhost:5432");
     var namespaceMeta = new NamespaceMeta(new OwnerName("marquez"), null);
-    namespaceDao.upsertNamespaceMeta(
-      namespaceName,
-      namespaceMeta
-    );
+    namespaceDao.upsertNamespaceMeta(namespaceName, namespaceMeta);
 
     assertTrue(namespaceDao.exists(namespaceName.getValue()));
   }

--- a/api/src/test/java/marquez/db/NamespaceDaoTest.java
+++ b/api/src/test/java/marquez/db/NamespaceDaoTest.java
@@ -1,0 +1,38 @@
+package marquez.db;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import marquez.common.models.NamespaceName;
+import marquez.common.models.OwnerName;
+import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
+import marquez.service.models.NamespaceMeta;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+@ExtendWith(MarquezJdbiExternalPostgresExtension.class)
+public class NamespaceDaoTest {
+
+  private static NamespaceDao namespaceDao;
+
+  @BeforeAll
+  public static void setUpOnce(Jdbi jdbi) {
+    namespaceDao = jdbi.onDemand(NamespaceDao.class);
+  }
+  
+  @Test
+  void testWriteAndReadNamespace() {
+    var namespaceName = NamespaceName.of("postgres://localhost:5432");
+    var namespaceMeta = new NamespaceMeta(new OwnerName("marquez"), null);
+    namespaceDao.upsertNamespaceMeta(
+      namespaceName,
+      namespaceMeta
+    );
+
+    assertTrue(namespaceDao.exists(namespaceName.getValue()));
+  }
+}

--- a/api/src/test/resources/config.test.yml
+++ b/api/src/test/resources/config.test.yml
@@ -2,6 +2,7 @@ server:
   applicationConnectors:
   - type: http
     port: 8080
+    httpCompliance: RFC2616_LEGACY
   adminConnectors:
   - type: http
     port: 8081

--- a/api/src/test/resources/open_lineage/event_namespace_naming.json
+++ b/api/src/test/resources/open_lineage/event_namespace_naming.json
@@ -1,0 +1,172 @@
+{
+  "eventType": "COMPLETE",
+  "eventTime": "2020-12-28T19:51:01.641Z",
+  "run": {
+    "runId": "ea041791-68bc-4ae1-bd89-4c8106a157e4",
+    "facets": {
+      "nominalTime": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "nominalStartTime": "2020-12-17T03:00:00.001Z",
+        "nominalEndTime": "2020-12-17T04:00:00.001Z"
+      },
+      "parent": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "run": {
+          "runId": "3f5e83fa-3480-44ff-99c5-ff943904e5e8"
+        },
+        "job": {
+          "namespace": "my-scheduler-namespace",
+          "name": "myjob.mytask"
+        }
+      },
+      "additionalProp1": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "additionalProp1": {}
+      },
+      "additionalProp2": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "additionalProp1": {}
+      },
+      "additionalProp3": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "additionalProp1": {}
+      }
+    }
+  },
+  "job": {
+    "namespace": "my-scheduler-namespace",
+    "name": "myjob.mytask",
+    "facets": {
+      "documentation": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "description": "string"
+      },
+      "sourceCodeLocation": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "type": "git",
+        "url": "http://example.com"
+      },
+      "sql": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "additionalPropExample": {
+          "example": true
+        },
+        "query": "SELECT * FROM foo"
+      },
+      "additionalProp1": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "additionalProp1": {}
+      },
+      "additionalProp2": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "additionalProp1": {}
+      },
+      "additionalProp3": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "additionalProp1": {}
+      }
+    }
+  },
+  "inputs": [
+    {
+      "namespace": "s3://blob-source",
+      "name": "instance.schema.table",
+      "facets": {
+        "documentation": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "description": "canonical representation of entity Foo"
+        },
+        "schema": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "fields": [
+            {
+              "name": "column1",
+              "type": "VARCHAR",
+              "description": "string"
+            }
+          ]
+        },
+        "dataSource": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "name": "s3://blob-source",
+          "uri": "s3://blob-source"
+        },
+        "additionalProp1": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "additionalProp1": {}
+        },
+        "additionalProp2": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "additionalProp1": {}
+        },
+        "additionalProp3": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "additionalProp1": {}
+        }
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "namespace": "s3://blob-sink",
+      "name": "instance.schema.table",
+      "facets": {
+        "documentation": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "description": "canonical representation of entity Foo"
+        },
+        "schema": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "fields": [
+            {
+              "name": "column1",
+              "type": "VARCHAR",
+              "description": "string"
+            }
+          ]
+        },
+        "dataSource": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "name": "s3://blob-sink",
+          "uri": "s3://blob-sink"
+        },
+        "additionalProp1": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "additionalProp1": {}
+        },
+        "additionalProp2": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "additionalProp1": {}
+        },
+        "additionalProp3": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "additionalProp1": {}
+        }
+      }
+    }
+  ],
+  "producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client"
+}

--- a/clients/java/src/main/java/marquez/client/Backend.java
+++ b/clients/java/src/main/java/marquez/client/Backend.java
@@ -1,6 +1,7 @@
 package marquez.client;
 
 import java.io.Closeable;
+import java.util.List;
 import javax.annotation.Nullable;
 
 /**
@@ -11,9 +12,17 @@ public interface Backend extends Closeable {
 
   void put(String path, String json);
 
+  default void put(List<String> path, String json) {
+    put(String.join("/", path), json);
+  }
+
+  void post(String path, @Nullable String json);
+
   default void post(String path) {
     post(path, null);
   }
 
-  void post(String path, @Nullable String json);
+  default void post(List<String> path, String json) {
+    put(String.join("/", path), json);
+  }
 }

--- a/clients/java/src/main/java/marquez/client/Backend.java
+++ b/clients/java/src/main/java/marquez/client/Backend.java
@@ -12,19 +12,11 @@ public interface Backend extends Closeable {
 
   void put(String path, String json);
 
-  default void put(List<String> path, String json) {
-    put(path, "", json);
-  }
-
   default void put(List<String> path, String queryParams, String json) {
-    post(String.join("/", path) + queryParams, json);
+    put(String.join("/", path) + queryParams, json);
   }
 
   void post(String path, @Nullable String json);
-
-  default void post(List<String> path, String json) {
-    post(path, "", json);
-  }
 
   default void post(List<String> path, String queryParams, String json) {
     post(String.join("/", path) + queryParams, json);

--- a/clients/java/src/main/java/marquez/client/Backend.java
+++ b/clients/java/src/main/java/marquez/client/Backend.java
@@ -13,16 +13,20 @@ public interface Backend extends Closeable {
   void put(String path, String json);
 
   default void put(List<String> path, String json) {
-    put(String.join("/", path), json);
+    put(path, "", json);
+  }
+
+  default void put(List<String> path, String queryParams, String json) {
+    post(String.join("/", path) + queryParams, json);
   }
 
   void post(String path, @Nullable String json);
 
-  default void post(String path) {
-    post(path, null);
+  default void post(List<String> path, String json) {
+    post(path, "", json);
   }
 
-  default void post(List<String> path, String json) {
-    put(String.join("/", path), json);
+  default void post(List<String> path, String queryParams, String json) {
+    post(String.join("/", path) + queryParams, json);
   }
 }

--- a/clients/java/src/main/java/marquez/client/MarquezPathV1.java
+++ b/clients/java/src/main/java/marquez/client/MarquezPathV1.java
@@ -15,6 +15,7 @@ class MarquezPathV1 {
     /*
      Converts path template (prepended with BASE_PATH), where path parts are separated
      by slashes, and formats strings filling pathArgs in place of %s placeholder.
+     This is required to properly handle double slashes in URLs using URIBuilder.
      Example:
      Path template "/namespaces/%s/datasets/%s/versions/%s"
      with args

--- a/clients/java/src/main/java/marquez/client/MarquezPathV1.java
+++ b/clients/java/src/main/java/marquez/client/MarquezPathV1.java
@@ -5,72 +5,98 @@ import javax.annotation.Nullable;
 import lombok.NonNull;
 import marquez.client.models.RunState;
 
-class MarquezPathV1 {
+import java.util.ArrayList;
+import java.util.List;
 
+class MarquezPathV1 {
   @VisibleForTesting static final String BASE_PATH = "/api/v1";
 
   @VisibleForTesting
-  static String path(String pathTemplate, @Nullable String... pathArgs) {
-    return BASE_PATH + String.format(pathTemplate, (Object[]) pathArgs);
+  static List<String> path(String pathTemplate, @Nullable String... pathArgs) {
+    /*
+      Converts path template (prepended with BASE_PATH), where path parts are separated
+      by slashes, and formats strings filling pathArgs in place of %s placeholder.
+      Example:
+      Path template "/namespaces/%s/datasets/%s/versions/%s"
+      with args
+      "nName", "dName", "vName"
+      is converted to list
+      ["api", "v1", "namespaces", "nName", "datasets", "dName", "versions", "vName"]
+     */
+    List<String> resultPath = new ArrayList<>();
+    pathTemplate = BASE_PATH + pathTemplate;
+    int argsIndex = 0;
+    for (String part : pathTemplate.split("/")) {
+      if (part == null || part.isEmpty()) {
+        continue;
+      }
+      if (part.equals("%s")) {
+        resultPath.add(pathArgs[argsIndex]);
+        argsIndex++;
+      } else {
+        resultPath.add(part);
+      }
+    }
+    return resultPath;
   }
 
-  static String listNamespacesPath() {
+  static List<String> listNamespacesPath() {
     return path("/namespaces");
   }
 
-  static String namespacePath(String namespaceName) {
+  static List<String> namespacePath(String namespaceName) {
     return path("/namespaces/%s", namespaceName);
   }
 
-  static String sourcePath(String sourceName) {
+  static List<String> sourcePath(String sourceName) {
     return path("/sources/%s", sourceName);
   }
 
-  static String listSourcesPath() {
+  static List<String> listSourcesPath() {
     return path("/sources");
   }
 
-  static String datasetVersionPath(
+  static List<String> datasetVersionPath(
       @NonNull final String namespaceName,
       @NonNull final String datasetName,
       @NonNull final String version) {
     return path("/namespaces/%s/datasets/%s/versions/%s", namespaceName, datasetName, version);
   }
 
-  static String listDatasetVersionsPath(
+  static List<String> listDatasetVersionsPath(
       @NonNull final String namespaceName, @NonNull final String datasetName) {
     return path("/namespaces/%s/datasets/%s/versions", namespaceName, datasetName);
   }
 
-  static String listDatasetsPath(@NonNull String namespaceName) {
+  static List<String> listDatasetsPath(@NonNull String namespaceName) {
     return path("/namespaces/%s/datasets", namespaceName);
   }
 
-  static String datasetPath(String namespaceName, String datasetName) {
+  static List<String> datasetPath(String namespaceName, String datasetName) {
     return path("/namespaces/%s/datasets/%s", namespaceName, datasetName);
   }
 
-  static String listJobsPath(@NonNull String namespaceName) {
+  static List<String> listJobsPath(@NonNull String namespaceName) {
     return path("/namespaces/%s/jobs", namespaceName);
   }
 
-  static String jobPath(String namespaceName, String jobName) {
+  static List<String> jobPath(String namespaceName, String jobName) {
     return path("/namespaces/%s/jobs/%s", namespaceName, jobName);
   }
 
-  static String createRunPath(String namespaceName, String jobName) {
+  static List<String> createRunPath(String namespaceName, String jobName) {
     return path("/namespaces/%s/jobs/%s/runs", namespaceName, jobName);
   }
 
-  static String runPath(@NonNull String runId) {
+  static List<String> runPath(@NonNull String runId) {
     return path("/jobs/runs/%s", runId);
   }
 
-  static String listRunsPath(@NonNull String namespaceName, @NonNull String jobName) {
+  static List<String> listRunsPath(@NonNull String namespaceName, @NonNull String jobName) {
     return path("/namespaces/%s/jobs/%s/runs", namespaceName, jobName);
   }
 
-  static String runTransitionPath(String runId, RunState runState) {
+  static List<String> runTransitionPath(String runId, RunState runState) {
     final String transition;
     switch (runState) {
       case RUNNING:
@@ -92,19 +118,19 @@ class MarquezPathV1 {
     return path("/jobs/runs/%s/%s", runId, transition);
   }
 
-  static String datasetTagPath(
+  static List<String> datasetTagPath(
       @NonNull String namespaceName, @NonNull String datasetName, @NonNull String tagName) {
     return path("/namespaces/%s/datasets/%s/tags/%s", namespaceName, datasetName, tagName);
   }
 
-  static String fieldTagPath(
+  static List<String> fieldTagPath(
       String namespaceName, String datasetName, String fieldName, String tagName) {
     return path(
         "/namespaces/%s/datasets/%s/fields/%s/tags/%s",
         namespaceName, datasetName, fieldName, tagName);
   }
 
-  static String listTagsPath() {
+  static List<String> listTagsPath() {
     return path("/tags");
   }
 }

--- a/clients/java/src/main/java/marquez/client/MarquezPathV1.java
+++ b/clients/java/src/main/java/marquez/client/MarquezPathV1.java
@@ -1,12 +1,11 @@
 package marquez.client;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nullable;
 import lombok.NonNull;
 import marquez.client.models.RunState;
-
-import java.util.ArrayList;
-import java.util.List;
 
 class MarquezPathV1 {
   @VisibleForTesting static final String BASE_PATH = "/api/v1";
@@ -14,15 +13,15 @@ class MarquezPathV1 {
   @VisibleForTesting
   static List<String> path(String pathTemplate, @Nullable String... pathArgs) {
     /*
-      Converts path template (prepended with BASE_PATH), where path parts are separated
-      by slashes, and formats strings filling pathArgs in place of %s placeholder.
-      Example:
-      Path template "/namespaces/%s/datasets/%s/versions/%s"
-      with args
-      "nName", "dName", "vName"
-      is converted to list
-      ["api", "v1", "namespaces", "nName", "datasets", "dName", "versions", "vName"]
-     */
+     Converts path template (prepended with BASE_PATH), where path parts are separated
+     by slashes, and formats strings filling pathArgs in place of %s placeholder.
+     Example:
+     Path template "/namespaces/%s/datasets/%s/versions/%s"
+     with args
+     "nName", "dName", "vName"
+     is converted to list
+     ["api", "v1", "namespaces", "nName", "datasets", "dName", "versions", "vName"]
+    */
     List<String> resultPath = new ArrayList<>();
     pathTemplate = BASE_PATH + pathTemplate;
     int argsIndex = 0;

--- a/clients/java/src/main/java/marquez/client/MarquezUrl.java
+++ b/clients/java/src/main/java/marquez/client/MarquezUrl.java
@@ -26,7 +26,11 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import lombok.NonNull;
 import marquez.client.models.RunState;
@@ -47,6 +51,26 @@ class MarquezUrl {
   @VisibleForTesting
   URL from(String path) {
     return from(path, ImmutableMap.of());
+  }
+
+  @VisibleForTesting
+  URL from(List<String> path) {
+    return from(path, ImmutableMap.of());
+  }
+
+  @VisibleForTesting
+  URL from(List<String> path, @Nullable Map<String, Object> queryParams) {
+    try {
+      final URIBuilder builder = new URIBuilder(baseUrl.toURI()).setPathSegments(path);
+      if (queryParams != null) {
+        queryParams.forEach((name, value) -> builder.addParameter(name, String.valueOf(value)));
+      }
+      return builder.build().toURL();
+    } catch (URISyntaxException | MalformedURLException e) {
+      throw new IllegalArgumentException(
+        "can not build url from parameters: " + path + " " + queryParams, e);
+    }
+
   }
 
   @VisibleForTesting

--- a/clients/java/src/main/java/marquez/client/MarquezUrl.java
+++ b/clients/java/src/main/java/marquez/client/MarquezUrl.java
@@ -26,11 +26,8 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import lombok.NonNull;
 import marquez.client.models.RunState;
@@ -68,9 +65,8 @@ class MarquezUrl {
       return builder.build().toURL();
     } catch (URISyntaxException | MalformedURLException e) {
       throw new IllegalArgumentException(
-        "can not build url from parameters: " + path + " " + queryParams, e);
+          "can not build url from parameters: " + path + " " + queryParams, e);
     }
-
   }
 
   @VisibleForTesting

--- a/clients/java/src/main/java/marquez/client/MarquezWriteOnlyClientImpl.java
+++ b/clients/java/src/main/java/marquez/client/MarquezWriteOnlyClientImpl.java
@@ -81,7 +81,7 @@ class MarquezWriteOnlyClientImpl implements MarquezWriteOnlyClient {
 
   @Override
   public void createRun(String namespaceName, String jobName, RunMeta runMeta) {
-    backend.post(createRunPath(namespaceName, jobName), null, runMeta.toJson());
+    backend.post(createRunPath(namespaceName, jobName), "", runMeta.toJson());
   }
 
   @Override

--- a/clients/java/src/main/java/marquez/client/MarquezWriteOnlyClientImpl.java
+++ b/clients/java/src/main/java/marquez/client/MarquezWriteOnlyClientImpl.java
@@ -81,14 +81,14 @@ class MarquezWriteOnlyClientImpl implements MarquezWriteOnlyClient {
 
   @Override
   public void createRun(String namespaceName, String jobName, RunMeta runMeta) {
-    backend.post(createRunPath(namespaceName, jobName), runMeta.toJson());
+    backend.post(createRunPath(namespaceName, jobName), null, runMeta.toJson());
   }
 
   @Override
   public void markRunAs(String runId, RunState runState, Instant at) {
     Map<String, Object> queryParams =
         at == null ? null : ImmutableMap.of("at", ISO_INSTANT.format(at));
-    backend.post(runTransitionPath(runId, runState), queryPath(queryParams));
+    backend.post(runTransitionPath(runId, runState), queryPath(queryParams), null);
   }
 
   @Override

--- a/clients/java/src/main/java/marquez/client/MarquezWriteOnlyClientImpl.java
+++ b/clients/java/src/main/java/marquez/client/MarquezWriteOnlyClientImpl.java
@@ -33,9 +33,8 @@ class MarquezWriteOnlyClientImpl implements MarquezWriteOnlyClient {
     this.backend = backend;
   }
 
-  private static String path(String path, Map<String, Object> queryParams) {
+  private static String queryPath(Map<String, Object> queryParams) {
     StringBuilder pathBuilder = new StringBuilder();
-    pathBuilder.append(path);
     if (queryParams != null && !queryParams.isEmpty()) {
       boolean first = true;
       for (Entry<String, Object> entry : queryParams.entrySet()) {
@@ -89,7 +88,7 @@ class MarquezWriteOnlyClientImpl implements MarquezWriteOnlyClient {
   public void markRunAs(String runId, RunState runState, Instant at) {
     Map<String, Object> queryParams =
         at == null ? null : ImmutableMap.of("at", ISO_INSTANT.format(at));
-    backend.post(path(runTransitionPath(runId, runState), queryParams));
+    backend.post(runTransitionPath(runId, runState), queryPath(queryParams));
   }
 
   @Override

--- a/clients/java/src/main/java/marquez/client/MarquezWriteOnlyClientImpl.java
+++ b/clients/java/src/main/java/marquez/client/MarquezWriteOnlyClientImpl.java
@@ -61,22 +61,22 @@ class MarquezWriteOnlyClientImpl implements MarquezWriteOnlyClient {
 
   @Override
   public void createNamespace(String namespaceName, NamespaceMeta namespaceMeta) {
-    backend.put(namespacePath(namespaceName), namespaceMeta.toJson());
+    backend.put(namespacePath(namespaceName), "", namespaceMeta.toJson());
   }
 
   @Override
   public void createSource(String sourceName, SourceMeta sourceMeta) {
-    backend.put(sourcePath(sourceName), sourceMeta.toJson());
+    backend.put(sourcePath(sourceName), "", sourceMeta.toJson());
   }
 
   @Override
   public void createDataset(String namespaceName, String datasetName, DatasetMeta datasetMeta) {
-    backend.put(datasetPath(namespaceName, datasetName), datasetMeta.toJson());
+    backend.put(datasetPath(namespaceName, datasetName), "", datasetMeta.toJson());
   }
 
   @Override
   public void createJob(String namespaceName, String jobName, JobMeta jobMeta) {
-    backend.put(jobPath(namespaceName, jobName), jobMeta.toJson());
+    backend.put(jobPath(namespaceName, jobName), "", jobMeta.toJson());
   }
 
   @Override

--- a/clients/java/src/test/java/marquez/client/LoggingBackendTest.java
+++ b/clients/java/src/test/java/marquez/client/LoggingBackendTest.java
@@ -45,7 +45,7 @@ public class LoggingBackendTest {
 
   @Test
   public void testLoggingBackendPostNoPayload() throws IOException {
-    loggingBackend.post("postPath");
+    loggingBackend.post("postPath", null);
     verify(logger, times(1)).info("POST postPath");
   }
 

--- a/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
@@ -38,7 +38,6 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.net.URL;
 import java.time.Instant;
-import java.util.List;
 import javax.net.ssl.SSLContext;
 import marquez.client.models.JsonGenerator;
 import marquez.client.models.Namespace;
@@ -118,7 +117,6 @@ public class MarquezHttpTest {
     URL actual = marquezUrl.from(path(pathTemplate, pathArg));
     assertThat(actual).isEqualTo(expected);
   }
-
 
   @Test
   public void testPost_noHttpBody() throws Exception {

--- a/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.net.URL;
 import java.time.Instant;
+import java.util.List;
 import javax.net.ssl.SSLContext;
 import marquez.client.models.JsonGenerator;
 import marquez.client.models.Namespace;
@@ -103,9 +104,21 @@ public class MarquezHttpTest {
     final String path = String.format(pathTemplate, pathArg);
 
     URL expected = new URL(BASE_URL_STRING + BASE_PATH + path);
-    URL actual = marquezUrl.from(path(path, pathArg));
+    URL actual = marquezUrl.from(path(pathTemplate, pathArg));
     assertThat(actual).isEqualTo(expected);
   }
+
+  @Test
+  public void testClient_properlyFormatsNamespaces() throws Exception {
+    final String pathTemplate = "/namespaces/%s";
+    final String pathArg = "database://localhost:1234";
+    final String path = "/namespaces/database:%2F%2Flocalhost:1234";
+
+    URL expected = new URL(BASE_URL_STRING + BASE_PATH + path);
+    URL actual = marquezUrl.from(path(pathTemplate, pathArg));
+    assertThat(actual).isEqualTo(expected);
+  }
+
 
   @Test
   public void testPost_noHttpBody() throws Exception {

--- a/clients/java/src/test/java/marquez/client/MarquezWriteOnlyClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezWriteOnlyClientTest.java
@@ -50,7 +50,7 @@ public class MarquezWriteOnlyClientTest {
     NamespaceMeta namespaceMeta = new NamespaceMeta("owner", "description");
     client.createNamespace("foo", namespaceMeta);
     verify(backend, times(1))
-        .put(Arrays.asList("api", "v1", "namespaces", "foo"), namespaceMeta.toJson());
+        .put(Arrays.asList("api", "v1", "namespaces", "foo"), "", namespaceMeta.toJson());
   }
 
   @Test
@@ -58,7 +58,7 @@ public class MarquezWriteOnlyClientTest {
     SourceMeta sourceMeta = new SourceMeta("type", new URI("connection:uri"), "description");
     client.createSource("sourceFoo", sourceMeta);
     verify(backend, times(1))
-        .put(Arrays.asList("api", "v1", "sources", "sourceFoo"), sourceMeta.toJson());
+        .put(Arrays.asList("api", "v1", "sources", "sourceFoo"), "", sourceMeta.toJson());
   }
 
   @Test
@@ -69,6 +69,7 @@ public class MarquezWriteOnlyClientTest {
     verify(backend, times(1))
         .put(
             Arrays.asList("api", "v1", "namespaces", "namespaceName", "datasets", "datasetName"),
+            "",
             datasetMeta.toJson());
   }
 
@@ -79,6 +80,7 @@ public class MarquezWriteOnlyClientTest {
     verify(backend, times(1))
         .put(
             Arrays.asList("api", "v1", "namespaces", "namespaceName", "jobs", "jobName"),
+            "",
             jobMeta.toJson());
   }
 

--- a/clients/java/src/test/java/marquez/client/MarquezWriteOnlyClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezWriteOnlyClientTest.java
@@ -12,7 +12,6 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
 import marquez.client.models.DatasetMeta;
 import marquez.client.models.DbTableMeta;
@@ -50,14 +49,16 @@ public class MarquezWriteOnlyClientTest {
   public void testCreateNamespace() {
     NamespaceMeta namespaceMeta = new NamespaceMeta("owner", "description");
     client.createNamespace("foo", namespaceMeta);
-    verify(backend, times(1)).put("/api/v1/namespaces/foo", namespaceMeta.toJson());
+    verify(backend, times(1))
+        .put(Arrays.asList("api", "v1", "namespaces", "foo"), namespaceMeta.toJson());
   }
 
   @Test
   public void testCreateSource() throws URISyntaxException {
     SourceMeta sourceMeta = new SourceMeta("type", new URI("connection:uri"), "description");
     client.createSource("sourceFoo", sourceMeta);
-    verify(backend, times(1)).put("/api/v1/sources/sourceFoo", sourceMeta.toJson());
+    verify(backend, times(1))
+        .put(Arrays.asList("api", "v1", "sources", "sourceFoo"), sourceMeta.toJson());
   }
 
   @Test
@@ -66,7 +67,9 @@ public class MarquezWriteOnlyClientTest {
         DbTableMeta.builder().physicalName("physical").sourceName("source").build();
     client.createDataset("namespaceName", "datasetName", datasetMeta);
     verify(backend, times(1))
-        .put("/api/v1/namespaces/namespaceName/datasets/datasetName", datasetMeta.toJson());
+        .put(
+            Arrays.asList("api", "v1", "namespaces", "namespaceName", "datasets"),
+            datasetMeta.toJson());
   }
 
   @Test
@@ -74,7 +77,9 @@ public class MarquezWriteOnlyClientTest {
     JobMeta jobMeta = JobMeta.builder().type(JobType.BATCH).build();
     client.createJob("namespaceName", "jobName", jobMeta);
     verify(backend, times(1))
-        .put("/api/v1/namespaces/namespaceName/jobs/jobName", jobMeta.toJson());
+        .put(
+            Arrays.asList("api", "v1", "namespaces", "namespaceName", "jobs", "jobName"),
+            jobMeta.toJson());
   }
 
   @Test
@@ -82,7 +87,9 @@ public class MarquezWriteOnlyClientTest {
     RunMeta runMeta = RunMeta.builder().build();
     client.createRun("namespaceName", "jobName", runMeta);
     verify(backend, times(1))
-        .post("/api/v1/namespaces/namespaceName/jobs/jobName/runs", runMeta.toJson());
+        .post(
+            Arrays.asList("api", "v1", "namespaces", "namespaceName", "jobs", "jobName", "runs"),
+            runMeta.toJson());
   }
 
   @Test
@@ -100,28 +107,35 @@ public class MarquezWriteOnlyClientTest {
     Instant at = Instant.now();
     String atParam = URLEncoder.encode(String.valueOf(at), UTF_8.name());
     client.markRunAsRunning(runId, at);
-    verify(backend, times(1)).post("/api/v1/jobs/runs/" + runId + "/start?at=" + atParam);
+    verify(backend, times(1))
+        .post(Arrays.asList("api", "v1", "jobs", "runs", runId, "start"), "?at=" + atParam, null);
     client.markRunAsAborted(runId, at);
-    verify(backend, times(1)).post("/api/v1/jobs/runs/" + runId + "/abort?at=" + atParam);
+    verify(backend, times(1))
+        .post(Arrays.asList("api", "v1", "jobs", "runs", runId, "abort"), "?at=" + atParam, null);
     client.markRunAsCompleted(runId, at);
-    verify(backend, times(1)).post("/api/v1/jobs/runs/" + runId + "/complete?at=" + atParam);
+    verify(backend, times(1))
+        .post(
+            Arrays.asList("api", "v1", "jobs", "runs", runId, "complete"), "?at=" + atParam, null);
     client.markRunAsFailed(runId, at);
-    verify(backend, times(1)).post("/api/v1/jobs/runs/" + runId + "/fail?at=" + atParam);
+    verify(backend, times(1))
+        .post(Arrays.asList("api", "v1", "jobs", "runs", runId, "fail"), "?at=" + atParam, null);
   }
 
   @Test
   public void testMarkRunAsNoAt() {
     String runId = UUID.randomUUID().toString();
     client.markRunAsRunning(runId);
-    verify(backend, times(1)).post(Arrays.asList(
-      "api", "v1", "jobs", "runs", runId, "start"
-    ), null);
+    verify(backend, times(1))
+        .post(Arrays.asList("api", "v1", "jobs", "runs", runId, "start"), "", null);
     client.markRunAsAborted(runId);
-    verify(backend, times(1)).post("/api/v1/jobs/runs/" + runId + "/abort");
+    verify(backend, times(1))
+        .post(Arrays.asList("api", "v1", "jobs", "runs", runId, "abort"), "", null);
     client.markRunAsCompleted(runId);
-    verify(backend, times(1)).post("/api/v1/jobs/runs/" + runId + "/complete");
+    verify(backend, times(1))
+        .post(Arrays.asList("api", "v1", "jobs", "runs", runId, "complete"), "", null);
     client.markRunAsFailed(runId);
-    verify(backend, times(1)).post("/api/v1/jobs/runs/" + runId + "/fail");
+    verify(backend, times(1))
+        .post(Arrays.asList("api", "v1", "jobs", "runs", runId, "fail"), "", null);
   }
 
   @Test

--- a/clients/java/src/test/java/marquez/client/MarquezWriteOnlyClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezWriteOnlyClientTest.java
@@ -11,6 +11,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import marquez.client.models.DatasetMeta;
 import marquez.client.models.DbTableMeta;
@@ -111,7 +113,9 @@ public class MarquezWriteOnlyClientTest {
   public void testMarkRunAsNoAt() {
     String runId = UUID.randomUUID().toString();
     client.markRunAsRunning(runId);
-    verify(backend, times(1)).post("/api/v1/jobs/runs/" + runId + "/start");
+    verify(backend, times(1)).post(Arrays.asList(
+      "api", "v1", "jobs", "runs", runId, "start"
+    ), null);
     client.markRunAsAborted(runId);
     verify(backend, times(1)).post("/api/v1/jobs/runs/" + runId + "/abort");
     client.markRunAsCompleted(runId);

--- a/clients/java/src/test/java/marquez/client/MarquezWriteOnlyClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezWriteOnlyClientTest.java
@@ -68,8 +68,7 @@ public class MarquezWriteOnlyClientTest {
     client.createDataset("namespaceName", "datasetName", datasetMeta);
     verify(backend, times(1))
         .put(
-            Arrays.asList("api", "v1", "namespaces", "namespaceName", "datasets"),
-            "",
+            Arrays.asList("api", "v1", "namespaces", "namespaceName", "datasets", "datasetName"),
             datasetMeta.toJson());
   }
 

--- a/clients/java/src/test/java/marquez/client/MarquezWriteOnlyClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezWriteOnlyClientTest.java
@@ -69,6 +69,7 @@ public class MarquezWriteOnlyClientTest {
     verify(backend, times(1))
         .put(
             Arrays.asList("api", "v1", "namespaces", "namespaceName", "datasets"),
+            "",
             datasetMeta.toJson());
   }
 
@@ -89,6 +90,7 @@ public class MarquezWriteOnlyClientTest {
     verify(backend, times(1))
         .post(
             Arrays.asList("api", "v1", "namespaces", "namespaceName", "jobs", "jobName", "runs"),
+            "",
             runMeta.toJson());
   }
 
@@ -98,7 +100,10 @@ public class MarquezWriteOnlyClientTest {
     RunMeta runMeta = RunMeta.builder().id(id).build();
     client.createRun("namespaceName", "jobName", runMeta);
     verify(backend, times(1))
-        .post("/api/v1/namespaces/namespaceName/jobs/jobName/runs", runMeta.toJson());
+        .post(
+            Arrays.asList("api", "v1", "namespaces", "namespaceName", "jobs", "jobName", "runs"),
+            "",
+            runMeta.toJson());
   }
 
   @Test

--- a/marquez.dev.yml
+++ b/marquez.dev.yml
@@ -2,6 +2,7 @@ server:
   applicationConnectors:
   - type: http
     port: 5000
+    httpCompliance: RFC2616_LEGACY
   adminConnectors:
   - type: http
     port: 5001

--- a/marquez.example.yml
+++ b/marquez.example.yml
@@ -17,6 +17,7 @@ server:
   applicationConnectors:
   - type: http
     port: ${MARQUEZ_PORT:-8080}
+    httpCompliance: RFC2616_LEGACY
   adminConnectors:
   - type: http
     port: ${MARQUEZ_ADMIN_PORT:-8081}


### PR DESCRIPTION
This allows valid OpenLineage namespaces and datasets like `s3://bucket` be created and retrieved using Marquez API and Marquez client. 

Fixes https://github.com/MarquezProject/marquez/issues/1397

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>