### PR TITLE
dbt packages should look for namespace packages

### DIFF
--- a/integrations/dbt/bigquery/setup.py
+++ b/integrations/dbt/bigquery/setup.py
@@ -14,7 +14,7 @@
 #
 # -*- coding: utf-8 -*-
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 with open("README.md") as readme_file:
     readme = readme_file.read()
@@ -50,7 +50,7 @@ setup(
     long_description=readme,
     long_description_content_type="text/markdown",
     author="Marquez Project",
-    packages=find_packages(),
+    packages=find_namespace_packages(include=['dbt', 'dbt.*']),
     package_data=data,
     include_package_data=True,
     install_requires=requirements,

--- a/integrations/dbt/snowflake/setup.py
+++ b/integrations/dbt/snowflake/setup.py
@@ -14,7 +14,7 @@
 #
 # -*- coding: utf-8 -*-
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 with open("README.md") as readme_file:
     readme = readme_file.read()
@@ -51,7 +51,7 @@ setup(
     long_description=readme,
     long_description_content_type="text/markdown",
     author='Marquez Project',
-    packages=find_packages(),
+    packages=find_namespace_packages(include=['dbt', 'dbt.*']),
     package_data=data,
     include_package_data=True,
     install_requires=requirements,


### PR DESCRIPTION
Building package without this results with **actual code not being packaged** because it uses PEP420 namespace packages. Of course, local install just adds this to the path, so it does not cause any problems in tests.
Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>