### PR TITLE
Clean up CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,16 @@ jobs:
             - ./dist/*.whl
             - ./dist/*.tar.gz
 
+  integration-test-integration-airflow:
+    working_directory: ~/marquez/integrations/
+    machine: true
+    steps:
+      - *checkout_project_root
+      - run: ./../.circleci/get-docker-compose.sh
+      - run: bash -c '(cd ~/marquez && docker build -t marquezproject/marquez . )'
+      - run: docker build -f airflow/Dockerfile.tests -t marquez-airflow-base .
+      - run: ./airflow/tests/integration/docker/up.sh
+
   lint-docs-api:
     working_directory: ~/marquez
     docker:
@@ -229,6 +239,9 @@ workflows:
       - build-client-java
       - build-integration-airflow
       - build-integration-spark
+      - integration-test-integration-airflow
+          requires:
+            - build-integration-airflow
       - unit-test-web
       - unit-test-client-python
       - lint-docs-api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: ./.circleci/get-jdk11.sh
+      - run: ./.circleci/get-jdk17.sh
       - run: docker build --no-cache --tag "marquezproject/marquez:${CIRCLE_SHA1}" .
       - run: docker save -o marquez.tar "marquezproject/marquez:${CIRCLE_SHA1}"
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,15 +15,6 @@ only-on-release: &only-on-release
       ignore: /.*/
 
 jobs:
-  build-docs:
-    working_directory: ~/marquez
-    docker:
-      - image: cimg/node:12.22.7
-    steps:
-      - checkout
-      - run: npm install --prefix=${HOME}/.local --global redoc-cli
-      - run: redoc-cli bundle spec/openapi.yml
-
   build-api:
     working_directory: ~/marquez
     machine: true
@@ -50,7 +41,32 @@ jobs:
           paths:
             - ~/.gradle
 
-  test-web:
+  build-image-api:
+    working_directory: ~/marquez
+    machine: true
+    steps:
+      - checkout
+      - run: ./.circleci/get-jdk11.sh
+      - run: docker build --no-cache --tag "marquezproject/marquez:${CIRCLE_SHA1}" .
+      - run: docker save -o marquez.tar "marquezproject/marquez:${CIRCLE_SHA1}"
+      - persist_to_workspace:
+          root: .
+          paths:
+            - marquez.tar
+
+  build-image-web:
+    working_directory: ~/marquez/web
+    machine: true
+    steps:
+      - *checkout_project_root
+      - run: docker build --no-cache --tag "marquezproject/marquez:${CIRCLE_SHA1}" .
+      - run: docker save -o marquez-web.tar "marquezproject/marquez-web:${CIRCLE_SHA1}"
+      - persist_to_workspace:
+          root: .
+          paths:
+            - marquez-web.tar
+
+  unit-test-web:
     working_directory: ~/marquez/web
     docker:
       - image: circleci/node:12.22.7
@@ -93,7 +109,7 @@ jobs:
           paths:
             - ~/.gradle
 
-  test-client-python:
+  unit-test-client-python:
     working_directory: ~/marquez/clients/python
     docker:
       - image: circleci/python:3.6
@@ -143,19 +159,6 @@ jobs:
           paths:
             - ~/.gradle
 
-  image-api:
-    working_directory: ~/marquez
-    machine: true
-    steps:
-      - checkout
-      - run: ./.circleci/get-jdk11.sh
-      - run: docker build --no-cache --tag "marquezproject/marquez:${CIRCLE_SHA1}" .
-      - run: mkdir ./build && docker save -o ./build/marquezproject-api-image.tar "marquezproject/marquez:${CIRCLE_SHA1}"
-      - persist_to_workspace:
-          root: .
-          paths:
-            - ./build/marquezproject-api-image.tar
-
   build-integration-airflow:
     working_directory: ~/marquez/integrations/airflow
     docker:
