### PR TITLE
Allow upsert of tags

### DIFF
--- a/api/src/main/java/marquez/db/TagDao.java
+++ b/api/src/main/java/marquez/db/TagDao.java
@@ -37,7 +37,9 @@ public interface TagDao {
   @SqlQuery(
       "INSERT INTO tags (uuid, created_at, updated_at, name, description) "
           + "VALUES (:uuid, :updatedAt, :updatedAt, :name, :description) "
-          + "ON CONFLICT(name) DO UPDATE SET updated_at = EXCLUDED.updated_at "
+          + "ON CONFLICT(name) DO UPDATE SET "
+          + "updated_at = EXCLUDED.updated_at, "
+          + "description = EXCLUDED.description "
           + "RETURNING *")
   TagRow upsert(UUID uuid, Instant updatedAt, String name, String description);
 

--- a/api/src/test/java/marquez/TagIntegrationTest.java
+++ b/api/src/test/java/marquez/TagIntegrationTest.java
@@ -50,7 +50,7 @@ public class TagIntegrationTest extends BaseIntegrationTest {
     Tag tagWithoutDescription = client.createTag("tag", "New Description");
 
     assertThat(tagWithoutDescription.getName()).isEqualTo("tag");
-    assertThat(tagWithoutDescription.getDescription()).contains("Description");
+    assertThat(tagWithoutDescription.getDescription()).contains("New Description");
   }
 
   @Test


### PR DESCRIPTION
Fixes #1412 that didn't allow to change the tag description after creation

Signed-off-by: Florian Schulz <florian.schulz@hanbei.de>