### PR TITLE
Deprecate `airflow` and `spark` integrations

### DIFF
--- a/integrations/airflow/README.md
+++ b/integrations/airflow/README.md
@@ -3,37 +3,3 @@
 [![Project status](https://img.shields.io/badge/status-deprecated-orange.svg)]()
 
 This repository has been moved to [`OpenLineage/integration/airflow`](https://github.com/OpenLineage/OpenLineage/tree/main/integration/airflow). **The** `marquez-airflow` **library extends the class** [`openlineage.airflow.DAG`](https://github.com/OpenLineage/OpenLineage/blob/main/integration/airflow/openlineage/airflow/dag.py) **for backwards compatibility.**
-
-## Requirements
-
-[Python 3.5.0](https://www.python.org/downloads)+
-
-## Installation
-
-```bash
-$ pip3 install marquez-airflow
-```
-
-To install from source run:
-
-```bash
-$ python3 setup.py install
-```
-
-## Configuration
-
-Configure the following environment variables in your Airflow instance:
-
-```bash
-MARQUEZ_URL=<marquez-url>              # The URL of the HTTP backend
-MARQUEZ_NAMESPACE=<marquez-namespace>  # The namespace associated with the collected metadata
-```
-
-## Usage
-
-To begin collecting DAG lineage metadata with Marquez, make the following change to your DAG definitions:
-
-```diff
-- from airflow import DAG
-+ from marquez_airflow import DAG
-```

--- a/integrations/airflow/README.md
+++ b/integrations/airflow/README.md
@@ -2,4 +2,4 @@
 
 [![Project status](https://img.shields.io/badge/status-deprecated-orange.svg)]()
 
-This repository has been moved to [`OpenLineage/integration/airflow`](https://github.com/OpenLineage/OpenLineage/tree/main/integration/airflow). **The** `marquez-airflow` **library extends the class** [`openlineage.airflow.DAG`](https://github.com/OpenLineage/OpenLineage/blob/main/integration/airflow/openlineage/airflow/dag.py) **for backwards compatibility.**
+This library has been moved to [`OpenLineage/integration/airflow`](https://github.com/OpenLineage/OpenLineage/tree/main/integration/airflow). **The** `marquez-airflow` **library extends the class** [`openlineage.airflow.DAG`](https://github.com/OpenLineage/OpenLineage/blob/main/integration/airflow/openlineage/airflow/dag.py) **for backwards compatibility.**

--- a/integrations/airflow/README.md
+++ b/integrations/airflow/README.md
@@ -2,4 +2,4 @@
 
 [![Project status](https://img.shields.io/badge/status-deprecated-orange.svg)]()
 
-This library has been moved to [`OpenLineage/integration/airflow`](https://github.com/OpenLineage/OpenLineage/tree/main/integration/airflow). **The** `marquez-airflow` **library extends the class** [`openlineage.airflow.DAG`](https://github.com/OpenLineage/OpenLineage/blob/main/integration/airflow/openlineage/airflow/dag.py) **for backwards compatibility.**
+This library has been moved to [`OpenLineage/integration/airflow`](https://github.com/OpenLineage/OpenLineage/tree/main/integration/airflow). The `marquez-airflow` library extends the class [`openlineage.airflow.DAG`](https://github.com/OpenLineage/OpenLineage/blob/main/integration/airflow/openlineage/airflow/dag.py) for backwards compatibility. **Please use the** [`openlineage-airflow`](https://pypi.org/project/openlineage-airflow) **library instead instead**.

--- a/integrations/airflow/README.md
+++ b/integrations/airflow/README.md
@@ -1,10 +1,39 @@
-## Moved
+# Marquez Airflow - `DEPRECATED`
 
-Airflow integration was moved to [OpenLineage](https://github.com/OpenLineage/OpenLineage/tree/main/integration/airflow).
-This module wraps OpenLineage codebase for backwards compatibility.
+[![Project status](https://img.shields.io/badge/status-deprecated-orange.svg)]()
+
+This repository has been moved to [`OpenLineage/integration/airflow`](https://github.com/OpenLineage/OpenLineage/tree/main/integration/airflow). **The** `marquez-airflow` **library extends the class** [`openlineage.airflow.DAG`](https://github.com/OpenLineage/OpenLineage/blob/main/integration/airflow/openlineage/airflow/dag.py) **for backwards compatibility.**
+
+## Requirements
+
+[Python 3.5.0](https://www.python.org/downloads)+
 
 ## Installation
 
 ```bash
 $ pip3 install marquez-airflow
+```
+
+To install from source run:
+
+```bash
+$ python3 setup.py install
+```
+
+## Configuration
+
+Configure the following environment variables in your Airflow instance:
+
+```bash
+MARQUEZ_URL=<marquez-url>              # The URL of the HTTP backend
+MARQUEZ_NAMESPACE=<marquez-namespace>  # The namespace associated with the collected metadata
+```
+
+## Usage
+
+To begin collecting DAG lineage metadata with Marquez, make the following change to your DAG definitions:
+
+```diff
+- from airflow import DAG
++ from marquez_airflow import DAG
 ```

--- a/integrations/airflow/marquez_airflow/dag.py
+++ b/integrations/airflow/marquez_airflow/dag.py
@@ -9,4 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from openlineage.airflow import DAG

--- a/integrations/airflow/setup.py
+++ b/integrations/airflow/setup.py
@@ -19,7 +19,6 @@ from setuptools import find_packages, setup
 with open("README.md") as readme_file:
     readme = readme_file.read()
 
-
 requirements = [
     "openlineage-airflow==0.1.0",
 ]

--- a/integrations/spark/README.md
+++ b/integrations/spark/README.md
@@ -2,4 +2,4 @@
 
 [![Project status](https://img.shields.io/badge/status-deprecated-orange.svg)]()
 
-This repository has been moved to [`OpenLineage/integration/spark`](https://github.com/OpenLineage/OpenLineage/tree/main/integration/spark). **The** `marquez-spark` **library extends the class** [`OpenLineageSparkListener`](https://github.com/OpenLineage/OpenLineage/blob/main/integration/spark/src/main/java/openlineage/spark/agent/OpenLineageSparkListener.java) **for backwards compatibility.**
+This library has been moved to [`OpenLineage/integration/spark`](https://github.com/OpenLineage/OpenLineage/tree/main/integration/spark). **The** `marquez-spark` **library extends the class** [`OpenLineageSparkListener`](https://github.com/OpenLineage/OpenLineage/blob/main/integration/spark/src/main/java/openlineage/spark/agent/OpenLineageSparkListener.java) **for backwards compatibility.**

--- a/integrations/spark/README.md
+++ b/integrations/spark/README.md
@@ -1,6 +1,8 @@
-# Marquez Spark Agent
+# Marquez Spark Agent - `DEPRECATED`
 
-The Marquez Spark Agent uses jvm instrumentation to emit OpenLineage metadata to Marquez.
+[![Project status](https://img.shields.io/badge/status-deprecated-orange.svg)]()
+
+This repository has been moved to [`OpenLineage/integration/spark`](https://github.com/OpenLineage/OpenLineage/tree/main/integration/spark). **The** `marquez-spark` **library extends the class** [`OpenLineageSparkListener`](https://github.com/OpenLineage/OpenLineage/blob/main/integration/spark/src/main/java/openlineage/spark/agent/OpenLineageSparkListener.java) **for backwards compatibility.**
 
 ## Installation
 
@@ -20,228 +22,15 @@ or Gradle:
 implementation 'io.github.marquezproject:marquez-spark:0.16.1
 ```
 
-## Getting started
+## Usage
 
-### Quickstart
-The fastest way to get started testing Spark and Marquez is to use the docker-compose files included
-in the project. From the spark integration directory ($MARQUEZ_ROOT/integrations/spark) execute
-```bash
-docker-compose up
-```
-This will start the Marquez service on localhost:5000, the web UI on localhost:3000, and a Jupyter
-Spark notebook on localhost:8888. On startup, the notebook container logs will show a list of URLs 
-including an access token, such as
-```bash
-notebook_1  |     To access the notebook, open this file in a browser:
-notebook_1  |         file:///home/jovyan/.local/share/jupyter/runtime/nbserver-9-open.html
-notebook_1  |     Or copy and paste one of these URLs:
-notebook_1  |         http://abc12345d6e:8888/?token=XXXXXX
-notebook_1  |      or http://127.0.0.1:8888/?token=XXXXXX
-```
-Copy the URL with the localhost IP and paste into your browser window to begin creating a new Jupyter
-Spark notebook (see the [https://jupyter-docker-stacks.readthedocs.io/en/latest/](docs) for info on 
-using the Jupyter docker image). 
-
-#### Marquez 0.15.1 and higher
-Starting with Marquez 0.15.1, the SparkListener can be referenced as a plain Spark Listener implementation.
-This makes setup very simple and easy to understand.
-
-Create a new notebook and paste the following into the first cell:
 ```python
 from pyspark.sql import SparkSession
 
 spark = (SparkSession.builder.master('local')
          .appName('sample_spark')
-         .config('spark.jars.packages', 'io.github.marquezproject:marquez-spark:0.16.1
+         .config('spark.jars.packages', 'io.github.marquez:marquez-spark-0.16.1.jar'
          .config('spark.extraListeners', 'marquez.spark.agent.SparkListener')
-         .config('spark.openlineage.url', 'http://marquez:5000/api/v1/namespaces/spark_integration/')
+         .config('spark.openlineage.url', 'http://<marquez-host>/api/v1/namespaces/<marquez-namespace>')
          .getOrCreate())
-```
-To use the local jar, you can build it with 
-```bash
-gradle shadowJar
-```
-then reference it in the Jupyter notebook with the following (note that the jar should be built 
-*before* running the `docker-compose up` step or docker will just mount a dummy folder; once the 
-`build/libs` directory exists, you can repeatedly build the jar without restarting the jupyter 
-container):
-```python
-from pyspark.sql import SparkSession
-
-file = "/home/jovyan/marquezlib/libs/marquez-spark-0.15.1-SNAPSHOT.jar"
-
-spark = (SparkSession.builder.master('local').appName('rdd_to_dataframe')
-             .config('spark.jars', file)
-             .config('spark.jars.packages', 'org.postgresql:postgresql:42.2.+')
-             .config('spark.extraListeners', 'marquez.spark.agent.SparkListener')
-             .config('spark.openlineage.url', 'http://marquez:5000/api/v1/namespaces/spark_integration/')
-             .getOrCreate())
-```
-
-#### Prior to Marquez 0.15.1
-Prior to Marquez 0.15.1, the SparkListener only worked as a java agent that needs to be added to 
-the JVM startup parameters. Setup in a pyspark notebook looks like the following:
-
-```python
-from pyspark.sql import SparkSession
-
-file = "/home/jovyan/marquezlib/libs/marquez-spark-0.15.1-SNAPSHOT.jar"
-
-spark = (SparkSession.builder.master('local').appName('rdd_to_dataframe')
-         .config('spark.driver.extraJavaOptions',
-                 f"-javaagent:{file}=http://marquez:5000/api/v1/namespaces/spark_integration/")
-         .config('spark.jars.packages', 'org.postgresql:postgresql:42.2.+')
-         .config('spark.sql.repl.eagerEval.enabled', 'true')
-         .getOrCreate())
-```
-When running on a real cluster, the marquez-spark jar has to be in a known location on the master 
-node of the cluster and its location referenced in the `spark.driver.extraJavaOptions` parameter.
-
-### Dataproc Airflow Example
-#### Using the SparkListener (Marquez 0.15.1 and higher)
-A Dataproc operator needs the `marquez-spark` package specified in the `spark.jars.packages` 
-configuration parameter and the OpenLineage server URL in the Spark configuration.
-```python
-import os
-...
-job_name = 'job_name'
-
-jar = 'marquez-spark-0.15.0.jar'
-files = [f"https://repo1.maven.org/maven2/io/github/marquezproject/marquez-spark/0.15.0/marquez-spark-0.15.0.jar"]
-
-marquez_url = os.environ.get('MARQUEZ_URL')
-marquez_namespace = os.getenv('MARQUEZ_NAMESPACE', 'default')
-api_key = os.environ.get('MARQUEZ_API_KEY')
-
-t1 = DataProcPySparkOperator(
-    task_id=job_name,
-    gcp_conn_id='google_cloud_default',
-    project_id='project_id',
-    cluster_name='cluster-name',
-    region='us-west1',
-    main='gs://bucket/your-prog.py',
-    job_name=job_name,
-    dataproc_pyspark_properties={
-      "spark.extraListeners": "marquez.spark.agent.SparkListener",
-      "spark.jars.packages": "io.github.marquezproject:marquez-spark:0.16.1
-      "spark.openlineage.url": f"{marquez_url}/api/v1/namespaces/{marquez_namespace}/jobs/dump_orders_to_gcs/runs/{{{{task_run_id(run_id, task)}}}}?api_key={api_key}"
-    },
-    dag=dag)
-```
-
-Alternatively, the Dataproc cluster can be created with the listener configuration in the Spark
-properties.
-
-```python
-import os
-...
-job_name = 'job_name'
-
-marquez_url = os.environ.get('MARQUEZ_URL')
-marquez_namespace = os.getenv('MARQUEZ_NAMESPACE', 'default')
-api_key = os.environ.get('MARQUEZ_API_KEY')
-
-t1 = DataprocClusterCreateOperator(
-    task_id='create_dataproc_cluster',
-    cluster_name='spark-airflow-bq',
-    gcp_conn_id=GCP_CONN_ID,
-    project_id=GCP_PROJECT_ID,
-    region=GCP_REGION,
-    zone=GCP_ZONE,
-    num_masters=1,
-    num_workers=2,
-    master_machine_type='n1-standard-4',
-    worker_machine_type='n1-standard-4',
-    image_version='1.4-debian10',
-    init_actions_uris=['gs://dataproc-initialization-actions/cloud-sql-proxy/cloud-sql-proxy.sh'],
-    properties={
-      "spark.extraListeners": "marquez.spark.agent.SparkListener",
-      "spark.jars.packages": "io.github.marquezproject:marquez-spark:0.16.1
-      "spark.openlineage.url": "{marquez_url}/api/v1/namespaces/{marquez_namespace}/?api_key={api_key}"
-    },
-    dag=dag)
-```
-#### Using the Javaagent (Marquez 0.15.0 and earlier)
-Dataproc requires two things: a uri to the marquez java agent jar in the `files` parameter and
-an additional spark property. Dataproc will copy the agent jar to the current working directory of the
-executor and the `-javaagent` parameter will load it on execution.
-
-```python
-import os
-...
-job_name = 'job_name'
-
-jar = 'marquez-spark-0.15.1-SNAPSHOT.jar'
-files = [f"https://repo1.maven.org/maven2/io/github/marquezproject/marquez-spark/0.15.1-SNAPSHOT/marquez-spark-0.15.1-SNAPSHOT.jar"]
-
-marquez_url = os.environ.get('MARQUEZ_URL')
-marquez_namespace = os.getenv('MARQUEZ_NAMESPACE', 'default')
-api_key = os.environ.get('MARQUEZ_API_KEY')
-
-# Using the lineage_run_id macro in the airflow integration
-t1 = DataProcPySparkOperator(
-    task_id=job_name,
-    gcp_conn_id='google_cloud_default',
-    project_id='project_id',
-    cluster_name='cluster-name',
-    region='us-west1',
-    main='gs://bucket/your-prog.py',
-    job_name=job_name,
-    dataproc_pyspark_properties={
-      'spark.driver.extraJavaOptions':
-        f"-javaagent:{jar}={marquez_url}/api/v1/namespaces/{marquez_namespace}/jobs/dump_orders_to_gcs/runs/{{{{lineage_run_id(run_id, task)}}}}?api_key={api_key}"
-    files=files,
-    dag=dag)
-```
-
-## Arguments
-
-### Spark Listener
-The SparkListener reads its configuration from SparkConf parameters. These can be specified on the
-command line (e.g., `--conf "spark.openlineage.url=http://marquez:5000/api/v1/namespaces/my_namespace/job/the_job"`)
-or from the `conf/spark-defaults.conf` file. The following parameters can be specified
-| Parameter | Definition | Example |
-| spark.openlineage.host | The hostname of the OpenLineage API server where events should be reported | http://localhost:5000 |
-| spark.openlineage.version | The API version of the OpenLineage API server | 1|
-| spark.openlineage.namespace | The default namespace to be applied for any jobs submitted | MyNamespace|
-| spark.openlineage.parentJobName | The job name to be used for the parent job facet | ParentJobName | 
-| spark.openlineage.parentRunId | The RunId of the parent job that initiated this Spark job | xxxx-xxxx-xxxx-xxxx |
-| spark.openlineage.apiKey | An API key to be used when sending events to the OpenLineage server | abcdefghijk |
-
-### Java Agent
-The java agent accepts an argument in the form of a uri. It includes the location of Marquez, the
-namespace name, the parent job name, and a parent run id. The run id will be emitted as a parent run
-facet.
-```
-{marquez_home}/api/v1/namespaces/{namespace}/job/{job_name}/runs/{run_uuid}?api_key={api_key}"
-
-```
-For example:
-```
-https://marquez.example.com:5000/api/v1/namespaces/foo/job/spark.submit_job/runs/a95858ad-f9b5-46d7-8f1c-ca9f58f68978"
-```
-
-# Compatibility Notes
-Tested and compatible for Spark `2.4.7` only.
-
-# Build
-
-## Java 8
-
-Testing requires a Java 8 JVM to test the scala spark components.
-
-`export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
-
-## Testing
-
-To run the tests, from the root directory run:
-
-```sh
-./gradlew :integrations:spark:test
-```
-
-## Build spark agent jar
-
-```sh
-./gradlew :integrations:spark:shadowJar
 ```

--- a/integrations/spark/README.md
+++ b/integrations/spark/README.md
@@ -2,4 +2,4 @@
 
 [![Project status](https://img.shields.io/badge/status-deprecated-orange.svg)]()
 
-This library has been moved to [`OpenLineage/integration/spark`](https://github.com/OpenLineage/OpenLineage/tree/main/integration/spark). **The** `marquez-spark` **library extends the class** [`OpenLineageSparkListener`](https://github.com/OpenLineage/OpenLineage/blob/main/integration/spark/src/main/java/openlineage/spark/agent/OpenLineageSparkListener.java) **for backwards compatibility.**
+This library has been moved to [`OpenLineage/integration/spark`](https://github.com/OpenLineage/OpenLineage/tree/main/integration/spark). The `marquez-spark` library extends the class [`OpenLineageSparkListener`](https://github.com/OpenLineage/OpenLineage/blob/main/integration/spark/src/main/java/openlineage/spark/agent/OpenLineageSparkListener.java) for backwards compatibility. **Please use the** [`openlineage-spark`](https://search.maven.org/artifact/io.openlineage/openlineage-spark) **library instead instead**.

--- a/integrations/spark/README.md
+++ b/integrations/spark/README.md
@@ -3,34 +3,3 @@
 [![Project status](https://img.shields.io/badge/status-deprecated-orange.svg)]()
 
 This repository has been moved to [`OpenLineage/integration/spark`](https://github.com/OpenLineage/OpenLineage/tree/main/integration/spark). **The** `marquez-spark` **library extends the class** [`OpenLineageSparkListener`](https://github.com/OpenLineage/OpenLineage/blob/main/integration/spark/src/main/java/openlineage/spark/agent/OpenLineageSparkListener.java) **for backwards compatibility.**
-
-## Installation
-
-Maven:
-
-```xml
-<dependency>
-    <groupId>io.github.marquezproject</groupId>
-    <artifactId>marquez-spark</artifactId>
-    <version>0.16.1</version>
-</dependency>
-```
-
-or Gradle:
-
-```groovy
-implementation 'io.github.marquezproject:marquez-spark:0.16.1
-```
-
-## Usage
-
-```python
-from pyspark.sql import SparkSession
-
-spark = (SparkSession.builder.master('local')
-         .appName('sample_spark')
-         .config('spark.jars.packages', 'io.github.marquez:marquez-spark-0.16.1.jar'
-         .config('spark.extraListeners', 'marquez.spark.agent.SparkListener')
-         .config('spark.openlineage.url', 'http://<marquez-host>/api/v1/namespaces/<marquez-namespace>')
-         .getOrCreate())
-```


### PR DESCRIPTION
This PR deprecates the `airflow` and `spark` integrations. Closes https://github.com/OpenLineage/OpenLineage/issues/73