### PR TITLE
Bump dbt dep to 0.20.0

### DIFF
--- a/integrations/dbt/bigquery/setup.py
+++ b/integrations/dbt/bigquery/setup.py
@@ -29,8 +29,8 @@ data = {
 }
 
 requirements = [
-    "dbt-core>=0.20.0b1",
-    "dbt-bigquery>=0.20.0b1",
+    "dbt-core>=0.20.0",
+    "dbt-bigquery>=0.20.0",
     "sqlparse>=0.3.1",
     f"marquez-integration-common=={__version__}",
     "openlineage-python==0.0.1rc6"

--- a/integrations/dbt/snowflake/setup.py
+++ b/integrations/dbt/snowflake/setup.py
@@ -29,8 +29,8 @@ data = {
 }
 
 requirements = [
-    "dbt-core>=0.20.0b1",
-    "dbt-snowflake>=0.20.0b1",
+    "dbt-core>=0.20.0",
+    "dbt-snowflake>=0.20.0",
     "sqlparse>=0.3.1",
     f"marquez-integration-common=={__version__}",
     "openlineage-python>=0.0.1rc6"


### PR DESCRIPTION
This PR bumps the dbt dep to `0.20.0` and replaces the `beta` release.