### PR TITLE
Drop IO tables

### DIFF
--- a/api/src/main/resources/marquez/db/migration/V35__drop_io_mapping_tables.sql
+++ b/api/src/main/resources/marquez/db/migration/V35__drop_io_mapping_tables.sql
@@ -1,0 +1,2 @@
+DROP TABLE job_versions_io_mapping_inputs;
+DROP TABLE job_versions_io_mapping_outputs;


### PR DESCRIPTION
Resolves #1280
Drop the tables job_versions_io_mapping_inputs and job_versions_io_mapping_outputs