### PR TITLE
Fix NodeId parsing bug when dataset name contains struct<>

### DIFF
--- a/api/src/main/java/marquez/service/models/NodeId.java
+++ b/api/src/main/java/marquez/service/models/NodeId.java
@@ -179,7 +179,7 @@ public final class NodeId implements Comparable<NodeId> {
       return parts;
     } else {
       // try to avoid matching colons in URIs- e.g., scheme://authority and host:port patterns
-      Pattern p = Pattern.compile("(?:" + ID_DELIM + "(?!//|\\d+))|" + VERSION_DELIM);
+      Pattern p = Pattern.compile("(?:" + ID_DELIM + "(?!//|\\d+))");
       Matcher matcher = p.matcher(value);
       String[] returnParts = new String[expectedParts];
 
@@ -217,16 +217,22 @@ public final class NodeId implements Comparable<NodeId> {
 
   @JsonIgnore
   public JobVersionId asJobVersionId() {
-    String[] parts = parts(4, ID_PREFX_JOB);
+    String[] parts = parts(3, ID_PREFX_JOB);
+    String[] nameAndVersion = parts[2].split(VERSION_DELIM);
     return new JobVersionId(
-        NamespaceName.of(parts[1]), JobName.of(parts[2]), UUID.fromString(parts[3]));
+        NamespaceName.of(parts[1]),
+        JobName.of(nameAndVersion[0]),
+        UUID.fromString(nameAndVersion[1]));
   }
 
   @JsonIgnore
   public DatasetVersionId asDatasetVersionId() {
-    String[] parts = parts(4, ID_PREFX_DATASET);
+    String[] parts = parts(3, ID_PREFX_DATASET);
+    String[] nameAndVersion = parts[2].split(VERSION_DELIM);
     return new DatasetVersionId(
-        NamespaceName.of(parts[1]), DatasetName.of(parts[2]), UUID.fromString(parts[3]));
+        NamespaceName.of(parts[1]),
+        DatasetName.of(nameAndVersion[0]),
+        UUID.fromString(nameAndVersion[1]));
   }
 
   @Override

--- a/api/src/test/java/marquez/service/models/NodeIdTest.java
+++ b/api/src/test/java/marquez/service/models/NodeIdTest.java
@@ -1,24 +1,75 @@
 package marquez.service.models;
 
+import static marquez.service.models.NodeId.VERSION_DELIM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import marquez.common.models.DatasetId;
 import marquez.common.models.DatasetName;
