### PR TITLE
Add option for docker/up to run in the background

### DIFF
--- a/docker/up.sh
+++ b/docker/up.sh
@@ -19,7 +19,7 @@ title() {
 }
 
 usage() {
-  echo "usage: ./$(basename -- ${0}) [--api-port PORT] [--web-port PORT] [--tag TAG] [--build] [--seed]"
+  echo "usage: ./$(basename -- ${0}) [--api-port PORT] [--web-port PORT] [--tag TAG] [--build] [--seed] [--daemon]"
   echo "A script used to run Marquez via Docker"
   echo
   title "EXAMPLES:"
@@ -47,6 +47,7 @@ usage() {
   title "FLAGS:"
   echo "  -b, --build           build images from source"
   echo "  -s, --seed            seed HTTP API server with metadata"
+  echo "  -d, --daemon          run in the background"
   echo "  -h, --help            show help for script"
   exit 1
 }
@@ -87,6 +88,9 @@ while [ $# -gt 0 ]; do
     -s|'--seed')
        SEED='true'
        ;;
+    -d|'--daemon')
+       DAEMON='true'
+       ;;
     -h|'--help')
        usage
        exit 0
@@ -97,6 +101,10 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
+
+if [[ "${DAEMON}" = "true" ]]; then
+  args+=" -d"
+fi
 
 if [[ "${BUILD}" = "true" ]]; then
   compose_files+=" -f docker-compose.dev.yml"


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross@rossturk.com>

I found myself hacking `docker/up.sh` regularly to add `-d` to the list of arguments so that I could keep Marquez running persistently. I tend to build models over several working sessions. Maybe this could be useful for others.