### PR TITLE
Add encoding for dataset names in URL construction

### DIFF
--- a/web/src/store/requests/datasets.ts
+++ b/web/src/store/requests/datasets.ts
@@ -19,7 +19,7 @@ export const getDatasetVersions = async (
 ) => {
   const url = `${API_URL}/namespaces/${encodeURIComponent(
     namespace
-  )}/datasets/${dataset}/versions?limit=${limit}&offset=${offset}`
+  )}/datasets/${encodeURIComponent(dataset)}/versions?limit=${limit}&offset=${offset}`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchDatasetVersions').then(
     (versions: DatasetVersions) => versions.versions
   )


### PR DESCRIPTION
Signed-off-by: Michael Collado <mike@datakin.com>

### Problem
Datasets that have colons or slashes in their names aren't encoded when the URL is constructed

Closes: #1744

### Solution

Added urlencoding to dataset names in URL construction
### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
