### PR TITLE
Change `type` column in `dataset_fields` table to `TEXT`

### DIFF
--- a/api/src/main/resources/marquez/db/migration/V37__alter_dataset_fields_to_change_type.sql
+++ b/api/src/main/resources/marquez/db/migration/V37__alter_dataset_fields_to_change_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE dataset_fields ALTER COLUMN type TYPE TEXT;


### PR DESCRIPTION
This PR changes the `type` column in `dataset_fields` table to `TEXT`. Note, this is a short term solution to support `STRUCTS` (see #1651), but also fixes exceptions thrown when the dataset field type is `> 64` characters (see #1649)  