### PR TITLE
Put MDC context from jersey filter so that all the logs have request context information.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-* Add MDC to the `LoggingJerseyFilter` to include API method, path, and request ID.
+* Add MDC to the `LoggingMdcFilter` to include API method, path, and request ID.
 
 ## [0.20.0](https://github.com/MarquezProject/marquez/compare/0.19.1...0.20.0) - 2021-12-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/MarquezProject/marquez/compare/0.20.0...HEAD)
 
+### Added
+
+* Add MDC to the `LoggingJerseyFilter` to include API method, path, and request ID.
+
 ## [0.20.0](https://github.com/MarquezProject/marquez/compare/0.19.1...0.20.0) - 2021-12-13
 
 ### Added

--- a/api/src/main/java/marquez/MarquezApp.java
+++ b/api/src/main/java/marquez/MarquezApp.java
@@ -38,6 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 import marquez.cli.SeedCommand;
 import marquez.common.Utils;
 import marquez.db.DbMigration;
+import marquez.logging.LoggingJerseyFilter;
 import marquez.tracing.SentryConfig;
 import marquez.tracing.TracingContainerResponseFilter;
 import marquez.tracing.TracingSQLLogger;
@@ -128,6 +129,7 @@ public final class MarquezApp extends Application<MarquezConfig> {
 
     registerResources(config, env, source);
     registerServlets(env);
+    registerFilters(env);
   }
 
   private boolean isSentryEnabled(MarquezConfig config) {
@@ -169,5 +171,9 @@ public final class MarquezApp extends Application<MarquezConfig> {
 
     // Expose metrics for monitoring.
     env.servlets().addServlet(PROMETHEUS, new MetricsServlet()).addMapping(PROMETHEUS_ENDPOINT);
+  }
+
+  private void registerFilters(@NonNull Environment env) {
+    env.jersey().getResourceConfig().register(new LoggingJerseyFilter());
   }
 }

--- a/api/src/main/java/marquez/MarquezApp.java
+++ b/api/src/main/java/marquez/MarquezApp.java
@@ -38,7 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 import marquez.cli.SeedCommand;
 import marquez.common.Utils;
 import marquez.db.DbMigration;
-import marquez.logging.LoggingJerseyFilter;
+import marquez.logging.LoggingMdcFilter;
 import marquez.tracing.SentryConfig;
 import marquez.tracing.TracingContainerResponseFilter;
 import marquez.tracing.TracingSQLLogger;
@@ -174,6 +174,6 @@ public final class MarquezApp extends Application<MarquezConfig> {
   }
 
   private void registerFilters(@NonNull Environment env) {
-    env.jersey().getResourceConfig().register(new LoggingJerseyFilter());
+    env.jersey().getResourceConfig().register(new LoggingMdcFilter());
   }
 }

--- a/api/src/main/java/marquez/logging/LoggingJerseyFilter.java
+++ b/api/src/main/java/marquez/logging/LoggingJerseyFilter.java
@@ -1,0 +1,34 @@
+package marquez.logging;
+
+import java.io.IOException;
+import java.util.UUID;
+import javax.ws.rs.container.CompletionCallback;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import org.slf4j.MDC;
+
+/**
+ * Puts request ID, method, and path to the MDC context so that this information is available from
+ * logs throughout the request context. Request ID is randomly generated UUID, which can be used to
+ * group by to see the logs for a particular request.
+ */
+public class LoggingJerseyFilter implements ContainerRequestFilter, CompletionCallback {
+
+  private static final String REQUEST_ID = "RequestID";
+  private static final String METHOD = "Method";
+  private static final String PATH = "Path";
+
+  @Override
+  public void onComplete(Throwable throwable) {
+    MDC.remove(REQUEST_ID);
+    MDC.remove(METHOD);
+    MDC.remove(PATH);
+  }
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    MDC.put(REQUEST_ID, UUID.randomUUID().toString());
+    MDC.put(METHOD, requestContext.getMethod());
+    MDC.put(PATH, requestContext.getUriInfo().getPath());
+  }
+}

--- a/api/src/main/java/marquez/logging/LoggingMdcFilter.java
+++ b/api/src/main/java/marquez/logging/LoggingMdcFilter.java
@@ -12,11 +12,11 @@ import org.slf4j.MDC;
  * logs throughout the request context. Request ID is randomly generated UUID, which can be used to
  * group by to see the logs for a particular request.
  */
