### PR TITLE
Changed Docker Java Base Image Source Provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine AS base
+FROM eclipse-temurin:11-alpine AS base
 WORKDIR /usr/src/app
 COPY gradle gradle
 COPY gradle.properties gradle.properties
@@ -14,7 +14,7 @@ COPY api/build.gradle ./api/build.gradle
 COPY clients/java ./clients/java
 RUN ./gradlew --no-daemon :api:shadowJar
 
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM eclipse-temurin:11-jre-alpine
 RUN apk update && apk add --virtual postgresql-client bash coreutils
 WORKDIR /usr/src/app
 COPY --from=build /usr/src/app/api/build/libs/marquez-*.jar /usr/src/app


### PR DESCRIPTION
### Problem

The base image used by the API component is provided by [AdoptOpenJDK](https://hub.docker.com/r/adoptopenjdk/openjdk11), which is a community supported project. This has worked well overall, but patches to security vulnerabilities is becoming to experience delays. After digging into this a bit more, I noticed a [depreciation notice](https://hub.docker.com/_/adoptopenjdk) on the project page.

### Solution

The replacement for this depreciation is called out as [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin/). As such, this PR updates the API base image to source the same flavor of Java 11 images from this new official Docker image source. 

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
