### PR TITLE
Change quickstart to use https instead of ssh for checkout

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,7 +27,7 @@ Before you begin, make sure you have installed:
 To checkout the Marquez source code, run:
 
 ```
-$ git clone git@github.com:MarquezProject/marquez.git && cd marquez
+$ git clone https://github.com/MarquezProject/marquez && cd marquez
 ```
 
 ## Marquez Data Model


### PR DESCRIPTION
### Problem

Quickstart guide assumes that users already have an SSH key generated for checking out from github. Some users may not have a github account or may not have set up SSH authentication.

### Solution

Updates the docs to use https for checkout so all users can follow the instructions without any extra setup.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
