### PR TITLE
Fixing the display for job sql

### DIFF
--- a/web/src/components/JobDetailPage.tsx
+++ b/web/src/components/JobDetailPage.tsx
@@ -111,11 +111,10 @@ const JobDetailPage: FunctionComponent<IProps> = props => {
     latestRun,
     location,
     namespace,
-    context = { SQL: '' }
+    context = { sql: '' }
   } = job as IJob
 
   const latestRuns = job ? job.latestRuns || [] : []
-  const { SQL } = context
 
   return (
     <Box
@@ -157,7 +156,7 @@ const JobDetailPage: FunctionComponent<IProps> = props => {
           <MqText subdued>{description}</MqText>
         </Box>
       </Box>
-      <Code>{SQL}</Code>
+      <Code code={context.sql} />
       <Box display={'flex'} justifyContent={'flex-end'} alignItems={'center'} mt={1}>
         <div className={classes.latestRunContainer}>
           {latestRuns.map(r => {


### PR DESCRIPTION
This fixes the display for job SQL. It was being transcluded in our React component instead of included as a prop. We perhaps wish to show other keys here as well, but it's out of scope for this fix.
![image](https://user-images.githubusercontent.com/7514204/122452412-16b88900-cf5e-11eb-8340-11eb911d2357.png)


Signed-off-by: Peter Hicks <peter@datakin.com>