### PR TITLE
Revert `openlineage-java` 0.2.2 bump

### DIFF
--- a/integrations/spark/build.gradle
+++ b/integrations/spark/build.gradle
@@ -33,7 +33,7 @@ ext {
 }
 
 dependencies {
-    implementation 'io.openlineage:openlineage-spark:0.2.2'
+    implementation 'io.openlineage:openlineage-spark:0.2.1'
     compileOnly "org.apache.spark:spark-core_2.11:${sparkVersion}"
 
     testImplementation 'com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:0.21.1'


### PR DESCRIPTION
This PR reverts the `openlineage-java` 0.2.2 bump that will be fixed by https://github.com/MarquezProject/marquez/issues/1630