@@ -169,15 +172,14 @@ jobs:
             - ./dist/*.whl
             - ./dist/*.tar.gz
 
-  integration-test-airflow:
-    working_directory: ~/marquez/integrations/
-    machine: true
+  lint-docs-api:
+    working_directory: ~/marquez
+    docker:
+      - image: cimg/node:12.22.7
     steps:
-      - *checkout_project_root
-      - run: ./../.circleci/get-docker-compose.sh
-      - run: bash -c '(cd ~/marquez && docker build -t marquezproject/marquez . )'
-      - run: docker build -f airflow/Dockerfile.tests -t marquez-airflow-base .
-      - run: ./airflow/tests/integration/docker/up.sh
+      - checkout
+      - run: npm install --prefix=${HOME}/.local --global @redocly/openapi-cli@latest
+      - run: openapi lint spec/openapi.yml
 
   release-java:
     working_directory: ~/marquez
@@ -193,14 +195,6 @@ jobs:
           # Publish *.jar
           ./gradlew publish
 
-  release-docker:
-    working_directory: ~/marquez
-    machine: true
-    steps:
-      - checkout
-      - run: ./docker/login.sh
-      - run: ./docker/build-and-push.sh $CIRCLE_TAG
-
   release-python:
     working_directory: ~/marquez
     docker:
@@ -212,17 +206,30 @@ jobs:
       - run: pip install wheel twine
       - run: python -m twine upload --non-interactive --verbose --repository pypi dist/*
 
+  release-docker:
+    working_directory: ~/marquez
+    machine: true
+    steps:
+      - checkout
+      - run: ./docker/login.sh
+      - run: ./docker/build-and-push.sh $CIRCLE_TAG
+
 workflows:
   marquez:
     jobs:
-      - build-docs
       - build-api
-      - image-api
-      - build-integration-spark
-      - test-web
+      - build-image-api:
+          requires:
+            - build-api
+      - build-image-web:
+          requires:
+            - unit-test-web
       - build-client-java
-      - test-client-python
-      - integration-test-airflow
+      - build-integration-airflow
+      - build-integration-spark
+      - unit-test-web
+      - unit-test-client-python
+      - lint-docs-api
   release:
     jobs:
       - build-client-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,22 +49,18 @@ jobs:
       - run: ./.circleci/get-jdk11.sh
       - run: docker build --no-cache --tag "marquezproject/marquez:${CIRCLE_SHA1}" .
       - run: docker save -o marquez.tar "marquezproject/marquez:${CIRCLE_SHA1}"
-      - persist_to_workspace:
-          root: .
-          paths:
-            - marquez.tar
+      - store_artifacts:
+          path: marquez.tar
 
   build-image-web:
     working_directory: ~/marquez/web
     machine: true
     steps:
       - *checkout_project_root
-      - run: docker build --no-cache --tag "marquezproject/marquez:${CIRCLE_SHA1}" .
+      - run: docker build --no-cache --tag "marquezproject/marquez-web:${CIRCLE_SHA1}" .
       - run: docker save -o marquez-web.tar "marquezproject/marquez-web:${CIRCLE_SHA1}"
-      - persist_to_workspace:
-          root: .
-          paths:
-            - marquez-web.tar
+      - store_artifacts:
+          path: marquez-web.tar
 
   unit-test-web:
     working_directory: ~/marquez/web

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,8 +174,8 @@ jobs:
       - image: cimg/node:12.22.7
     steps:
       - checkout
-      - run: npm install --prefix=${HOME}/.local --global @redocly/openapi-cli@latest
-      - run: openapi lint spec/openapi.yml
+      - run: npm install --prefix=${HOME}/.local --global redoc-cli
+      - run: redoc-cli bundle spec/openapi.yml
 
   release-java:
     working_directory: ~/marquez

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ workflows:
       - build-client-java
       - build-integration-airflow
       - build-integration-spark
-      - integration-test-integration-airflow
+      - integration-test-integration-airflow:
           requires:
             - build-integration-airflow
       - unit-test-web

--- a/integrations/airflow/tests/integration/docker/up.sh
+++ b/integrations/airflow/tests/integration/docker/up.sh
@@ -34,6 +34,7 @@ echo "${MARQUEZ_AIRFLOW_WHL_ALL}" > requirements.txt
 
 # Add revision to integration-requirements.txt
 cat > integration-requirements.txt <<EOL
+apache-airflow==1.10.12
 psycopg2-binary==2.8.6
 retrying==1.3.3
 ${MARQUEZ_AIRFLOW_WHL}

--- a/integrations/airflow/tests/integration/docker/up.sh
+++ b/integrations/airflow/tests/integration/docker/up.sh
@@ -32,7 +32,9 @@ MARQUEZ_AIRFLOW_WHL_ALL=$(docker run marquez-airflow-base:latest sh -c "ls /whl/
 # Add revision to requirements.txt
 echo "${MARQUEZ_AIRFLOW_WHL_ALL}" > requirements.txt
 
-# Add lib revision to integration-requirements.txt
-cat "${MARQUEZ_AIRFLOW_WHL}" > integration-requirements.txt
+# Add revision to integration-requirements.txt
+cat > integration-requirements.txt <<EOL
+${MARQUEZ_AIRFLOW_WHL}
+EOL
 
 docker-compose up --build --force-recreate --exit-code-from integration

--- a/integrations/airflow/tests/integration/docker/up.sh
+++ b/integrations/airflow/tests/integration/docker/up.sh
@@ -34,6 +34,8 @@ echo "${MARQUEZ_AIRFLOW_WHL_ALL}" > requirements.txt
 
 # Add revision to integration-requirements.txt
 cat > integration-requirements.txt <<EOL
+psycopg2-binary==2.8.6
+retrying==1.3.3
 ${MARQUEZ_AIRFLOW_WHL}
 EOL
 

--- a/integrations/airflow/tests/integration/docker/up.sh
+++ b/integrations/airflow/tests/integration/docker/up.sh
@@ -35,6 +35,7 @@ echo "${MARQUEZ_AIRFLOW_WHL_ALL}" > requirements.txt
 # Add revision to integration-requirements.txt
 cat > integration-requirements.txt <<EOL
 apache-airflow==1.10.12
+marquez-python
 psycopg2-binary==2.8.6
 retrying==1.3.3
 ${MARQUEZ_AIRFLOW_WHL}

--- a/integrations/airflow/tests/integration/docker/up.sh
+++ b/integrations/airflow/tests/integration/docker/up.sh
@@ -32,27 +32,7 @@ MARQUEZ_AIRFLOW_WHL_ALL=$(docker run marquez-airflow-base:latest sh -c "ls /whl/
 # Add revision to requirements.txt
 echo "${MARQUEZ_AIRFLOW_WHL_ALL}" > requirements.txt
 
-# Add revision to integration-requirements.txt
-cat > integration-requirements.txt <<EOL
-apache-airflow==1.10.12
-apache-airflow[gcp]==1.10.12
-apache-airflow[gcp_api]==1.10.12
-apache-airflow[google]==1.10.12
-apache-airflow[postgres]==1.10.12
-requests==2.24.0
-psycopg2-binary==2.8.6
-httplib2>=0.18.1
-google-cloud-bigquery>=1.28.0
-google-auth-httplib2>=0.0.4
-google-api-core>=1.22.2
-google-api-python-client>=1.12.2
-pandas-gbq>=0.13.2
-google-cloud-storage>=1.31.2
-retrying==1.3.3
-snowflake-connector-python==2.4.3
-git+git://github.com/MarquezProject/marquez.git@main#egg=marquez_python&subdirectory=clients/python
-marquez-python
-${MARQUEZ_AIRFLOW_WHL}
-EOL
+# Add lib revision to integration-requirements.txt
+cat "${MARQUEZ_AIRFLOW_WHL}" > integration-requirements.txt
 
 docker-compose up --build --force-recreate --exit-code-from integration


### PR DESCRIPTION
### Problem

Our CI workflow contains jobs that don't follow some of our naming conventions (i.e. general to more specific hierarchy naming structure). For example, `image-api` can be more precise and be prefixed with `build-`. Similarly, `test-web` can have the prefix `unit` to convey the set of tests executed. We also don't have a CI job for testing our web docker image build. 

### Solution

I've made the following changes to the CI workflow:

* Renamed `build-docs` to `lint-docs-api`
* Renamed `image-api` to `build-image-api`
* Renamed `test-client-python` to `unit-test-client-python`
* Renamed `test-web` to `unit-test-web`
* Renamed `integration-test-airflow` to `integration-test-integration-airflow`
* Added `build-image-web`

Note, this PR depends on #1819

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
