### PR TITLE
Add FlexibleDateTimeDeserializer mixin to the Dropwized Jackson ObjectMapper

### DIFF
--- a/api/src/main/java/marquez/MarquezApp.java
+++ b/api/src/main/java/marquez/MarquezApp.java
@@ -36,6 +36,7 @@ import javax.sql.DataSource;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import marquez.cli.SeedCommand;
+import marquez.common.Utils;
 import marquez.db.DbMigration;
 import marquez.tracing.SentryConfig;
 import marquez.tracing.TracingContainerResponseFilter;
@@ -84,6 +85,7 @@ public final class MarquezApp extends Application<MarquezConfig> {
     bootstrap.addCommand(new SeedCommand());
 
     bootstrap.getObjectMapper().disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    Utils.addZonedDateTimeMixin(bootstrap.getObjectMapper());
 
     // Add graphql playground
     bootstrap.addBundle(

--- a/api/src/main/java/marquez/common/Utils.java
+++ b/api/src/main/java/marquez/common/Utils.java
@@ -83,8 +83,19 @@ public final class Utils {
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     mapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
 
-    mapper.addMixIn(ZonedDateTime.class, ZonedDateTimeMixin.class);
+    addZonedDateTimeMixin(mapper);
     return mapper;
+  }
+
+  /**
+   * Add a mixin to the object mapper to support a {@link FlexibleDateTimeDeserializer}. This allows
+   * us to support ISO timestamps that are missing timezones and defaults to the server timezone in
+   * such cases.
+   *
+   * @param mapper
+   */
+  public static void addZonedDateTimeMixin(ObjectMapper mapper) {
+    mapper.addMixIn(ZonedDateTime.class, ZonedDateTimeMixin.class);
   }
 
   @JsonDeserialize(using = FlexibleDateTimeDeserializer.class)


### PR DESCRIPTION
This change is needed to use the FlexibleDateTimeDeserializer in the Dropwizard Jackson ObjectMapper which is used to deserialize POST bodies