### PR TITLE
Upgrade Node 12 Version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
   build-docs:
     working_directory: ~/marquez
     docker:
-      - image: cimg/node:12.21
+      - image: cimg/node:12.22.7
     steps:
       - checkout
       - run: npm install --prefix=${HOME}/.local --global redoc-cli
@@ -53,7 +53,7 @@ jobs:
   test-web:
     working_directory: ~/marquez/web
     docker:
-      - image: circleci/node:12.21.0
+      - image: circleci/node:12.22.7
     environment:
       TZ: 'America/New_York'
     steps:

--- a/web/README.md
+++ b/web/README.md
@@ -2,7 +2,7 @@
 
 ### Requirements
 
-To develop on this project, you need to have Node version 12.21.0 installed. In order to easily switch between node versions, we recommend using node version manager like [nvm](https://github.com/nvm-sh/nvm/blob/master/README.md)
+To develop on this project, you need to have Node version 12.22.7 installed. In order to easily switch between node versions, we recommend using node version manager like [nvm](https://github.com/nvm-sh/nvm/blob/master/README.md)
 
 ### Development
 

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "eslint-fix": "eslint . --ext .ts,.tsx --ignore-pattern \"src/__tests__/*\" --fix"
   },
   "engines": {
-    "node": "12.21.0"
+    "node": "12.22.7"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",


### PR DESCRIPTION
### Problem

The version of Node 12 being used by the web component is outdated, which makes it subject to security vulnerabilities.

### Solution

This PR updates the version of Node 12 from `12.21` to `12.22.7`. As part of a future effort, we should look at upgrading to newer versions of Node; however, I wanted to keep that separate from this change.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
