### PR TITLE
Bump shadow to `7.1.1`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.adarshr:gradle-test-logger-plugin:3.1.0'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:6.1.0'
+        classpath 'gradle.plugin.com.github.johnrengelman:shadow:7.1.1'
         classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.0.5'
     }
 }


### PR DESCRIPTION
This PR bumps our `shadow` plugin to `7.1.1`.