### PR TITLE
Use `--next-version` arg in new-version.sh

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@
 2. Tag the release and prepare for the next version with:
 
    ```bash
-   $ ./new-version.sh --release-version X.Y.Z --next-release X.Y.Z
+   $ ./new-version.sh --release-version X.Y.Z --next-version X.Y.Z
    ```
 
    > **Tip:** Use `--help` to see script usage

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ subprojects {
         dropwizardVersion = '2.0.24'
         junit5Version = '5.7.2'
         lombokVersion = '1.18.20'
-        mockitoVersion = '3.12.1'
+        mockitoVersion = '3.12.4'
         slf4jVersion = '1.7.32'
         postgresqlVersion = '42.2.23'
         isReleaseVersion = !version.endsWith('SNAPSHOT')

--- a/new-version.sh
+++ b/new-version.sh
@@ -44,15 +44,22 @@ usage() {
   echo "  # Bump release candidate"
   echo "  $ ./new-version.sh -r 0.0.1-rc.1 -n 0.0.2-rc.2"
   echo
+  echo "  # Bump release candidate without push"
+  echo "  $ ./new-version.sh -r 0.0.1-rc.1 -n 0.0.2-rc.2 -p"
+  echo
   title "ARGUMENTS:"
-  echo "  -r, --release-version string       the release version (ex: X.Y.Z, X.Y.Z-rc.*)"
-  echo "  -n, --next-version string          the next version (ex: X.Y.Z, X.Y.Z-SNAPSHOT)"
+  echo "  -r, --release-version string    the release version (ex: X.Y.Z, X.Y.Z-rc.*)"
+  echo "  -n, --next-version string       the next version (ex: X.Y.Z, X.Y.Z-SNAPSHOT)"
+  echo
+  title "FLAGS:"
+  echo "  -p, --no-push    local changes are not automatically pushed to the remote repository"
   exit 1
 }
 
-readonly SEMVER_REGEX="^[0-9]+(\.[0-9]+){2}((-rc\.[0-9]+)?|(-SNAPSHOT)?)$" # X.Y.Z
-                                                                           # X.Y.Z-rc.*
-                                                                           # X.Y.Z-SNAPSHOT
+readonly SEMVER_REGEX="^[0-9]+(\.[0-9]+){2}((-rc\.[0-9]+)?(-SNAPSHOT)?)$" # X.Y.Z
+                                                                          # X.Y.Z-rc.*
+                                                                          # X.Y.Z-rc.*-SNAPSHOT
+                                                                          # X.Y.Z-SNAPSHOT
 
 # Change working directory to project root
 project_root=$(git rev-parse --show-toplevel)
@@ -76,15 +83,18 @@ fi
 
 while [ $# -gt 0 ]; do
   case $1 in
-    -r|'--release-version')
+    -r|--release-version)
        shift
        RELEASE_VERSION="${1}"
        ;;
-    -n|'--next-version')
+    -n|--next-version)
        shift
        NEXT_VERSION="${1}"
        ;;
-    -h|'--help')
+    -p|--no-push)
+       PUSH="false"
+       ;;
+    -h|--help)
        usage
        exit 0
        ;;
@@ -107,8 +117,9 @@ if [[ -n "$(git status --porcelain --untracked-files=no)" ]] ; then
   exit 1;
 fi
 
-# Append '-SNAPSHOT' to 'NEXT_VERSION' if not a release candidate, or missing
-if [[ ! "${NEXT_VERSION}" == *-rc.? &&
+# Append '-SNAPSHOT' to 'NEXT_VERSION' if a release candidate, or missing
+# (ex: '-SNAPSHOT' will be appended to X.Y.Z or X.Y.Z-rc.N)
+if [[ "${NEXT_VERSION}" == *-rc.? ||
       ! "${NEXT_VERSION}" == *-SNAPSHOT ]]; then
   NEXT_VERSION="${NEXT_VERSION}-SNAPSHOT"
 fi
@@ -167,6 +178,11 @@ sed -i "" "s/version=.*/version=${NEXT_VERSION}/g" gradle.properties
 git commit -sam "Prepare next development version"
 
 # (11) Push commits and tag
-git push origin main && git push origin "${RELEASE_VERSION}"
+if [[ ${PUSH} = "true" ]]; then
+  git push origin main && \
+    git push origin "${RELEASE_VERSION}"
+else
+  echo "...skipping push to 'main'; to push manually, use 'git push origin main && git push origin "${RELEASE_VERSION}"'"
+fi
 
 echo "DONE!"

--- a/new-version.sh
+++ b/new-version.sh
@@ -45,14 +45,14 @@ usage() {
   echo "  $ ./new-version.sh -r 0.0.1-rc.1 -n 0.0.2-rc.2"
   echo
   echo "  # Bump release candidate without push"
-  echo "  $ ./new-version.sh -r 0.0.1-rc.1 -n 0.0.2-rc.2 -p"
+  echo "  $ ./new-version.sh -r 0.0.1-rc.1 -n 0.0.2-rc.2 --no-push"
   echo
   title "ARGUMENTS:"
   echo "  -r, --release-version string    the release version (ex: X.Y.Z, X.Y.Z-rc.*)"
   echo "  -n, --next-version string       the next version (ex: X.Y.Z, X.Y.Z-SNAPSHOT)"
   echo
   title "FLAGS:"
-  echo "  -p, --no-push    local changes are not automatically pushed to the remote repository"
+  echo "  --no-push    local changes are not automatically pushed to the remote repository"
   exit 1
 }
 
@@ -81,6 +81,7 @@ if [[ $# -eq 0 ]] ; then
   usage
 fi
 
+PUSH="true"
 while [ $# -gt 0 ]; do
   case $1 in
     -r|--release-version)
@@ -91,7 +92,7 @@ while [ $# -gt 0 ]; do
        shift
        NEXT_VERSION="${1}"
        ;;
-    -p|--no-push)
+    --no-push)
        PUSH="false"
        ;;
     -h|--help)


### PR DESCRIPTION
This PR updates `new-version.sh` with the following changes:

* Append `-SNAPSHOT` to release candidates set via the `--next-version` argument
* Fix typo for `--next-release`, should be `--next-version`
* Add `--no-push` flag to skip pushing changes to `main` branch on releases