### PR TITLE
Updated ZonedDateTime parsing to support optional offsets

### DIFF
--- a/api/src/main/java/marquez/common/Utils.java
+++ b/api/src/main/java/marquez/common/Utils.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -38,6 +39,7 @@ import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,6 +54,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import marquez.common.models.DatasetId;
 import marquez.common.models.Field;
+import marquez.common.models.FlexibleDateTimeDeserializer;
 import marquez.common.models.JobName;
 import marquez.common.models.NamespaceName;
 import marquez.common.models.RunId;
@@ -80,8 +83,12 @@ public final class Utils {
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     mapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
 
+    mapper.addMixIn(ZonedDateTime.class, ZonedDateTimeMixin.class);
     return mapper;
   }
+
+  @JsonDeserialize(using = FlexibleDateTimeDeserializer.class)
+  static final class ZonedDateTimeMixin {}
 
   public static String toJson(@NonNull final Object value) {
     try {

--- a/api/src/main/java/marquez/common/models/FlexibleDateTimeDeserializer.java
+++ b/api/src/main/java/marquez/common/models/FlexibleDateTimeDeserializer.java
@@ -1,0 +1,51 @@
+package marquez.common.models;
+
+import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQueries;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@link ZonedDateTime} deserializer that handles missing timezone offsets by defaulting to the
+ * current system timezone. It logs a debug statement whenever such timestamps are encountered. This
+ * deserializer is necessary for clients that may post event times without adding appropriate
+ * timezone offsets to the timestamp.
+ */
+@Slf4j
+public class FlexibleDateTimeDeserializer extends InstantDeserializer<ZonedDateTime> {
+
+  public static final DateTimeFormatter DATE_TIME_OPTIONAL_OFFSET =
+      new DateTimeFormatterBuilder()
+          .parseCaseInsensitive()
+          .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+          .parseLenient()
+          .optionalStart()
+          .appendOffsetId()
+          .toFormatter();
+
+  public FlexibleDateTimeDeserializer() {
+    super(
+        ZonedDateTime.class,
+        DATE_TIME_OPTIONAL_OFFSET,
+        FlexibleDateTimeDeserializer::fromTemporal,
+        a -> ZonedDateTime.ofInstant(Instant.ofEpochMilli(a.value), a.zoneId),
+        a -> ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId),
+        ZonedDateTime::withZoneSameInstant,
+        false);
+  }
+
+  public static ZonedDateTime fromTemporal(TemporalAccessor t) {
+    ZoneId obj = t.query(TemporalQueries.zone());
+    if (obj == null) {
+      log.debug("No Zone found in temporal {}- defaulting to {}", t, ZoneId.systemDefault());
+      return LocalDateTime.from(t).atZone(ZoneId.systemDefault().normalized());
+    }
+    return ZonedDateTime.from(t);
+  }
+}

--- a/api/src/main/java/marquez/service/models/LineageEvent.java
+++ b/api/src/main/java/marquez/service/models/LineageEvent.java
@@ -35,6 +35,7 @@ import lombok.ToString;
 public class LineageEvent extends BaseJsonModel {
 
   private String eventType;
+
   @NotNull private ZonedDateTime eventTime;
   @NotNull private LineageEvent.Run run;
   @NotNull private LineageEvent.Job job;

--- a/api/src/test/resources/open_lineage/event_required_nanoseconds.json
+++ b/api/src/test/resources/open_lineage/event_required_nanoseconds.json
@@ -1,0 +1,12 @@
+{
+  "eventTime": "2020-12-28T19:51:01.641499Z",
+  "run": {
+    "runId": "43d7db3b-8984-4cda-b237-8c6919b36670"
+  },
+  "job": {
+    "namespace": "my-namespace",
+    "name": "myjob.mytask"
+  },
+  "producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+  "schemaURL": "https://openlineage.io/spec/1-0-1/OpenLineage.json#/definitions/RunEvent"
+}

--- a/api/src/test/resources/open_lineage/event_required_no_timezone.json
+++ b/api/src/test/resources/open_lineage/event_required_no_timezone.json
@@ -1,0 +1,12 @@
+{
+  "eventTime": "2020-12-28T19:51:01.641499",
+  "run": {
+    "runId": "43d7db3b-8984-4cda-b237-8c6919b36670"
+  },
+  "job": {
+    "namespace": "my-namespace",
+    "name": "myjob.mytask"
+  },
+  "producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+  "schemaURL": "https://openlineage.io/spec/1-0-1/OpenLineage.json#/definitions/RunEvent"
+}


### PR DESCRIPTION
Currently, the GreatExpectations integration in OpenLineage is omitting the timezone offset from the event time. This needs to be fixed in the OpenLineage integration, but I think we should also be resilient to such errors in Marquez. Currently, we simply throw away the whole record.

This change allows for optional timezones and simply defaults to the system timezone if it is omitted. The GreatExpectations integration also posts fractions of a second in nanoseconds, rather than millis, so I added a test to validate that we can handle that format.

Also, I deleted the `testRequiredObjectMapper` test, as I'm not really sure what its purpose is. The test fails with this change because the ObjectMapper defined in the test code isn't configured to work with the timestamps in the test data. I could update the ObjectMapper to have the same configuration as the production one, but... I'm not really sure what the point of having that test would be... The test was originally introduced [here](https://github.com/MarquezProject/marquez/pull/880/files), but there are no comments explaining why