### PR TITLE
Z-Index fix for nodes and edges

### DIFF
--- a/web/src/components/lineage/Lineage.tsx
+++ b/web/src/components/lineage/Lineage.tsx
@@ -187,6 +187,10 @@ class Lineage extends React.Component<LineageProps, LineageState> {
                           cursor: zoom.isDragging ? 'grabbing' : 'grab'
                         }}
                       >
+                        {/* background */}
+                        <g transform={zoom.toString()}>
+                          <Edge edgePoints={this.state.edges} />
+                        </g>
                         <rect
                           width={parent.width}
                           height={parent.height}
@@ -214,8 +218,8 @@ class Lineage extends React.Component<LineageProps, LineageState> {
                             })
                           }}
                         />
+                        {/* foreground */}
                         <g transform={zoom.toString()}>
-                          <Edge edgePoints={this.state.edges} />
                           {this.state.nodes.map(node => (
                             <Node
                               key={node.data.name}

--- a/web/src/components/lineage/Lineage.tsx
+++ b/web/src/components/lineage/Lineage.tsx
@@ -215,6 +215,7 @@ class Lineage extends React.Component<LineageProps, LineageState> {
                           }}
                         />
                         <g transform={zoom.toString()}>
+                          <Edge edgePoints={this.state.edges} />
                           {this.state.nodes.map(node => (
                             <Node
                               key={node.data.name}
@@ -225,7 +226,6 @@ class Lineage extends React.Component<LineageProps, LineageState> {
                               selectedNode={this.props.selectedNode}
                             />
                           ))}
-                          <Edge edgePoints={this.state.edges} />
                         </g>
                       </svg>
                     </Box>


### PR DESCRIPTION
Fixes: #1643 

This makes the `<Node/>` the highest precedence for click actions on our lineage page and avoids collisions with edges that have more complex polyline overlays.

Signed-off-by: Peter Hicks <peter@datakin.com>