### PR TITLE
Openlineage validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased](https://github.com/MarquezProject/marquez/compare/0.19.1...HEAD)
+### Fixed
+* Fixed validation of OpenLineage events on write [@collado-mike](https://github.com/collado-mike)
 
 ## [0.19.1](https://github.com/MarquezProject/marquez/compare/0.19.0...0.19.1)
 

--- a/api/src/main/java/marquez/service/models/LineageEvent.java
+++ b/api/src/main/java/marquez/service/models/LineageEvent.java
@@ -37,11 +37,11 @@ public class LineageEvent extends BaseJsonModel {
   private String eventType;
 
   @NotNull private ZonedDateTime eventTime;
-  @NotNull private LineageEvent.Run run;
-  @NotNull private LineageEvent.Job job;
-  private List<Dataset> inputs;
-  private List<Dataset> outputs;
-  @NotNull private String producer;
+  @Valid @NotNull private LineageEvent.Run run;
+  @Valid @NotNull private LineageEvent.Job job;
+  @Valid private List<Dataset> inputs;
+  @Valid private List<Dataset> outputs;
+  @Valid @NotNull private String producer;
 
   @AllArgsConstructor
   @NoArgsConstructor
@@ -53,7 +53,7 @@ public class LineageEvent extends BaseJsonModel {
   public static class Run extends BaseJsonModel {
 
     @NotNull private String runId;
-    private RunFacet facets;
+    @Valid private RunFacet facets;
   }
 
   @Builder
@@ -65,8 +65,8 @@ public class LineageEvent extends BaseJsonModel {
   @JsonPropertyOrder({"nominalTime", "parent"})
   public static class RunFacet {
 
-    private NominalTimeRunFacet nominalTime;
-    private ParentRunFacet parent;
+    @Valid private NominalTimeRunFacet nominalTime;
+    @Valid private ParentRunFacet parent;
 
     @Builder.Default @JsonIgnore private Map<String, Object> additional = new LinkedHashMap<>();
 
@@ -194,7 +194,7 @@ public class LineageEvent extends BaseJsonModel {
 
     @NotNull private String namespace;
     @NotNull private String name;
-    private JobFacet facets;
+    @Valid private JobFacet facets;
   }
 
   @Builder
@@ -206,9 +206,9 @@ public class LineageEvent extends BaseJsonModel {
   @JsonPropertyOrder({"documentation", "sourceCodeLocation", "sql", "description"})
   public static class JobFacet {
 
-    private DocumentationJobFacet documentation;
-    private SourceCodeLocationJobFacet sourceCodeLocation;
-    private SQLJobFacet sql;
+    @Valid private DocumentationJobFacet documentation;
+    @Valid private SourceCodeLocationJobFacet sourceCodeLocation;
+    @Valid private SQLJobFacet sql;
     @Builder.Default @JsonIgnore private Map<String, Object> additional = new LinkedHashMap<>();
 
     @JsonAnySetter
@@ -298,7 +298,7 @@ public class LineageEvent extends BaseJsonModel {
 
     @NotNull private String namespace;
     @NotNull private String name;
-    private DatasetFacets facets;
+    @Valid private DatasetFacets facets;
   }
 
   @Builder
@@ -310,9 +310,9 @@ public class LineageEvent extends BaseJsonModel {
   @JsonPropertyOrder({"documentation", "schema", "dataSource", "description"})
   public static class DatasetFacets {
 
-    private DocumentationDatasetFacet documentation;
-    private SchemaDatasetFacet schema;
-    private DatasourceDatasetFacet dataSource;
+    @Valid private DocumentationDatasetFacet documentation;
+    @Valid private SchemaDatasetFacet schema;
+    @Valid private DatasourceDatasetFacet dataSource;
     private String description;
     @Builder.Default @JsonIgnore private Map<String, Object> additional = new LinkedHashMap<>();
 
@@ -367,7 +367,7 @@ public class LineageEvent extends BaseJsonModel {
   @ToString
   public static class SchemaDatasetFacet extends BaseFacet {
 
-    private List<SchemaField> fields;
+    @Valid private List<SchemaField> fields;
 
     @Builder
     public SchemaDatasetFacet(


### PR DESCRIPTION
Signed-off-by: Michael Collado <collado.mike@gmail.com>

### Problem
I found that OpenLineage events aren't being validated as expected by the annotations on the model classes. It seems that the `@Valid` annotation at the class level doesn't apply to field declarations. Only the top level `LineageEvent` class was validated to ensure its fields were non-null.

A customer posted the following event, which resulted in a 500 error, rather than a 4XX.

```json
{"eventTime": "2021-11-03T10:53:52.427343", "eventType": "COMPLETE", "inputs": [{"facets": {}, "name": "OPEN_LINEAGE_DEMO.DEMO.SOURCE_TABLE", "namespace": "testing_namespace"}], "job": {"facets": {}, "name": "testing_name", "namespace": "testing_namespace"}, "outputs": [{"facets": {"schema": {"_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client", "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/DataQualityAssertionsDatasetFacet.json", "fields": [{"assertion": "a", "success": true}]}}, "name": "OPEN_LINEAGE_DEMO.DEMO.SOURCE_TABLE", "namespace": "testing_namespace_0.6125706796160107"}], "producer": "me", "run": {"facets": {}, "runId": "dae0d60a-6010-4c37-980e-c5270f5a6be4"}}
```
Here, the output dataset has a `SchemaDatasetFacet`, but the `fields` list seems to contain `DataQualityAssertionsDatasetFacetAssertions` instead.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
