### PR TITLE
Fixing job, dataset, and run url encodings.

### DIFF
--- a/web/src/requests/datasets.ts
+++ b/web/src/requests/datasets.ts
@@ -4,7 +4,7 @@ import { genericFetchWrapper } from '.'
 export const fetchDatasets = async (namespace: Namespace) => {
   const { name } = namespace
   // eslint-disable-next-line no-undef
-  const url = `${__API_URL__}/namespaces/${name}/datasets?limit=700`
+  const url = `${__API_URL__}/namespaces/${encodeURIComponent(name)}/datasets?limit=700`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchDatasets').then((r: Datasets) => {
     return r.datasets.map(d => ({ ...d, namespace: namespace.name }))
   })

--- a/web/src/requests/jobs.ts
+++ b/web/src/requests/jobs.ts
@@ -4,7 +4,7 @@ import { genericFetchWrapper } from '.'
 export const fetchJobs = async (namespace: Namespace) => {
   const { name } = namespace
   // eslint-disable-next-line no-undef
-  const url = `${__API_URL__}/namespaces/${name}/jobs?limit=700`
+  const url = `${__API_URL__}/namespaces/${encodeURIComponent(name)}/jobs?limit=700`
   return genericFetchWrapper<Job[]>(url, { method: 'GET' }, 'fetchJobs').then((r: Jobs) => {
     return r.jobs.map(j => ({ ...j, namespace: namespace.name }))
   })
@@ -12,6 +12,8 @@ export const fetchJobs = async (namespace: Namespace) => {
 
 export const fetchLatestJobRuns = async (jobName: string, namespace: string) => {
   // eslint-disable-next-line no-undef
-  const url = `${__API_URL__}/namespaces/${namespace}/jobs/${jobName}/runs?limit=10`
+  const url = `${__API_URL__}/namespaces/${encodeURIComponent(namespace)}/jobs/${encodeURIComponent(
+    jobName
+  )}/runs?limit=10`
   return genericFetchWrapper<Run[]>(url, { method: 'GET' }, 'fetchLatestJobRuns')
 }


### PR DESCRIPTION
Fixes: #1501 

This encodes certain entity names in our fetch URLs since they can include delimiter characters such as `/` that will not work.

Signed-off-by: Peter Hicks <peter@datakin.com>