### PR TITLE
Deprecate write endpoints for `datasets`, `sources`, and `jobs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Changelog
 
 ## [Unreleased](https://github.com/MarquezProject/marquez/compare/0.19.1...HEAD)
+
+### Changed
+
+* Clarify the doc on using OpenLineage for metadata collection [@fm100](https://github.com/fm100)
+* Upgrade to gradle `7.x` [@wslulciuc](https://github.com/wslulciuc)
+* Use `eclipse-temurin` as base image for Marquez API [@fm100](https://github.com/fm100)
+
 ### Fixed
-* Fixed validation of OpenLineage events on write [@collado-mike](https://github.com/collado-mike)
+
+* Validation of OpenLineage events on write [@collado-mike](https://github.com/collado-mike)
+* Increase `name` column size for tables `namespaces` and `sources` [@mmeasic](https://github.com/mmeasic)
 
 ## [0.19.1](https://github.com/MarquezProject/marquez/compare/0.19.0...0.19.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@
 
 ### Deprecated
 
-* `/datasets` endpoint to collect dataset metadata (**scheduled to be removed in** `0.25.0`)
-* `/sources` endpoint to collect source metadata (**scheduled to be removed in** `0.25.0`)
-* `/jobs` endpoint to collect job metadata (**scheduled to be removed in** `0.25.0`)
+* The following endpoints have been deprecated and are **scheduled to be removed in** `0.25.0`. Please use the [`/lineage`](https://marquezproject.github.io/marquez/openapi.html#tag/Lineage/paths/~1lineage/post) endpoint when collecting dataset, source, and job run metadata [@wslulciuc](https://github.com/wslulciuc):
+  * `/datasets` endpoint to collect dataset metadata
+  * `/sources` endpoint to collect source metadata
+  * `/jobs` endpoint to collect job metadata
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 * Upgrade to gradle `7.x` [@wslulciuc](https://github.com/wslulciuc)
 * Use `eclipse-temurin` as base image for Marquez API [@fm100](https://github.com/fm100)
 
+### Deprecated
+
+* `/datasets` endpoint to collect dataset metadata (**scheduled to be removed in** `0.25.0`)
+* `/sources` endpoint to collect source metadata (**scheduled to be removed in** `0.25.0`)
+* `/jobs` endpoint to collect job metadata (**scheduled to be removed in** `0.25.0`)
+
 ### Fixed
 
 * Validation of OpenLineage events on write [@collado-mike](https://github.com/collado-mike)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Deprecated
 
-* The following endpoints have been deprecated and are **scheduled to be removed in** `0.25.0`. Please use the [`/lineage`](https://marquezproject.github.io/marquez/openapi.html#tag/Lineage/paths/~1lineage/post) endpoint when collecting dataset, source, and job run metadata [@wslulciuc](https://github.com/wslulciuc):
+* The following endpoints have been deprecated and are **scheduled to be removed in** `0.25.0`. Please use the [`/lineage`](https://marquezproject.github.io/marquez/openapi.html#tag/Lineage/paths/~1lineage/post) endpoint when collecting dataset, source, and job metadata [@wslulciuc](https://github.com/wslulciuc):
   * `/datasets` endpoint to collect dataset metadata
   * `/sources` endpoint to collect source metadata
   * `/jobs` endpoint to collect job metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,16 @@
 
 ### Changed
 
-* Clarify the doc on using OpenLineage for metadata collection [@fm100](https://github.com/fm100)
+* Clarify docs on using OpenLineage for metadata collection [@fm100](https://github.com/fm100)
 * Upgrade to gradle `7.x` [@wslulciuc](https://github.com/wslulciuc)
-* Use `eclipse-temurin` as base image for Marquez API [@fm100](https://github.com/fm100)
+* Use `eclipse-temurin` for Marquez API base docker image [@fm100](https://github.com/fm100)
 
 ### Deprecated
 
-* The following endpoints have been deprecated and are **scheduled to be removed in** `0.25.0`. Please use the [`/lineage`](https://marquezproject.github.io/marquez/openapi.html#tag/Lineage/paths/~1lineage/post) endpoint when collecting dataset, source, and job metadata [@wslulciuc](https://github.com/wslulciuc):
-  * `/datasets` endpoint to collect dataset metadata
-  * `/sources` endpoint to collect source metadata
-  * `/jobs` endpoint to collect job metadata
+* The following endpoints have been deprecated and are **scheduled to be removed in** `0.25.0`. Please use the [`/lineage`](https://marquezproject.github.io/marquez/openapi.html#tag/Lineage/paths/~1lineage/post) endpoint when collecting source, dataset, and job metadata [@wslulciuc](https://github.com/wslulciuc):
+  * [`/sources`](https://marquezproject.github.io/marquez/openapi.html#tag/Sources/paths/~1sources~1{source}/put) endpoint to collect source metadata
+  * [`/datasets`](https://marquezproject.github.io/marquez/openapi.html#tag/Datasets/paths/~1namespaces~1{namespace}~1datasets~1{dataset}/put) endpoint to collect dataset metadata
+  * [`/jobs`](https://marquezproject.github.io/marquez/openapi.html#tag/Jobs/paths/~1namespaces~1{namespace}~1jobs~1{job}/put) endpoint to collect job metadata
 
 ### Fixed
 

--- a/api/src/main/java/marquez/api/DatasetResource.java
+++ b/api/src/main/java/marquez/api/DatasetResource.java
@@ -58,6 +58,11 @@ public class DatasetResource extends BaseResource {
     super(serviceFactory);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
+   */
   @Timed
   @ResponseMetered
   @ExceptionMetered

--- a/api/src/main/java/marquez/api/JobResource.java
+++ b/api/src/main/java/marquez/api/JobResource.java
@@ -67,6 +67,11 @@ public class JobResource extends BaseResource {
     this.jobVersionDao = jobVersionDao;
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
+   */
   @Timed
   @ResponseMetered
   @ExceptionMetered

--- a/api/src/main/java/marquez/api/RunResource.java
+++ b/api/src/main/java/marquez/api/RunResource.java
@@ -46,6 +46,11 @@ public class RunResource {
     return Response.ok(run).build();
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
+   */
   @Timed
   @ResponseMetered
   @ExceptionMetered
@@ -56,6 +61,11 @@ public class RunResource {
     return markRunAs(RUNNING, atAsIso);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
+   */
   @Timed
   @ResponseMetered
   @ExceptionMetered
@@ -66,6 +76,11 @@ public class RunResource {
     return markRunAs(COMPLETED, atAsIso);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
+   */
   @Timed
   @ResponseMetered
   @ExceptionMetered
@@ -76,6 +91,11 @@ public class RunResource {
     return markRunAs(FAILED, atAsIso);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
+   */
   @Timed
   @ResponseMetered
   @ExceptionMetered

--- a/api/src/main/java/marquez/api/SourceResource.java
+++ b/api/src/main/java/marquez/api/SourceResource.java
@@ -46,6 +46,11 @@ public class SourceResource extends BaseResource {
     super(serviceFactory);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
+   */
   @Timed
   @ResponseMetered
   @ExceptionMetered

--- a/api/src/main/java/marquez/service/DatasetService.java
+++ b/api/src/main/java/marquez/service/DatasetService.java
@@ -60,6 +60,11 @@ public class DatasetService extends DelegatingDaos.DelegatingDatasetDao {
     this.runService = runService;
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
+   */
   public Dataset createOrUpdate(
       @NonNull NamespaceName namespaceName,
       @NonNull DatasetName datasetName,

--- a/api/src/main/java/marquez/service/JobService.java
+++ b/api/src/main/java/marquez/service/JobService.java
@@ -47,6 +47,11 @@ public class JobService extends DelegatingDaos.DelegatingJobDao {
     this.runService = runService;
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
+   */
   public Job createOrUpdate(
       @NonNull NamespaceName namespaceName, @NonNull JobName jobName, @NonNull JobMeta jobMeta) {
     JobRow jobRow = upsertJobMeta(namespaceName, jobName, jobMeta, mapper);

--- a/api/src/main/java/marquez/service/RunService.java
+++ b/api/src/main/java/marquez/service/RunService.java
@@ -65,11 +65,6 @@ public class RunService extends DelegatingDaos.DelegatingRunDao {
     return findRunByUuid(runRow.getUuid()).get();
   }
 
-  /**
-   * @deprecated Prefer OpenLineage, see <a
-   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
-   *     removed in release {@code 0.25.0}.
-   */
   public void markRunAs(
       @NonNull RunId runId, @NonNull RunState runState, @Nullable Instant transitionedAt) {
     log.debug("Marking run with ID '{}' as '{}'...", runId, runState);

--- a/api/src/main/java/marquez/service/RunService.java
+++ b/api/src/main/java/marquez/service/RunService.java
@@ -51,6 +51,11 @@ public class RunService extends DelegatingDaos.DelegatingRunDao {
     this.runTransitionListeners = runTransitionListeners;
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
+   */
   public Run createRun(
       @NonNull NamespaceName namespaceName, @NonNull JobName jobName, @NonNull RunMeta runMeta) {
     log.info("Creating run for job '{}'...", jobName.getValue());
@@ -60,6 +65,11 @@ public class RunService extends DelegatingDaos.DelegatingRunDao {
     return findRunByUuid(runRow.getUuid()).get();
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
+   */
   public void markRunAs(
       @NonNull RunId runId, @NonNull RunState runState, @Nullable Instant transitionedAt) {
     log.debug("Marking run with ID '{}' as '{}'...", runId, runState);

--- a/api/src/main/java/marquez/service/SourceService.java
+++ b/api/src/main/java/marquez/service/SourceService.java
@@ -35,6 +35,11 @@ public class SourceService extends DelegatingDaos.DelegatingSourceDao {
     super(dao.createSourceDao());
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
+   */
   public Source createOrUpdate(@NonNull SourceName name, @NonNull SourceMeta meta) {
     log.info("Create/upsert source '{}' with meta: {}", name.getValue(), meta);
     sources.inc();

--- a/clients/java/src/main/java/marquez/client/MarquezClient.java
+++ b/clients/java/src/main/java/marquez/client/MarquezClient.java
@@ -117,8 +117,9 @@ public class MarquezClient {
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   public Source createSource(@NonNull String sourceName, @NonNull SourceMeta sourceMeta) {
     final String bodyAsJson = http.put(url.toSourceUrl(sourceName), sourceMeta.toJson());
@@ -140,8 +141,9 @@ public class MarquezClient {
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   public Dataset createDataset(
       @NonNull String namespaceName,
@@ -202,8 +204,9 @@ public class MarquezClient {
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   public Job createJob(
       @NonNull String namespaceName, @NonNull String jobName, @NonNull JobMeta jobMeta) {
@@ -239,16 +242,18 @@ public class MarquezClient {
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   public Run createRun(String namespaceName, String jobName, RunMeta runMeta) {
     return createRun(namespaceName, jobName, runMeta, false);
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   private Run createRun(
       @NonNull String namespaceName,
@@ -262,8 +267,9 @@ public class MarquezClient {
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   public Run createRunAndStart(String namespaceName, String jobName, RunMeta runMeta) {
     return createRun(namespaceName, jobName, runMeta, true);
@@ -285,16 +291,18 @@ public class MarquezClient {
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   public Run markRunAs(String runId, RunState runState) {
     return markRunAs(runId, runState, null);
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   public Run markRunAs(String runId, @NonNull RunState runState, @Nullable Instant at) {
     final String bodyAsJson = http.post(url.toRunTransitionUrl(runId, runState, at));
@@ -302,64 +310,72 @@ public class MarquezClient {
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   public Run markRunAsRunning(String runId) {
     return markRunAsRunning(runId, null);
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   public Run markRunAsRunning(String runId, @Nullable Instant at) {
     return markRunAs(runId, RUNNING, at);
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   public Run markRunAsCompleted(String runId) {
     return markRunAsCompleted(runId, null);
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   public Run markRunAsCompleted(String runId, @Nullable Instant at) {
     return markRunAs(runId, COMPLETED, at);
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   public Run markRunAsAborted(String runId) {
     return markRunAsAborted(runId, null);
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   public Run markRunAsAborted(String runId, @Nullable Instant at) {
     return markRunAs(runId, ABORTED, at);
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   public Run markRunAsFailed(String runId) {
     return markRunAsFailed(runId, null);
   }
 
   /**
-   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
-   *     scheduled to be removed in release {@code 0.25.0}.
+   * @deprecated Prefer OpenLineage, see <a
+   *     href="https://openlineage.io">https://openlineage.io</a>. This method is scheduled to be
+   *     removed in release {@code 0.25.0}.
    */
   public Run markRunAsFailed(String runId, @Nullable Instant at) {
     return markRunAs(runId, FAILED, at);

--- a/clients/java/src/main/java/marquez/client/MarquezClient.java
+++ b/clients/java/src/main/java/marquez/client/MarquezClient.java
@@ -116,6 +116,10 @@ public class MarquezClient {
     return Namespaces.fromJson(bodyAsJson).getValue();
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   public Source createSource(@NonNull String sourceName, @NonNull SourceMeta sourceMeta) {
     final String bodyAsJson = http.put(url.toSourceUrl(sourceName), sourceMeta.toJson());
     return Source.fromJson(bodyAsJson);
@@ -135,6 +139,10 @@ public class MarquezClient {
     return Sources.fromJson(bodyAsJson).getValue();
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   public Dataset createDataset(
       @NonNull String namespaceName,
       @NonNull String datasetName,
@@ -193,6 +201,10 @@ public class MarquezClient {
     return Dataset.fromJson(bodyAsJson);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   public Job createJob(
       @NonNull String namespaceName, @NonNull String jobName, @NonNull JobMeta jobMeta) {
     final String bodyAsJson = http.put(url.toJobUrl(namespaceName, jobName), jobMeta.toJson());
@@ -226,10 +238,18 @@ public class MarquezClient {
     return JobVersions.fromJson(bodyAsJson).getValue();
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   public Run createRun(String namespaceName, String jobName, RunMeta runMeta) {
     return createRun(namespaceName, jobName, runMeta, false);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   private Run createRun(
       @NonNull String namespaceName,
       @NonNull String jobName,
@@ -241,6 +261,10 @@ public class MarquezClient {
     return (markRunAsRunning) ? markRunAsRunning(run.getId()) : run;
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   public Run createRunAndStart(String namespaceName, String jobName, RunMeta runMeta) {
     return createRun(namespaceName, jobName, runMeta, true);
   }
@@ -260,43 +284,83 @@ public class MarquezClient {
     return Runs.fromJson(bodyAsJson).getValue();
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   public Run markRunAs(String runId, RunState runState) {
     return markRunAs(runId, runState, null);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   public Run markRunAs(String runId, @NonNull RunState runState, @Nullable Instant at) {
     final String bodyAsJson = http.post(url.toRunTransitionUrl(runId, runState, at));
     return Run.fromJson(bodyAsJson);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   public Run markRunAsRunning(String runId) {
     return markRunAsRunning(runId, null);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   public Run markRunAsRunning(String runId, @Nullable Instant at) {
     return markRunAs(runId, RUNNING, at);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   public Run markRunAsCompleted(String runId) {
     return markRunAsCompleted(runId, null);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   public Run markRunAsCompleted(String runId, @Nullable Instant at) {
     return markRunAs(runId, COMPLETED, at);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   public Run markRunAsAborted(String runId) {
     return markRunAsAborted(runId, null);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   public Run markRunAsAborted(String runId, @Nullable Instant at) {
     return markRunAs(runId, ABORTED, at);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   public Run markRunAsFailed(String runId) {
     return markRunAsFailed(runId, null);
   }
 
+  /**
+   * @deprecated Prefer OpenLineage, see <a href="https://openlineage.io</a>. This method is
+   *     scheduled to be removed in release {@code 0.25.0}.
+   */
   public Run markRunAsFailed(String runId, @Nullable Instant at) {
     return markRunAs(runId, FAILED, at);
   }

--- a/clients/python/marquez_client/client.py
+++ b/clients/python/marquez_client/client.py
@@ -336,15 +336,23 @@ class MarquezClient:
         Utils.is_valid_uuid(run_id, 'run_id')
         return self._get(self._url('/jobs/runs/{0}', run_id))
 
+    @deprecated(deprecated_in='0.20.0', removed_in='0.25.0',
+                details='Use OpenLineage instead, see `https://openlineage.io`')
     def mark_job_run_as_started(self, run_id, at=None):
         return self.__mark_job_run_as(run_id, 'start', at)
 