-public class LoggingJerseyFilter implements ContainerRequestFilter, CompletionCallback {
+public class LoggingMdcFilter implements ContainerRequestFilter, CompletionCallback {
 
-  private static final String REQUEST_ID = "RequestID";
-  private static final String METHOD = "Method";
-  private static final String PATH = "Path";
+  private static final String REQUEST_ID = "requestID";
+  private static final String METHOD = "method";
+  private static final String PATH = "path";
 
   @Override
   public void onComplete(Throwable throwable) {

--- a/api/src/main/java/marquez/logging/MdcPropagating.java
+++ b/api/src/main/java/marquez/logging/MdcPropagating.java
@@ -1,0 +1,43 @@
+package marquez.logging;
+
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.slf4j.MDC;
+
+/**
+ * MDC uses ThreadLocal to store the context, and this is not propagated when the logic runs in
+ * separate thread. This class provides static wrapper methods to propagate the MDC context to the
+ * thread where the logic runs.
+ */
+public class MdcPropagating {
+  public static <T> Supplier<T> withMdc(Supplier<T> supplier) {
+    Map<String, String> mdcContext = MDC.getCopyOfContextMap();
+    return () -> {
+      if (mdcContext != null) {
+        MDC.setContextMap(mdcContext);
+      }
+      return supplier.get();
+    };
+  }
+
+  public static <T> Consumer<T> withMdc(Consumer<T> consumer) {
+    Map<String, String> mdcContext = MDC.getCopyOfContextMap();
+    return (t) -> {
+      if (mdcContext != null) {
+        MDC.setContextMap(mdcContext);
+      }
+      consumer.accept(t);
+    };
+  }
+
+  public static Runnable withMdc(Runnable runnable) {
+    Map<String, String> mdcContext = MDC.getCopyOfContextMap();
+    return () -> {
+      if (mdcContext != null) {
+        MDC.setContextMap(mdcContext);
+      }
+      runnable.run();
+    };
+  }
+}

--- a/api/src/main/java/marquez/service/OpenLineageService.java
+++ b/api/src/main/java/marquez/service/OpenLineageService.java
@@ -1,5 +1,6 @@
 package marquez.service;
 
+import static marquez.logging.MdcPropagating.withMdc;
 import static marquez.tracing.SentryPropagating.withSentry;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -52,7 +53,8 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
   public CompletableFuture<Void> createAsync(LineageEvent event) {
     CompletableFuture<Void> marquez =
         CompletableFuture.supplyAsync(
-                withSentry(() -> updateMarquezModel(event, mapper)), ForkJoinPool.commonPool())
+                withSentry(withMdc(() -> updateMarquezModel(event, mapper))),
+                ForkJoinPool.commonPool())
             .thenAccept(
                 (update) -> {
                   if (event.getEventType() != null) {
@@ -67,15 +69,16 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
     CompletableFuture<Void> openLineage =
         CompletableFuture.runAsync(
             withSentry(
-                () ->
-                    createLineageEvent(
-                        event.getEventType() == null ? "" : event.getEventType(),
-                        event.getEventTime().withZoneSameInstant(ZoneId.of("UTC")).toInstant(),
-                        runUuid,
-                        event.getJob().getName(),
-                        event.getJob().getNamespace(),
-                        createJsonArray(event, mapper),
-                        event.getProducer())),
+                withMdc(
+                    () ->
+                        createLineageEvent(
+                            event.getEventType() == null ? "" : event.getEventType(),
+                            event.getEventTime().withZoneSameInstant(ZoneId.of("UTC")).toInstant(),
+                            runUuid,
+                            event.getJob().getName(),
+                            event.getJob().getNamespace(),
+                            createJsonArray(event, mapper),
+                            event.getProducer()))),
             ForkJoinPool.commonPool());
 
     return CompletableFuture.allOf(marquez, openLineage);


### PR DESCRIPTION
Signed-off-by: Minkyu Park <minkyu@datakin.com>

### Problem
Ability to see the logging statements within the context is important. This PR adds API method, path, and request ID to the MDC so that all subsequent logging statements within the same request context contain the same context information inline.

Closes: #1696 

### Solution
Put MDC context information from jersey filter.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
