### PR TITLE
Fixes web project index files

### DIFF
--- a/web/src/index.html
+++ b/web/src/index.html
@@ -15,9 +15,5 @@
 
     <!-- Main -->
     <script src="./bundle.js"></script>
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css"
-    />
   </body>
 </html>

--- a/web/src/index.prod.html
+++ b/web/src/index.prod.html
@@ -1,43 +1,19 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="UTF-8" />
-    <title>Marquez</title>
-    <link
-      href="https://fonts.googleapis.com/css?family=Inconsolata:400,700|Karla:400,700&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css"
-    />
-    <!DOCTYPE html>
-    <html>
-      <head>
-        <meta charset="UTF-8" />
+    <head>
+        <meta charset="UTF-8"/>
         <title>Marquez</title>
+        <base href="/"/>
         <link
-          rel="stylesheet"
-          href="https://fonts.googleapis.com/css?family=Karla:400,700&display=swap"
+                href="https://fonts.googleapis.com/css?family=Inconsolata:400,700|Karla:400,700&display=swap"
+                rel="stylesheet"
         />
-        <link
-          rel="stylesheet"
-          href="https://use.fontawesome.com/releases/v5.8.1/css/all.css"
-          integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf"
-          crossorigin="anonymous"
-        />
-        <link
-          rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css"
-        />
-      </head>
+    </head>
 
-      <body>
+    <body>
         <div id="root"></div>
 
         <!-- Main -->
         <script src="./bundle.js"></script>
-      </body>
-    </html>
-  </head>
+    </body>
 </html>


### PR DESCRIPTION
Fixes #1050 

This removes the `animate.css` import that isn't used in the project and is also imported incorrectly since it bypasses the webpack build process. There was also invalid HTML in these files with fonts we do not need. These issues have also been remediated and removed respectively.

Signed-off-by: Peter Hicks <peter@datakin.com>