### PR TITLE
bug: don't overwrite nominal time if it's null in complete event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Z-Index fix for nodes and edges in lineage graph [@phixMe](https://github.com/phixMe)
 * Format of the index files for web UI [@phixMe](https://github.com/phixMe)
 * Fix OpenLineage API to return correct response codes for exceptions propagated from async calls [@collado-mike](https://github.com/collado-mike)
+* Stopped overwriting nominal time information with nulls [@mobuchowski](https://github.com/mobuchowski)
 
 ### Removed
 

--- a/api/src/main/java/marquez/db/RunDao.java
+++ b/api/src/main/java/marquez/db/RunDao.java
@@ -187,8 +187,8 @@ public interface RunDao extends BaseDao {
           + "updated_at = EXCLUDED.updated_at, "
           + "current_run_state = EXCLUDED.current_run_state, "
           + "transitioned_at = EXCLUDED.transitioned_at, "
-          + "nominal_start_time = EXCLUDED.nominal_start_time, "
-          + "nominal_end_time = EXCLUDED.nominal_end_time, "
+          + "nominal_start_time = COALESCE(EXCLUDED.nominal_start_time, runs.nominal_start_time), "
+          + "nominal_end_time = COALESCE(EXCLUDED.nominal_end_time, runs.nominal_end_time), "
           + "location = EXCLUDED.location "
           + "RETURNING *")
   ExtendedRunRow upsert(
@@ -236,8 +236,8 @@ public interface RunDao extends BaseDao {
           + ") ON CONFLICT(uuid) DO "
           + "UPDATE SET "
           + "updated_at = EXCLUDED.updated_at, "
-          + "nominal_start_time = EXCLUDED.nominal_start_time, "
-          + "nominal_end_time = EXCLUDED.nominal_end_time, "
+          + "nominal_start_time = COALESCE(EXCLUDED.nominal_start_time, runs.nominal_start_time), "
+          + "nominal_end_time = COALESCE(EXCLUDED.nominal_end_time, runs.nominal_end_time), "
           + "location = EXCLUDED.location "
           + "RETURNING *")
   ExtendedRunRow upsert(

--- a/api/src/test/java/marquez/db/RunDaoTest.java
+++ b/api/src/test/java/marquez/db/RunDaoTest.java
@@ -141,4 +141,36 @@ class RunDaoTest {
         .map(RunId::getValue)
         .containsAll(expectedRuns.stream().map(RunRow::getUuid).collect(Collectors.toSet()));
   }
+
+  @Test
+  public void updateRowWithNullNominalTimeDoesNotUpdateNominalTime() {
+    final RunDao runDao = jdbi.onDemand(RunDao.class);
+
+    final JobMeta jobMeta = newJobMetaWith(NamespaceName.of(namespaceRow.getName()));
+    final JobRow jobRow =
+        DbTestUtils.newJobWith(jdbi, namespaceRow.getName(), newJobName().getValue(), jobMeta);
+
+    RunRow row = DbTestUtils.newRun(jdbi, namespaceRow.getName(), jobRow.getName());
+
+    RunRow updatedRow =
+        runDao.upsert(
+            row.getUuid(),
+            row.getUuid().toString(),
+            row.getUpdatedAt(),
+            null,
+            row.getRunArgsUuid(),
+            null,
+            null,
+            namespaceRow.getUuid(),
+            namespaceRow.getName(),
+            row.getJobName(),
+            null,
+            null);
+
+    assertThat(row.getUuid()).isEqualTo(updatedRow.getUuid());
+    assertThat(row.getNominalStartTime()).isNotNull();
+    assertThat(row.getNominalEndTime()).isNotNull();
+    assertThat(updatedRow.getNominalStartTime()).isEqualTo(row.getNominalStartTime());
+    assertThat(updatedRow.getNominalEndTime()).isEqualTo(row.getNominalEndTime());
+  }
 }


### PR DESCRIPTION
Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>

### Problem

OpenLineage Airflow integration sends `NominalTimeFacet` in `START` event, but does not send it in `COMPLETE` event.
Currently, Marquez always overwrites nominal time information when finishing event for a run is send. 

Closes: #1567

### Solution

This PR changes this behavior to stop doing it when we get nulls by getting values from source row instead of target row.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
