### PR TITLE
api: allow urlencoded path parameters, java client: properly urlencode path parameters

### DIFF
--- a/api/src/main/java/marquez/common/models/NamespaceName.java
+++ b/api/src/main/java/marquez/common/models/NamespaceName.java
@@ -41,7 +41,8 @@ public final class NamespaceName {
     checkArgument(
         PATTERN.matcher(value).matches(),
         "namespace '%s' must contain only letters (a-z, A-Z), numbers (0-9), "
-            + "underscores (_), dashes (-), or dots (.) with a maximum length of %s characters.",
+            + "underscores (_), dashes (-), colons (:), slashes (/) or dots (.) with a maximum "
+            + "length of %s characters.",
         value,
         MAX_SIZE);
     this.value = value;

--- a/api/src/test/java/marquez/MarquezAppIntegrationTest.java
+++ b/api/src/test/java/marquez/MarquezAppIntegrationTest.java
@@ -35,17 +35,20 @@ import marquez.client.models.Stream;
 import marquez.client.models.StreamMeta;
 import marquez.client.models.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @org.junit.jupiter.api.Tag("IntegrationTests")
 public class MarquezAppIntegrationTest extends BaseIntegrationTest {
 
-  @Test
-  public void testApp_createNamespace() {
+  @ParameterizedTest
+  @ValueSource(strings = {"DEFAULT", "database://localhost:1234", "s3://bucket", "bigquery:"})
+  public void testApp_createNamespace(String namespaceName) {
     final NamespaceMeta namespaceMeta =
         NamespaceMeta.builder().ownerName(OWNER_NAME).description(NAMESPACE_DESCRIPTION).build();
 
-    final Namespace namespace = client.createNamespace(NAMESPACE_NAME, namespaceMeta);
-    assertThat(namespace.getName()).isEqualTo(NAMESPACE_NAME);
+    final Namespace namespace = client.createNamespace(namespaceName, namespaceMeta);
+    assertThat(namespace.getName()).isEqualTo(namespaceName);
     assertThat(namespace.getCreatedAt()).isAfter(EPOCH);
     assertThat(namespace.getUpdatedAt()).isAfter(EPOCH);
     assertThat(namespace.getOwnerName()).isEqualTo(OWNER_NAME);
@@ -53,13 +56,14 @@ public class MarquezAppIntegrationTest extends BaseIntegrationTest {
 
     assertThat(
             client.listNamespaces().stream()
-                .filter(other -> other.getName().equals(NAMESPACE_NAME))
+                .filter(other -> other.getName().equals(namespaceName))
                 .count())
         .isEqualTo(1);
   }
 
-  @Test
-  public void testApp_createSource() {
+  @ParameterizedTest
+  @ValueSource(strings = {"test_source312", "s3://bucket", "asdf", "bigquery:"})
+  public void testApp_createSource(String sourceName) {
     final SourceMeta sourceMeta =
         SourceMeta.builder()
             .type(SOURCE_TYPE)
@@ -67,9 +71,9 @@ public class MarquezAppIntegrationTest extends BaseIntegrationTest {
             .description(SOURCE_DESCRIPTION)
             .build();
 
-    final Source source = client.createSource(SOURCE_NAME, sourceMeta);
+    final Source source = client.createSource(sourceName, sourceMeta);
     assertThat(source.getType()).isEqualTo(SOURCE_TYPE);
-    assertThat(source.getName()).isEqualTo(SOURCE_NAME);
+    assertThat(source.getName()).isEqualTo(sourceName);
     assertThat(source.getCreatedAt()).isAfter(EPOCH);
     assertThat(source.getUpdatedAt()).isAfter(EPOCH);
     assertThat(source.getConnectionUrl()).isEqualTo(CONNECTION_URL);
@@ -77,7 +81,7 @@ public class MarquezAppIntegrationTest extends BaseIntegrationTest {
 
     assertThat(
             client.listSources().stream()
-                .filter(other -> other.getName().equals(SOURCE_NAME))
+                .filter(other -> other.getName().equals(sourceName))
                 .count())
         .isEqualTo(1);
   }

--- a/api/src/test/java/marquez/OpenLineageIntegrationTest.java
+++ b/api/src/test/java/marquez/OpenLineageIntegrationTest.java
@@ -34,6 +34,7 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
   public static String EVENT_UNICODE = "open_lineage/event_unicode.json";
   public static String EVENT_LARGE = "open_lineage/event_large.json";
   public static String NULL_NOMINAL_END_TIME = "open_lineage/null_nominal_end_time.json";
+  public static String EVENT_NAMESPACE_NAMING = "open_lineage/event_namespace_naming.json";
 
   public static List<String> data() {
     return Arrays.asList(
@@ -43,7 +44,8 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
         EVENT_UNICODE,
         // FIXME: A very large event fails the test.
         // EVENT_LARGE,
-        NULL_NOMINAL_END_TIME);
+        NULL_NOMINAL_END_TIME,
+        EVENT_NAMESPACE_NAMING);
   }
 
   @ParameterizedTest

--- a/api/src/test/java/marquez/common/models/CommonModelGenerator.java
+++ b/api/src/test/java/marquez/common/models/CommonModelGenerator.java
@@ -31,7 +31,7 @@ public final class CommonModelGenerator extends Generator {
   private CommonModelGenerator() {}
 
   public static NamespaceName newNamespaceName() {
-    return NamespaceName.of("test_namespace" + newId());
+    return NamespaceName.of("s3://test_namespace" + newId());
   }
 
   public static OwnerName newOwnerName() {

--- a/api/src/test/java/marquez/db/NamespaceDaoTest.java
+++ b/api/src/test/java/marquez/db/NamespaceDaoTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package marquez.db;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import marquez.common.models.NamespaceName;
+import marquez.common.models.OwnerName;
+import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
+import marquez.service.models.NamespaceMeta;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MarquezJdbiExternalPostgresExtension.class)
+public class NamespaceDaoTest {
+
+  private static NamespaceDao namespaceDao;
+
+  @BeforeAll
+  public static void setUpOnce(Jdbi jdbi) {
+    namespaceDao = jdbi.onDemand(NamespaceDao.class);
+  }
+
+  @Test
+  void testWriteAndReadNamespace() {
+    var namespaceName = NamespaceName.of("postgres://localhost:5432");
+    var namespaceMeta = new NamespaceMeta(new OwnerName("marquez"), null);
+    namespaceDao.upsertNamespaceMeta(namespaceName, namespaceMeta);
+
+    assertTrue(namespaceDao.exists(namespaceName.getValue()));
+  }
+}

--- a/api/src/test/resources/config.test.yml
+++ b/api/src/test/resources/config.test.yml
@@ -2,6 +2,7 @@ server:
   applicationConnectors:
   - type: http
     port: 8080
+    httpCompliance: RFC7230_LEGACY
   adminConnectors:
   - type: http
     port: 8081

--- a/api/src/test/resources/open_lineage/event_namespace_naming.json
+++ b/api/src/test/resources/open_lineage/event_namespace_naming.json
@@ -1,0 +1,172 @@
+{
+  "eventType": "COMPLETE",
+  "eventTime": "2020-12-28T19:51:01.641Z",
+  "run": {
+    "runId": "ea041791-68bc-4ae1-bd89-4c8106a157e4",
+    "facets": {
+      "nominalTime": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "nominalStartTime": "2020-12-17T03:00:00.001Z",
+        "nominalEndTime": "2020-12-17T04:00:00.001Z"
+      },
+      "parent": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "run": {
+          "runId": "3f5e83fa-3480-44ff-99c5-ff943904e5e8"
+        },
+        "job": {
+          "namespace": "my-scheduler-namespace",
+          "name": "myjob.mytask"
+        }
+      },
+      "additionalProp1": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "additionalProp1": {}
+      },
+      "additionalProp2": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "additionalProp1": {}
+      },
+      "additionalProp3": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "additionalProp1": {}
+      }
+    }
+  },
+  "job": {
+    "namespace": "my-scheduler-namespace",
+    "name": "myjob.mytask",
+    "facets": {
+      "documentation": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "description": "string"
+      },
+      "sourceCodeLocation": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "type": "git",
+        "url": "http://example.com"
+      },
+      "sql": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "additionalPropExample": {
+          "example": true
+        },
+        "query": "SELECT * FROM foo"
+      },
+      "additionalProp1": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "additionalProp1": {}
+      },
+      "additionalProp2": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "additionalProp1": {}
+      },
+      "additionalProp3": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "additionalProp1": {}
+      }
+    }
+  },
+  "inputs": [
+    {
+      "namespace": "s3://blob-source",
+      "name": "instance.schema.table",
+      "facets": {
+        "documentation": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "description": "canonical representation of entity Foo"
+        },
+        "schema": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "fields": [
+            {
+              "name": "column1",
+              "type": "VARCHAR",
+              "description": "string"
+            }
+          ]
+        },
+        "dataSource": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "name": "s3://blob-source",
+          "uri": "s3://blob-source"
+        },
+        "additionalProp1": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "additionalProp1": {}
+        },
+        "additionalProp2": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "additionalProp1": {}
+        },
+        "additionalProp3": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "additionalProp1": {}
+        }
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "namespace": "s3://blob-sink",
+      "name": "instance.schema.table",
+      "facets": {
+        "documentation": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "description": "canonical representation of entity Foo"
+        },
+        "schema": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "fields": [
+            {
+              "name": "column1",
+              "type": "VARCHAR",
+              "description": "string"
+            }
+          ]
+        },
+        "dataSource": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "name": "s3://blob-sink",
+          "uri": "s3://blob-sink"
+        },
+        "additionalProp1": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "additionalProp1": {}
+        },
+        "additionalProp2": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "additionalProp1": {}
+        },
+        "additionalProp3": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+          "additionalProp1": {}
+        }
+      }
+    }
+  ],
+  "producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client"
+}