+    @deprecated(deprecated_in='0.20.0', removed_in='0.25.0',
+                details='Use OpenLineage instead, see `https://openlineage.io`')
     def mark_job_run_as_completed(self, run_id, at=None):
         return self.__mark_job_run_as(run_id, 'complete', at)
 
+    @deprecated(deprecated_in='0.20.0', removed_in='0.25.0',
+                details='Use OpenLineage instead, see `https://openlineage.io`')
     def mark_job_run_as_failed(self, run_id, at=None):
         return self.__mark_job_run_as(run_id, 'fail', at)
 
+    @deprecated(deprecated_in='0.20.0', removed_in='0.25.0',
+                details='Use OpenLineage instead, see `https://openlineage.io`')
     def mark_job_run_as_aborted(self, run_id, at=None):
         return self.__mark_job_run_as(run_id, 'abort', at)
 
@@ -367,6 +375,8 @@ class MarquezClient:
             payload=payload
         )
 
+    @deprecated(deprecated_in='0.20.0', removed_in='0.25.0',
+                details='Use OpenLineage instead, see `https://openlineage.io`')
     def __mark_job_run_as(self, run_id, action, at=None):
         Utils.is_valid_uuid(run_id, 'run_id')
 

--- a/clients/python/marquez_client/client.py
+++ b/clients/python/marquez_client/client.py
@@ -17,6 +17,7 @@ import requests
 
 import marquez_client
 
