### PR TITLE
Clarify client READMEs to use OpenLineage for metadata collection.

### DIFF
--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -22,19 +22,17 @@ implementation 'io.github.marquezproject:marquez-java:0.19.1
 
 ## Usage
 
+### Metadata Collection
+Marquez implements OpenLineage specification. Use [OpenLineage client](https://github.com/OpenLineage/OpenLineage/tree/main/client/java) to collect metadata.
+
+### Metadata Navigation
 ```java
 MarquezClient client = MarquezClient().builder()
     .baseUrl("http://localhost:5000")
     .build()
 
-// Metadata
-NamespaceMeta meta = NamespaceMeta().builder()
-    .ownerName("me")
-    .description("My first namespace!")
-    .build()
-
-// Create namespace
-Namespace namespace = client.createNamespace("my-namespace", meta);
+// List namespaces
+List<Namespace> namespaces = client.listNamespaces();
 ```
 
 ## HTTPS

--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -22,10 +22,7 @@ implementation 'io.github.marquezproject:marquez-java:0.19.1
 
 ## Usage
 
-### Metadata Collection
-Marquez implements OpenLineage specification. Use [OpenLineage client](https://github.com/OpenLineage/OpenLineage/tree/main/client/java) to collect metadata.
-
-### Metadata Navigation
+### Reading Metadata
 ```java
 MarquezClient client = MarquezClient().builder()
     .baseUrl("http://localhost:5000")
@@ -34,6 +31,8 @@ MarquezClient client = MarquezClient().builder()
 // List namespaces
 List<Namespace> namespaces = client.listNamespaces();
 ```
+### Writing Metadata
+To collect OpenLineage events using Marquez, please use the [openlineage-java](https://search.maven.org/artifact/io.openlineage/openlineage-java) library. OpenLineage is an Open Standard for lineage metadata collection designed to collect metadata for a job in execution.
 
 ## HTTPS
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -24,10 +24,7 @@ $ python3 setup.py install
 
 ## Usage
 
-### Metadata Collection
-Marquez implements OpenLineage specification. Use [OpenLineage client](https://github.com/OpenLineage/OpenLineage/tree/main/client/python) to collect metadata.
-
-### Metadata Navigation
+### Reading Metadata
 ```python
 from marquez_client import MarquezClient
 
@@ -42,6 +39,9 @@ To enable logging, set the environment variable `MARQUEZ_LOG_LEVEL` to `DEBUG`, 
 ```
 $ export MARQUEZ_LOG_LEVEL='INFO'
 ```
+
+### Writing Metadata
+To collect OpenLineage events using Marquez, please use the [openlineage-python](https://pypi.org/project/openlineage-python/) library. OpenLineage is an Open Standard for lineage metadata collection designed to collect metadata for a job in execution.
 
 ## Development
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -24,13 +24,17 @@ $ python3 setup.py install
 
 ## Usage
 
+### Metadata Collection
+Marquez implements OpenLineage specification. Use [OpenLineage client](https://github.com/OpenLineage/OpenLineage/tree/main/client/python) to collect metadata.
+
+### Metadata Navigation
 ```python
 from marquez_client import MarquezClient
 
 client = MarquezClient(url='http://localhost:5000')
 
-# create namespace
-client.create_namespace('my-namespace', 'me', 'My first namespace!')
+# list namespaces
+client.list_namespaces()
 ```
 
 To enable logging, set the environment variable `MARQUEZ_LOG_LEVEL` to `DEBUG`, `INFO`, or `ERROR`:


### PR DESCRIPTION
Signed-off-by: Minkyu Park <minkyu@datakin.com>

### Problem
Marquez provides metadata collection APIs but we want users to use OpenLineage. We want to make it clear that we use OpenLineage for metadata collection, and marquez APIs are for the metadata navigation.

Closes: #1686 

### Solution
Updated client READMEs' usage section with metadata collection and metadata navigation. Metadata collection subsection clarifies to use OpenLineage.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