+import marquez.common.models.JobId;
+import marquez.common.models.JobName;
 import marquez.common.models.NamespaceName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 class NodeIdTest {
 
-  @ParameterizedTest(name = "testDatasetWithUrl-{index} {argumentsWithNames}")
-  @CsvSource({"gs://bucket,/path/to/data", "postgresql://hostname:5432/database,my_table"})
-  public void testDatasetWithUrl() {
-    String namespace = "gs://bucket";
-    String datasetName = "/path/to/data";
-    DatasetName dsName = DatasetName.of(datasetName);
-    DatasetId dsId = new DatasetId(NamespaceName.of(namespace), dsName);
+  @ParameterizedTest(name = "testJob-{index} {argumentsWithNames}")
+  @CsvSource(
+      value = {"my-namespace$my-job", "org://team$my-job"},
+      delimiter = '$')
+  public void testJob(String namespace, String job) {
+    NamespaceName nsName = NamespaceName.of(namespace);
+    JobName jobName = JobName.of(job);
+    JobId jobId = new JobId(nsName, jobName);
+    NodeId nodeId = NodeId.of(jobId);
+    assertFalse(nodeId.isRunType());
+    assertTrue(nodeId.isJobType());
+    assertFalse(nodeId.isDatasetType());
+    assertFalse(nodeId.hasVersion());
+    assertEquals(jobId, nodeId.asJobId());
+    assertEquals(nodeId, NodeId.of(nodeId.getValue()));
+    assertEquals(namespace, nodeId.asJobId().getNamespace().getValue());
+    assertEquals(job, nodeId.asJobId().getName().getValue());
+  }
+
+  @ParameterizedTest(name = "testJobWithVersion-{index} {argumentsWithNames}")
+  @CsvSource(
+      value = {
+        "my-namespace$my-job#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "org://team$my-job#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+      },
+      delimiter = '$')
+  public void testJobWithVersion(String namespace, String job) {
+    NamespaceName nsName = NamespaceName.of(namespace);
+    JobName jobName = JobName.of(job);
+    JobId jobId = new JobId(nsName, jobName);
+    NodeId nodeId = NodeId.of(jobId);
+    assertFalse(nodeId.isRunType());
+    assertTrue(nodeId.isJobType());
+    assertFalse(nodeId.isDatasetType());
+    assertTrue(nodeId.hasVersion());
+    assertEquals(jobId, nodeId.asJobId());
+    assertEquals(nodeId, NodeId.of(nodeId.getValue()));
+    assertEquals(namespace, nodeId.asJobId().getNamespace().getValue());
+    assertEquals(job, nodeId.asJobId().getName().getValue());
+    assertEquals(job.split(VERSION_DELIM)[1], nodeId.asJobVersionId().getVersion().toString());
+  }
+
+  @ParameterizedTest(name = "testDataset-{index} {argumentsWithNames}")
+  @CsvSource(
+      value = {
+        "my-namespace$my-dataset",
+        "gs://bucket$/path/to/data",
+        "postgresql://hostname:5432/database$my_table",
+        "my-namespace$my_struct<a:bigint,b:bigint,c:string>"
+      },
+      delimiter = '$')
+  public void testDataset(String namespace, String dataset) {
+    NamespaceName namespaceName = NamespaceName.of(namespace);
+    DatasetName datasetName = DatasetName.of(dataset);
+    DatasetId dsId = new DatasetId(namespaceName, datasetName);
     NodeId nodeId = NodeId.of(dsId);
     assertFalse(nodeId.isRunType());
     assertFalse(nodeId.isJobType());
@@ -26,8 +77,33 @@ class NodeIdTest {
     assertFalse(nodeId.hasVersion());
     assertEquals(dsId, nodeId.asDatasetId());
     assertEquals(nodeId, NodeId.of(nodeId.getValue()));
-    DatasetId ds = nodeId.asDatasetId();
-    assertEquals(namespace, ds.getNamespace().getValue());
-    assertEquals(datasetName, ds.getName().getValue());
+    assertEquals(namespace, nodeId.asDatasetId().getNamespace().getValue());
+    assertEquals(dataset, nodeId.asDatasetId().getName().getValue());
+  }
+
+  @ParameterizedTest(name = "testDatasetWithVersion-{index} {argumentsWithNames}")
+  @CsvSource(
+      value = {
+        "my-namespace$my-dataset#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "gs://bucket$/path/to/data#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "postgresql://hostname:5432/database$my_table#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "my-namespace$my_struct<a:bigint,b:bigint,c:string>#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+      },
+      delimiter = '$')
+  public void testDatasetWithVersion(String namespace, String dataset) {
+    NamespaceName namespaceName = NamespaceName.of(namespace);
+    DatasetName datasetName = DatasetName.of(dataset);
+    DatasetId dsId = new DatasetId(namespaceName, datasetName);
+    NodeId nodeId = NodeId.of(dsId);
+    assertFalse(nodeId.isRunType());
+    assertFalse(nodeId.isJobType());
+    assertTrue(nodeId.isDatasetType());
+    assertTrue(nodeId.isDatasetVersionType());
+    assertTrue(nodeId.hasVersion());
+    assertEquals(dsId, nodeId.asDatasetId());
+    assertEquals(namespace, nodeId.asDatasetId().getNamespace().getValue());
+    assertEquals(dataset, nodeId.asDatasetId().getName().getValue());
+    assertEquals(
+        dataset.split(VERSION_DELIM)[1], nodeId.asDatasetVersionId().getVersion().toString());
   }
 }


### PR DESCRIPTION
Signed-off-by: Minkyu Park <minkyu@datakin.com>

### Problem
For the dataset which contains `struct<>` inside its name, `NodeId.asDatasetVersionId` fails due to the parsing error. `struct<>` contains its sub fields and their types which contains colon(`:`), for example `struct<a:bigint,b:string>`, and the current regex only takes URL scheme(`://`) and port number(`:<port>`) into account.

Closes: #1729 

### Solution
This PR changes the logic of `asDatasetVersionId` and `asJobVersionId` so that they get their name along with the version, and then parse the version separately.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