+from deprecation import deprecated
 from six.moves.urllib.parse import quote
 
 from marquez_client import errors
@@ -79,6 +80,8 @@ class MarquezClient:
             }
         )
 
+    @deprecated(deprecated_in='0.20.0', removed_in='0.25.0',
+                details='Use OpenLineage instead, see `https://openlineage.io`')
     def create_source(self, source_name, source_type, connection_url,
                       description=None):
         Utils.check_name_length(source_name, 'source_name')
@@ -110,6 +113,8 @@ class MarquezClient:
             }
         )
 
+    @deprecated(deprecated_in='0.20.0', removed_in='0.25.0',
+                details='Use OpenLineage instead, see `https://openlineage.io`')
     def create_dataset(self, namespace_name, dataset_name, dataset_type,
                        dataset_physical_name, source_name,
                        description=None, run_id=None,
@@ -223,6 +228,8 @@ class MarquezClient:
                       tag_name)
         )
 
+    @deprecated(deprecated_in='0.20.0', removed_in='0.25.0',
+                details='Use OpenLineage instead, see `https://openlineage.io`')
     def create_job(self, namespace_name, job_name, job_type, location=None,
                    inputs: [DatasetId] = None, outputs: [DatasetId] = None,
                    description=None, context=None, run_id=None):
