### PR TITLE
fix: bigquery URI should lose colon at the end

### DIFF
--- a/integrations/airflow/marquez_airflow/extractors/bigquery_extractor.py
+++ b/integrations/airflow/marquez_airflow/extractors/bigquery_extractor.py
@@ -28,7 +28,7 @@ from marquez_airflow.extractors.base import (
 )
 from marquez_airflow.utils import get_job_name
 
-_BIGQUERY_CONN_URL = 'bigquery:{}'
+_BIGQUERY_CONN_URL = 'bigquery'
 
 log = logging.getLogger(__name__)
 

--- a/integrations/airflow/marquez_airflow/extractors/great_expectations_extractor.py
+++ b/integrations/airflow/marquez_airflow/extractors/great_expectations_extractor.py
@@ -46,7 +46,7 @@ try:
 except Exception:
     # Create placeholder for GreatExpectationsOperator
     GreatExpectationsOperator = None
-    log.exception('Did not find great_expectations_provider library or failed to import it')
+    log.warning('Did not find great_expectations_provider library or failed to import it')
     _has_great_expectations = False
 
 
@@ -147,6 +147,8 @@ class GreatExpectationsExtractorImpl(BaseExtractor):
                     scheme, authority = namespace.split('://')
                 elif ':' in namespace:
                     scheme, authority = namespace.split(':')
+                else:
+                    scheme = namespace
             else:
                 name = batch_kwargs.get('datasource', None)
                 path = batch_kwargs.get('path', None)

--- a/integrations/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integrations/airflow/tests/extractors/test_bigquery_extractor.py
@@ -97,10 +97,8 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
             'bigquery-public-data.usa_names.usa_1910_2013'
 
         assert step_meta.inputs[0].fields is not None
-        assert step_meta.inputs[0].source.name == \
-               'bigquery:'
-        assert step_meta.inputs[0].source.connection_url == \
-               'bigquery:'
+        assert step_meta.inputs[0].source.name == 'bigquery'
+        assert step_meta.inputs[0].source.connection_url == 'bigquery'
         assert len(step_meta.inputs[0].fields) == 5
         assert step_meta.outputs is not None
         assert len(step_meta.outputs) == 1

--- a/integrations/airflow/tests/extractors/test_great_expectations_extractor.py
+++ b/integrations/airflow/tests/extractors/test_great_expectations_extractor.py
@@ -126,7 +126,7 @@ def test_great_expectations_operator_batch_kwargs_success():
 
 @pytest.mark.parametrize('namespace,scheme,authority', [
     ('postgres://localhost:5432', 'postgres', 'localhost:5432'),
-    ('bigquery:', 'bigquery', ''),
+    ('bigquery', 'bigquery', None),
     ('s3://bucket', "s3", 'bucket')
 ])
 def test_great_expectations_operator_with_provided_namespace_success(namespace, scheme, authority):

--- a/integrations/common/marquez/dataset.py
+++ b/integrations/common/marquez/dataset.py
@@ -39,8 +39,8 @@ class Source:
                self.connection_url == other.connection_url
 
     def __repr__(self):
-        authority = '://' + self.authority if self.authority else ''
-        return f"Source({self.scheme!r}{authority} - {self.connection_url!r})"
+        authority = '//' + self.authority if self.authority else ''
+        return f"Source({self.scheme!r}:{authority} - {self.connection_url!r})"
 
     @property
     def name(self) -> str:
@@ -48,7 +48,7 @@ class Source:
             return self._name
         if self.authority:
             return f'{self.scheme}://{self.authority}'
-        return f'{self.scheme}:'
+        return f'{self.scheme}'
 
 
 class Field:

--- a/integrations/common/marquez/provider/bigquery.py
+++ b/integrations/common/marquez/provider/bigquery.py
@@ -26,7 +26,7 @@ from openlineage.facet import BaseFacet
 
 from marquez.utils import get_from_nullable_chain
 
-_BIGQUERY_CONN_URL = 'bigquery:{}'
+_BIGQUERY_CONN_URL = 'bigquery'
 
 
 @attr.s
@@ -262,7 +262,7 @@ class BigQueryDatasetsProvider:
     def _source(self) -> Source:
         return Source(
             scheme='bigquery',
-            connection_url='bigquery:'
+            connection_url='bigquery'
         )
 
     def _bq_table_name(self, bq_table):

--- a/integrations/common/tests/bigquery/test_bigquery.py
+++ b/integrations/common/tests/bigquery/test_bigquery.py
@@ -44,7 +44,7 @@ def test_bq_job_information():
         Dataset(
             source=Source(
                 scheme='bigquery',
-                connection_url='bigquery:'
+                connection_url='bigquery'
             ),
             name='bigquery-public-data.usa_names.usa_1910_2013',
             fields=[
@@ -59,7 +59,7 @@ def test_bq_job_information():
     assert statistics.output == Dataset(
         source=Source(
             scheme='bigquery',
-            connection_url='bigquery:'
+            connection_url='bigquery'
         ),
         name='bq-airflow-marquez.new_dataset.output_table',
     )

--- a/integrations/dbt/bigquery/dbt/adapters/openlineage_bigquery/connections.py
+++ b/integrations/dbt/bigquery/dbt/adapters/openlineage_bigquery/connections.py
@@ -126,13 +126,13 @@ class OpenLineageBigQueryConnectionManager(BigQueryConnectionManager):
             producer=PRODUCER,
             inputs=sorted([
                 Dataset(
-                    namespace='bigquery:',
+                    namespace='bigquery',
                     name=relation,
                     facets={}
                 ) for relation in inputs
             ], key=lambda x: x.name),
             outputs=[
-                Dataset(namespace='bigquery:', name=output_relation_name)
+                Dataset(namespace='bigquery', name=output_relation_name)
             ]
         ))
         return run_id

--- a/integrations/dbt/bigquery/tests/test_bigquery_adapter.py
+++ b/integrations/dbt/bigquery/tests/test_bigquery_adapter.py
@@ -140,17 +140,17 @@ class TestOpenLineageBQAdapterAcquire(BaseTestOpenLineageBQAdapter):
             producer=PRODUCER,
             inputs=[
                 Dataset(
-                    namespace='bigquery:',
+                    namespace='bigquery',
                     name='speedy-vim-308516.dbt_test1.test_second_dbt_model'
                 ),
                 Dataset(
-                    namespace='bigquery:',
+                    namespace='bigquery',
                     name='speedy-vim-308516.dbt_test1.test_second_parallel_dbt_model'
                 )
             ],
             outputs=[
                 Dataset(
-                    namespace='bigquery:',
+                    namespace='bigquery',
                     name='speedy-vim-308516.dbt_test1.test_third_dbt_model'
                 )
             ]


### PR DESCRIPTION
Java URI class does not accept URI with colon at the end,
Then, method getUrlOrPlaceholder changes it to http://bigquery: as a result.