### PR TITLE
Order nodes in lineage graph by node ID

### DIFF
--- a/api/src/main/java/marquez/service/models/Edge.java
+++ b/api/src/main/java/marquez/service/models/Edge.java
@@ -1,14 +1,22 @@
 package marquez.service.models;
 
+import java.util.Comparator;
 import lombok.NonNull;
 import lombok.Value;
 
 @Value
-public class Edge {
+public class Edge implements Comparable<Edge> {
   @NonNull NodeId origin;
   @NonNull NodeId destination;
 
   public static Edge of(@NonNull final NodeId origin, @NonNull final NodeId destination) {
     return new Edge(origin, destination);
+  }
+
+  @Override
+  public int compareTo(Edge o) {
+    return Comparator.comparing(Edge::getOrigin)
+        .thenComparing(Edge::getDestination)
+        .compare(this, o);
   }
 }

--- a/api/src/main/java/marquez/service/models/Graph.java
+++ b/api/src/main/java/marquez/service/models/Graph.java
@@ -15,7 +15,7 @@ public final class Graph {
   private Graph() {}
 
   public void add(@NonNull final Node node) {
-    addAll(Sets.newHashSet(node));
+    mutableNodes.add(node);
   }
 
   public void addAll(@NonNull final Set<Node> nodes) {

--- a/api/src/main/java/marquez/service/models/Graph.java
+++ b/api/src/main/java/marquez/service/models/Graph.java
@@ -1,7 +1,9 @@
 package marquez.service.models;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Sets;
+import java.util.Comparator;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
@@ -10,6 +12,9 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public final class Graph {
+  private static final Comparator<Node> ORDER_BY_NODE_ID =
+      Comparator.comparing(node -> node.getId().getValue());
+
   private final Set<Node> mutableNodes = Sets.newHashSet();
 
   public void add(@NonNull final Node node) {
@@ -21,7 +26,7 @@ public final class Graph {
   }
 
   public Set<Node> nodes() {
-    return ImmutableSet.copyOf(mutableNodes);
+    return ImmutableSortedSet.copyOf(ORDER_BY_NODE_ID, mutableNodes);
   }
 
   public static Builder directed() {
@@ -30,6 +35,15 @@ public final class Graph {
 
   public static final class Builder {
     private Set<Node> nodes;
+
+    public Builder() {
+      this.nodes = Sets.newHashSet();
+    }
+
+    public Builder nodes(@NonNull Node... nodes) {
+      this.nodes = Sets.newHashSet(nodes);
+      return this;
+    }
 
     public Builder nodes(@NonNull Set<Node> nodes) {
       this.nodes = nodes;

--- a/api/src/main/java/marquez/service/models/Graph.java
+++ b/api/src/main/java/marquez/service/models/Graph.java
@@ -12,6 +12,8 @@ import lombok.ToString;
 public final class Graph {
   private final Set<Node> mutableNodes = Sets.newTreeSet();
 
+  private Graph() {}
+
   public void add(@NonNull final Node node) {
     addAll(Sets.newHashSet(node));
   }

--- a/api/src/main/java/marquez/service/models/Graph.java
+++ b/api/src/main/java/marquez/service/models/Graph.java
@@ -1,9 +1,7 @@
 package marquez.service.models;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Sets;
-import java.util.Comparator;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
@@ -12,13 +10,10 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public final class Graph {
-  private static final Comparator<Node> ORDER_BY_NODE_ID =
-      Comparator.comparing(node -> node.getId().getValue());
-
-  private final Set<Node> mutableNodes = Sets.newHashSet();
+  private final Set<Node> mutableNodes = Sets.newTreeSet();
 
   public void add(@NonNull final Node node) {
-    addAll(ImmutableSet.of(node));
+    addAll(Sets.newHashSet(node));
   }
 
   public void addAll(@NonNull final Set<Node> nodes) {
@@ -26,7 +21,7 @@ public final class Graph {
   }
 
   public Set<Node> nodes() {
-    return ImmutableSortedSet.copyOf(ORDER_BY_NODE_ID, mutableNodes);
+    return ImmutableSortedSet.copyOf(mutableNodes);
   }
 
   public static Builder directed() {

--- a/api/src/main/java/marquez/service/models/Node.java
+++ b/api/src/main/java/marquez/service/models/Node.java
@@ -4,6 +4,9 @@ import static marquez.common.base.MorePreconditions.checkNotBlank;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Sets;
+import java.util.Set;
 import javax.annotation.Nullable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -19,25 +22,25 @@ public final class Node implements Comparable<Node> {
   @Getter private final NodeId id;
   @Getter private final NodeType type;
   @Getter @Setter @Nullable private NodeData data;
-  @Getter private final ImmutableSet<Edge> inEdges;
-  @Getter private final ImmutableSet<Edge> outEdges;
+  @Getter private final Set<Edge> inEdges;
+  @Getter private final Set<Edge> outEdges;
 
   public Node(
       @NonNull final NodeId id,
       @NonNull final NodeType type,
       @Nullable final NodeData data,
-      @Nullable final ImmutableSet<Edge> inEdges,
-      @Nullable final ImmutableSet<Edge> outEdges) {
+      @Nullable final Set<Edge> inEdges,
+      @Nullable final Set<Edge> outEdges) {
     this.id = id;
     this.type = type;
     this.data = data;
-    this.inEdges = (inEdges == null) ? ImmutableSet.of() : inEdges;
-    this.outEdges = (outEdges == null) ? ImmutableSet.of() : outEdges;
+    this.inEdges = (inEdges == null) ? ImmutableSet.of() : ImmutableSortedSet.copyOf(inEdges);
+    this.outEdges = (outEdges == null) ? ImmutableSet.of() : ImmutableSortedSet.copyOf(outEdges);
   }
 
   @Override
   public int compareTo(Node node) {
-    return this.getId().getValue().compareTo(node.getId().getValue());
+    return id.compareTo(node.getId());
   }
 
   public static Builder dataset() {
@@ -64,8 +67,8 @@ public final class Node implements Comparable<Node> {
     private NodeId id;
     private final NodeType type;
     private NodeData data;
-    private ImmutableSet<Edge> inEdges;
-    private ImmutableSet<Edge> outEdges;
+    private Set<Edge> inEdges;
+    private Set<Edge> outEdges;
 
     private Builder(@NonNull final NodeType type) {
       this.type = type;
@@ -87,12 +90,22 @@ public final class Node implements Comparable<Node> {
       return this;
     }
 
-    public Builder inEdges(@Nullable ImmutableSet<Edge> inEdges) {
+    public Builder inEdges(@NonNull Edge... inEdges) {
+      this.inEdges = Sets.newHashSet(inEdges);
+      return this;
+    }
+
+    public Builder inEdges(@Nullable Set<Edge> inEdges) {
       this.inEdges = (inEdges == null) ? ImmutableSet.of() : inEdges;
       return this;
     }
 
-    public Builder outEdges(@Nullable ImmutableSet<Edge> outEdges) {
+    public Builder outEdges(@NonNull Edge... outEdges) {
+      this.outEdges = Sets.newHashSet(outEdges);
+      return this;
+    }
+
+    public Builder outEdges(@Nullable Set<Edge> outEdges) {
       this.outEdges = (outEdges == null) ? ImmutableSet.of() : outEdges;
       return this;
     }

--- a/api/src/main/java/marquez/service/models/NodeId.java
+++ b/api/src/main/java/marquez/service/models/NodeId.java
@@ -30,7 +30,7 @@ import marquez.service.models.LineageEvent.Job;
 @ToString
 @JsonDeserialize(converter = NodeId.FromValue.class)
 @JsonSerialize(converter = NodeId.ToValue.class)
-public final class NodeId {
+public final class NodeId implements Comparable<NodeId> {
   public static final String ID_DELIM = ":";
   public static final Joiner ID_JOINER = Joiner.on(ID_DELIM);
 
@@ -227,6 +227,11 @@ public final class NodeId {
     String[] parts = parts(4, ID_PREFX_DATASET);
     return new DatasetVersionId(
         NamespaceName.of(parts[1]), DatasetName.of(parts[2]), UUID.fromString(parts[3]));
+  }
+
+  @Override
+  public int compareTo(NodeId o) {
+    return value.compareTo(o.getValue());
   }
 
   public static class FromValue extends StdConverter<String, NodeId> {

--- a/api/src/test/java/marquez/service/models/GraphTest.java
+++ b/api/src/test/java/marquez/service/models/GraphTest.java
@@ -52,7 +52,7 @@ public class GraphTest {
   @Test
   public void testDirectedGraph_edges_backwards() {
     final Node nodeWithUnorderedEdges =
-            Node.job().id(NodeId.of("job:test-namespace:c")).inEdges(E1, E0).outEdges(E3, E2).build();
+        Node.job().id(NodeId.of("job:test-namespace:c")).inEdges(E1, E0).outEdges(E3, E2).build();
     final Graph graph = Graph.directed().nodes(N0, N1, nodeWithUnorderedEdges, N3, N4).build();
     assertThat(graph.nodes()).containsExactly(N0, N1, N3, N4, N2);
   }

--- a/api/src/test/java/marquez/service/models/GraphTest.java
+++ b/api/src/test/java/marquez/service/models/GraphTest.java
@@ -7,25 +7,53 @@ import org.junit.Test;
 /** The test suite for {@link Graph}. */
 @org.junit.jupiter.api.Tag("UnitTests")
 public class GraphTest {
-  private static final Node A = Node.dataset().id(NodeId.of("dataset:test:a")).build();
-  private static final Node B = Node.dataset().id(NodeId.of("dataset:test:b")).build();
-  private static final Node C = Node.dataset().id(NodeId.of("dataset:test:c")).build();
+  private static final Edge E0 =
+      Edge.of(NodeId.of("dataset:test-namespace:a"), NodeId.of("job:test-namespace:c"));
+  private static final Edge E1 =
+      Edge.of(NodeId.of("dataset:test-namespace:b"), NodeId.of("job:test-namespace:c"));
+  private static final Edge E2 =
+      Edge.of(NodeId.of("job:test-namespace:c"), NodeId.of("dataset:test-namespace:d"));
+  private static final Edge E3 =
+      Edge.of(NodeId.of("job:test-namespace:c"), NodeId.of("dataset:test-namespace:e"));
+
+  private static final Node N0 = Node.dataset().id(NodeId.of("dataset:test-namespace:a")).build();
+  private static final Node N1 = Node.dataset().id(NodeId.of("dataset:test-namespace:b")).build();
+  private static final Node N2 =
+      Node.job().id(NodeId.of("job:test-namespace:c")).inEdges(E0, E1).outEdges(E2, E3).build();
+  private static final Node N3 = Node.dataset().id(NodeId.of("dataset:test-namespace:d")).build();
+  private static final Node N4 = Node.dataset().id(NodeId.of("dataset:test-namespace:e")).build();
 
   @Test
   public void testDirectedGraph() {
-    final Graph graph = Graph.directed().nodes(A, B, C).build();
-    assertThat(graph.nodes()).containsExactly(A, B, C);
+    final Graph graph = Graph.directed().nodes(N0, N1, N2, N3, N4).build();
+    assertThat(graph.nodes()).containsExactly(N0, N1, N3, N4, N2);
   }
 
   @Test
   public void testDirectedGraph_unordered() {
-    final Graph graph = Graph.directed().nodes(A, C, B).build();
-    assertThat(graph.nodes()).containsExactly(A, B, C);
+    final Graph graph = Graph.directed().nodes(N0, N2, N1, N3, N4).build();
+    assertThat(graph.nodes()).containsExactly(N0, N1, N3, N4, N2);
   }
 
   @Test
   public void testDirectedGraph_backwards() {
-    final Graph graph = Graph.directed().nodes(C, B, A).build();
-    assertThat(graph.nodes()).containsExactly(A, B, C);
+    final Graph graph = Graph.directed().nodes(N4, N3, N2, N1, N0).build();
+    assertThat(graph.nodes()).containsExactly(N0, N1, N3, N4, N2);
+  }
+
+  @Test
+  public void testDirectedGraph_edges_unordered() {
+    final Node nodeWithUnorderedEdges =
+        Node.job().id(NodeId.of("job:test-namespace:c")).inEdges(E1, E0).outEdges(E2, E3).build();
+    final Graph graph = Graph.directed().nodes(N0, N1, nodeWithUnorderedEdges, N3, N4).build();
+    assertThat(graph.nodes()).containsExactly(N0, N1, N3, N4, N2);
+  }
+
+  @Test
+  public void testDirectedGraph_edges_backwards() {
+    final Node nodeWithUnorderedEdges =
+            Node.job().id(NodeId.of("job:test-namespace:c")).inEdges(E1, E0).outEdges(E3, E2).build();
+    final Graph graph = Graph.directed().nodes(N0, N1, nodeWithUnorderedEdges, N3, N4).build();
+    assertThat(graph.nodes()).containsExactly(N0, N1, N3, N4, N2);
   }
 }

--- a/api/src/test/java/marquez/service/models/GraphTest.java
+++ b/api/src/test/java/marquez/service/models/GraphTest.java
@@ -1,0 +1,31 @@
+package marquez.service.models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+/** The test suite for {@link Graph}. */
+@org.junit.jupiter.api.Tag("UnitTests")
+public class GraphTest {
+  private static final Node A = Node.dataset().id(NodeId.of("dataset:test:a")).build();
+  private static final Node B = Node.dataset().id(NodeId.of("dataset:test:b")).build();
+  private static final Node C = Node.dataset().id(NodeId.of("dataset:test:c")).build();
+
+  @Test
+  public void testDirectedGraph() {
+    final Graph graph = Graph.directed().nodes(A, B, C).build();
+    assertThat(graph.nodes()).containsExactly(A, B, C);
+  }
+
+  @Test
+  public void testDirectedGraph_unordered() {
+    final Graph graph = Graph.directed().nodes(A, C, B).build();
+    assertThat(graph.nodes()).containsExactly(A, B, C);
+  }
+
+  @Test
+  public void testDirectedGraph_backwards() {
+    final Graph graph = Graph.directed().nodes(C, B, A).build();
+    assertThat(graph.nodes()).containsExactly(A, B, C);
+  }
+}

--- a/api/src/test/java/marquez/service/models/GraphTest.java
+++ b/api/src/test/java/marquez/service/models/GraphTest.java
@@ -43,17 +43,17 @@ public class GraphTest {
 
   @Test
   public void testDirectedGraph_edges_unordered() {
-    final Node nodeWithUnorderedEdges =
+    final Node nodeWithEdgesUnordered =
         Node.job().id(NodeId.of("job:test-namespace:c")).inEdges(E1, E0).outEdges(E2, E3).build();
-    final Graph graph = Graph.directed().nodes(N0, N1, nodeWithUnorderedEdges, N3, N4).build();
+    final Graph graph = Graph.directed().nodes(N0, N1, nodeWithEdgesUnordered, N3, N4).build();
     assertThat(graph.nodes()).containsExactly(N0, N1, N3, N4, N2);
   }
 
   @Test
   public void testDirectedGraph_edges_backwards() {
-    final Node nodeWithUnorderedEdges =
+    final Node nodeWithEdgesBackwards =
         Node.job().id(NodeId.of("job:test-namespace:c")).inEdges(E1, E0).outEdges(E3, E2).build();
-    final Graph graph = Graph.directed().nodes(N0, N1, nodeWithUnorderedEdges, N3, N4).build();
+    final Graph graph = Graph.directed().nodes(N0, N1, nodeWithEdgesBackwards, N3, N4).build();
     assertThat(graph.nodes()).containsExactly(N0, N1, N3, N4, N2);
   }
 }


### PR DESCRIPTION
This PR fixes #1459 by sorting nodes within a [`Graph`](https://github.com/MarquezProject/marquez/blob/main/api/src/main/java/marquez/service/models/Graph.java) by node ID. The nodes are sorted when invoking `Graph.nodes()`.