--- a/clients/java/src/main/java/marquez/client/MarquezUrl.java
+++ b/clients/java/src/main/java/marquez/client/MarquezUrl.java
@@ -24,6 +24,7 @@ import static marquez.client.MarquezPathV1.sourcePath;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.Instant;
@@ -53,7 +54,7 @@ class MarquezUrl {
   @VisibleForTesting
   URL from(String path, @Nullable Map<String, Object> queryParams) {
     try {
-      final URIBuilder builder = new URIBuilder(baseUrl.toURI()).setPath(baseUrl.getPath() + path);
+      final URIBuilder builder = new URIBuilder(URI.create(baseUrl.toURI() + path));
       if (queryParams != null) {
         queryParams.forEach((name, value) -> builder.addParameter(name, String.valueOf(value)));
       }

--- a/clients/java/src/main/java/marquez/client/MarquezWriteOnlyClientImpl.java
+++ b/clients/java/src/main/java/marquez/client/MarquezWriteOnlyClientImpl.java
@@ -33,9 +33,8 @@ class MarquezWriteOnlyClientImpl implements MarquezWriteOnlyClient {
     this.backend = backend;
   }
 
-  private static String path(String path, Map<String, Object> queryParams) {
-    StringBuilder pathBuilder = new StringBuilder();
-    pathBuilder.append(path);
+  private static String pathWithQueryParams(String path, Map<String, Object> queryParams) {
+    StringBuilder pathBuilder = new StringBuilder(path);
     if (queryParams != null && !queryParams.isEmpty()) {
       boolean first = true;
       for (Entry<String, Object> entry : queryParams.entrySet()) {
@@ -89,7 +88,7 @@ class MarquezWriteOnlyClientImpl implements MarquezWriteOnlyClient {
   public void markRunAs(String runId, RunState runState, Instant at) {
     Map<String, Object> queryParams =
         at == null ? null : ImmutableMap.of("at", ISO_INSTANT.format(at));
-    backend.post(path(runTransitionPath(runId, runState), queryParams));
+    backend.post(pathWithQueryParams(runTransitionPath(runId, runState), queryParams));
   }
 
   @Override

--- a/clients/java/src/main/java/marquez/client/Utils.java
+++ b/clients/java/src/main/java/marquez/client/Utils.java
@@ -59,7 +59,11 @@ public final class Utils {
 
   public static URL toUrl(@NonNull final String urlString) {
     try {
-      return new URL(urlString);
+      String url = urlString;
+      if (url.endsWith("/")) {
+        url = url.substring(0, url.length() - 1);
+      }
+      return new URL(url);
     } catch (MalformedURLException e) {
       final AssertionError error = new AssertionError("Malformed URL: " + urlString);
       error.initCause(e);

--- a/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
@@ -102,8 +102,19 @@ public class MarquezHttpTest {
     final String pathArg = "default";
     final String path = String.format(pathTemplate, pathArg);
 
-    URL expected = new URL(BASE_URL_STRING + BASE_PATH + path);
-    URL actual = marquezUrl.from(path(path, pathArg));
+    URL expected = new URL(BASE_URL + BASE_PATH + path);
+    URL actual = marquezUrl.from(path(pathTemplate, pathArg));
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void testClient_properlyFormatsNamespaces() throws Exception {
+    final String pathTemplate = "/namespaces/%s";
+    final String pathArg = "database://localhost:1234";
+    final String path = "/namespaces/database%3A%2F%2Flocalhost%3A1234";
+
+    URL expected = new URL(BASE_URL + BASE_PATH + path);
+    URL actual = marquezUrl.from(path(pathTemplate, pathArg));
     assertThat(actual).isEqualTo(expected);
   }
 

--- a/clients/java/src/test/java/marquez/client/MarquezPathV1Test.java
+++ b/clients/java/src/test/java/marquez/client/MarquezPathV1Test.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package marquez.client;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@org.junit.jupiter.api.Tag("UnitTests")
+public class MarquezPathV1Test {
+
+  @ParameterizedTest
+  @MethodSource
+  void testPath_namespaceUrl(String expected, String namespaceName) {
+    Assertions.assertEquals(expected, MarquezPathV1.namespacePath(namespaceName));
+  }
+
+  private static Stream<Arguments> testPath_namespaceUrl() {
+    return Stream.of(
+        Arguments.of("/api/v1/namespaces/s3%3A%2F%2Fbucket", "s3://bucket"),
+        Arguments.of("/api/v1/namespaces/bigquery%3A", "bigquery:"),
+        Arguments.of("/api/v1/namespaces/usual-namespace-name", "usual-namespace-name"),
+        Arguments.of("/api/v1/namespaces/a%3A%5C%3Aa", "a:\\:a"));
+  }
+
+  @Test
+  void testPath_datasetUrl() {
+    Assertions.assertEquals(
+        "/api/v1/namespaces/s3%3A%2F%2Fbuckets/datasets/source-file.json",
+        MarquezPathV1.datasetPath("s3://buckets", "source-file.json"));
+  }
+
+  @Test
+  void testPath_placeholderReplacement() {
+    Assertions.assertEquals(
+        "/api/v1/whatever/replace1/next", MarquezPathV1.path("/whatever/%s/next", "replace1"));
+
+    Assertions.assertEquals("/api/v1/whatever/next", MarquezPathV1.path("/whatever/next"));
+  }
+
+  @Test
+  void testPath_notEnoughPlaceholders() {
+    Assertions.assertThrows(
+        MarquezClientException.class,
+        () -> {
+          MarquezPathV1.path("/whatever/%s/next/%s/replace1");
+        });
+
+    Assertions.assertThrows(
+        MarquezClientException.class,
+        () -> {
+          MarquezPathV1.path("/whatever/%s/next/%s/%s/replace1");
+        });
+  }
+
+  @Test
+  void testPath_tooMuchPlaceholders() {
+    Assertions.assertThrows(
+        MarquezClientException.class,
+        () -> {
+          MarquezPathV1.path("/whatever/%s/next/replace1/replace2");
+        });
+  }
+
+  @Test
+  void testPath_noPlaceholders() {
+    Assertions.assertThrows(
+        MarquezClientException.class,
+        () -> {
+          MarquezPathV1.path("/whatever/%s");
+        });
+    Assertions.assertThrows(
+        MarquezClientException.class,
+        () -> {
+          MarquezPathV1.path("/whatever/%s/next/%s");
+        });
+  }
+}

--- a/clients/java/src/test/java/marquez/client/MarquezUrlTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezUrlTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package marquez.client;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@org.junit.jupiter.api.Tag("UnitTests")
+public class MarquezUrlTest {
+  static String basePath = "http://marquez:5000";
+  static MarquezUrl marquezUrl;
+
+  @BeforeAll
+  static void beforeAll() throws MalformedURLException {
+    marquezUrl = MarquezUrl.create(Utils.toUrl(basePath));
+  }
+
+  @Test
+  void testBasicMarquezUrl() {
+    URL url = marquezUrl.from("/namespace/nname/job/jname");
+    Assertions.assertEquals("http://marquez:5000/namespace/nname/job/jname", url.toString());
+  }
+
+  @Test
+  void testEncodedMarquezUrl() {
+    URL url = marquezUrl.from("/namespace/s3:%2F%2Fbucket/job/jname");
+    Assertions.assertEquals(
+        "http://marquez:5000/namespace/s3:%2F%2Fbucket/job/jname", url.toString());
+  }
+}

--- a/clients/java/src/test/java/marquez/client/UtilsTest.java
+++ b/clients/java/src/test/java/marquez/client/UtilsTest.java
@@ -70,6 +70,14 @@ public class UtilsTest {
   }
 
   @Test
+  public void testToUrl_stripsTrailingSlash() throws Exception {
+    final String urlString = "http://test.com:8080/";
+    final URL expected = new URL("http://test.com:8080");
+    final URL actual = Utils.toUrl(urlString);
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
   public void testToUrl_throwsOnNull() {
     assertThatNullPointerException().isThrownBy(() -> Utils.toUrl(null));
   }

--- a/marquez.dev.yml
+++ b/marquez.dev.yml
@@ -2,6 +2,7 @@ server:
   applicationConnectors:
   - type: http
     port: 5000
+    httpCompliance: RFC7230_LEGACY
   adminConnectors:
   - type: http
     port: 5001

--- a/marquez.example.yml
+++ b/marquez.example.yml
@@ -17,6 +17,7 @@ server:
   applicationConnectors:
   - type: http
     port: ${MARQUEZ_PORT:-8080}
+    httpCompliance: RFC7230_LEGACY
   adminConnectors:
   - type: http
     port: ${MARQUEZ_ADMIN_PORT:-8081}


### PR DESCRIPTION
Use HttpCompliance.RFC7230_LEGACY to allow potentially ambiguous URIs with encoded path segments.
Refactor Marquez Java client to properly urlencode path segments.