@@ -276,6 +283,8 @@ class MarquezClient:
             }
         )
 
+    @deprecated(deprecated_in='0.20.0', removed_in='0.25.0',
+                details='Use OpenLineage instead, see `https://openlineage.io`')
     def create_job_run(self, namespace_name, job_name, run_id=None,
                        nominal_start_time=None,
                        nominal_end_time=None, run_args=None,

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -21,6 +21,7 @@ paths:
         underscores (`_`), dashes (`-`), colons (`:`), slashes (`/`), or dots (`.`).
         A namespace is case-insensitive with a maximum length of `1024` characters.
         Note jobs and datasets will be unique within a namespace, but not across namespaces.
+      deprecated: true
       tags:
         - Namespaces
       requestBody:
@@ -73,6 +74,7 @@ paths:
       description: Creates a new source object. A source is the physical location of a dataset such as
         a table in PostgreSQL, or topic in Kafka. A source enables the grouping of physical datasets
         to their physical source.
+      deprecated: true
       tags:
         - Sources
       requestBody:
@@ -124,6 +126,7 @@ paths:
     put:
       summary: Create a dataset
       description: Creates a new dataset.
+      deprecated: true
       tags:
         - Datasets
       requestBody:
@@ -255,6 +258,7 @@ paths:
         Marquez will create a version of a job each time the contents of the object is modified. For example, the `location`
         of a job may change over time resulting in new versions. The accumulated versions can be listed, used to rerun a
         specific job version or possibly help debug a failed job run.
+      deprecated: true
       tags:
         - Jobs
       requestBody:


### PR DESCRIPTION
### Problem

Marquez has adopted the [OpenLineage](https://openlineage.io) standard to collect lineage metadata within the context of job execution. Using the endpoint [`/lineage`](https://marquezproject.github.io/marquez/openapi.html#tag/Lineage/paths/~1lineage/post), callers can use Marquez to record OpenLineage events. An OpenLineage event allows callers to record, dataset, job and run metadata in a single request. This means, the Marquez write endpoints for datasets, jobs, and runs can be deprecated (and eventually removed). This also means some refactoring of the codebase needs to happen. For more details, see #1727.

Closes: #1783, #1784 

### Solution

This PR deprecates the write endpoints to collect dataset, source, and job metadata.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
