### PR TITLE
SPDX license update

### DIFF
--- a/api/src/main/java/marquez/MarquezApp.java
+++ b/api/src/main/java/marquez/MarquezApp.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez;
 

--- a/api/src/main/java/marquez/MarquezConfig.java
+++ b/api/src/main/java/marquez/MarquezConfig.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez;
 

--- a/api/src/main/java/marquez/MarquezContext.java
+++ b/api/src/main/java/marquez/MarquezContext.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez;
 
 import com.google.common.collect.ImmutableList;

--- a/api/src/main/java/marquez/api/BaseResource.java
+++ b/api/src/main/java/marquez/api/BaseResource.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.api;
 
 import com.google.common.collect.ImmutableSet;

--- a/api/src/main/java/marquez/api/DatasetResource.java
+++ b/api/src/main/java/marquez/api/DatasetResource.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api;
 

--- a/api/src/main/java/marquez/api/JobResource.java
+++ b/api/src/main/java/marquez/api/JobResource.java
@@ -1,17 +1,4 @@
-/*
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api;
 

--- a/api/src/main/java/marquez/api/LineageResource.java
+++ b/api/src/main/java/marquez/api/LineageResource.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.api;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;

--- a/api/src/main/java/marquez/api/NamespaceResource.java
+++ b/api/src/main/java/marquez/api/NamespaceResource.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api;
 

--- a/api/src/main/java/marquez/api/OpenLineageResource.java
+++ b/api/src/main/java/marquez/api/OpenLineageResource.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api;
 

--- a/api/src/main/java/marquez/api/RunResource.java
+++ b/api/src/main/java/marquez/api/RunResource.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.api;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;

--- a/api/src/main/java/marquez/api/SearchResource.java
+++ b/api/src/main/java/marquez/api/SearchResource.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api;
 

--- a/api/src/main/java/marquez/api/SourceResource.java
+++ b/api/src/main/java/marquez/api/SourceResource.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api;
 

--- a/api/src/main/java/marquez/api/TagResource.java
+++ b/api/src/main/java/marquez/api/TagResource.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api;
 

--- a/api/src/main/java/marquez/api/exceptions/DatasetNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/DatasetNotFoundException.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api.exceptions;
 

--- a/api/src/main/java/marquez/api/exceptions/DatasetVersionNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/DatasetVersionNotFoundException.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api.exceptions;
 

--- a/api/src/main/java/marquez/api/exceptions/FieldNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/FieldNotFoundException.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api.exceptions;
 

--- a/api/src/main/java/marquez/api/exceptions/JdbiExceptionExceptionMapper.java
+++ b/api/src/main/java/marquez/api/exceptions/JdbiExceptionExceptionMapper.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.api.exceptions;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;

--- a/api/src/main/java/marquez/api/exceptions/JobNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/JobNotFoundException.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api.exceptions;
 

--- a/api/src/main/java/marquez/api/exceptions/JobVersionNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/JobVersionNotFoundException.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api.exceptions;
 

--- a/api/src/main/java/marquez/api/exceptions/NamespaceNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/NamespaceNotFoundException.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api.exceptions;
 

--- a/api/src/main/java/marquez/api/exceptions/RunAlreadyExistsException.java
+++ b/api/src/main/java/marquez/api/exceptions/RunAlreadyExistsException.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api.exceptions;
 

--- a/api/src/main/java/marquez/api/exceptions/RunNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/RunNotFoundException.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api.exceptions;
 

--- a/api/src/main/java/marquez/api/exceptions/SourceNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/SourceNotFoundException.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api.exceptions;
 

--- a/api/src/main/java/marquez/api/exceptions/TagNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/TagNotFoundException.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api.exceptions;
 

--- a/api/src/main/java/marquez/api/models/JobVersion.java
+++ b/api/src/main/java/marquez/api/models/JobVersion.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api.models;
 

--- a/api/src/main/java/marquez/api/models/ResultsPage.java
+++ b/api/src/main/java/marquez/api/models/ResultsPage.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.api.models;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;

--- a/api/src/main/java/marquez/api/models/SearchFilter.java
+++ b/api/src/main/java/marquez/api/models/SearchFilter.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api.models;
 

--- a/api/src/main/java/marquez/api/models/SearchResult.java
+++ b/api/src/main/java/marquez/api/models/SearchResult.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api.models;
 

--- a/api/src/main/java/marquez/api/models/SearchSort.java
+++ b/api/src/main/java/marquez/api/models/SearchSort.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.api.models;
 

--- a/api/src/main/java/marquez/cli/SeedCommand.java
+++ b/api/src/main/java/marquez/cli/SeedCommand.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.cli;
 
 import static com.google.common.base.Preconditions.checkArgument;

--- a/api/src/main/java/marquez/common/Utils.java
+++ b/api/src/main/java/marquez/common/Utils.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common;
 

--- a/api/src/main/java/marquez/common/base/MorePreconditions.java
+++ b/api/src/main/java/marquez/common/base/MorePreconditions.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.base;
 

--- a/api/src/main/java/marquez/common/models/DatasetId.java
+++ b/api/src/main/java/marquez/common/models/DatasetId.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.common.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/api/src/main/java/marquez/common/models/DatasetName.java
+++ b/api/src/main/java/marquez/common/models/DatasetName.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/common/models/DatasetType.java
+++ b/api/src/main/java/marquez/common/models/DatasetType.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/common/models/DatasetVersionId.java
+++ b/api/src/main/java/marquez/common/models/DatasetVersionId.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/common/models/Field.java
+++ b/api/src/main/java/marquez/common/models/Field.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/common/models/FieldName.java
+++ b/api/src/main/java/marquez/common/models/FieldName.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/common/models/FlexibleDateTimeDeserializer.java
+++ b/api/src/main/java/marquez/common/models/FlexibleDateTimeDeserializer.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.common.models;
 
 import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;

--- a/api/src/main/java/marquez/common/models/JobId.java
+++ b/api/src/main/java/marquez/common/models/JobId.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.common.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/api/src/main/java/marquez/common/models/JobName.java
+++ b/api/src/main/java/marquez/common/models/JobName.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/common/models/JobType.java
+++ b/api/src/main/java/marquez/common/models/JobType.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/common/models/JobVersionId.java
+++ b/api/src/main/java/marquez/common/models/JobVersionId.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/common/models/NamespaceName.java
+++ b/api/src/main/java/marquez/common/models/NamespaceName.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/common/models/OwnerName.java
+++ b/api/src/main/java/marquez/common/models/OwnerName.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/common/models/RunId.java
+++ b/api/src/main/java/marquez/common/models/RunId.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/common/models/RunState.java
+++ b/api/src/main/java/marquez/common/models/RunState.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/common/models/SourceName.java
+++ b/api/src/main/java/marquez/common/models/SourceName.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/common/models/SourceType.java
+++ b/api/src/main/java/marquez/common/models/SourceType.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/common/models/TagName.java
+++ b/api/src/main/java/marquez/common/models/TagName.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/common/models/Version.java
+++ b/api/src/main/java/marquez/common/models/Version.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/main/java/marquez/db/BaseDao.java
+++ b/api/src/main/java/marquez/db/BaseDao.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db;
 
 import org.jdbi.v3.sqlobject.CreateSqlObject;

--- a/api/src/main/java/marquez/db/Columns.java
+++ b/api/src/main/java/marquez/db/Columns.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/DatasetDao.java
+++ b/api/src/main/java/marquez/db/DatasetDao.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/DatasetFieldDao.java
+++ b/api/src/main/java/marquez/db/DatasetFieldDao.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/DatasetVersionDao.java
+++ b/api/src/main/java/marquez/db/DatasetVersionDao.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/DbMigration.java
+++ b/api/src/main/java/marquez/db/DbMigration.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db;
 
 import javax.sql.DataSource;

--- a/api/src/main/java/marquez/db/FlywayFactory.java
+++ b/api/src/main/java/marquez/db/FlywayFactory.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/JobContextDao.java
+++ b/api/src/main/java/marquez/db/JobContextDao.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/JobDao.java
+++ b/api/src/main/java/marquez/db/JobDao.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/JobVersionDao.java
+++ b/api/src/main/java/marquez/db/JobVersionDao.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/NamespaceDao.java
+++ b/api/src/main/java/marquez/db/NamespaceDao.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/api/src/main/java/marquez/db/RunArgsDao.java
+++ b/api/src/main/java/marquez/db/RunArgsDao.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/RunDao.java
+++ b/api/src/main/java/marquez/db/RunDao.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/RunStateDao.java
+++ b/api/src/main/java/marquez/db/RunStateDao.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/SearchDao.java
+++ b/api/src/main/java/marquez/db/SearchDao.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/SourceDao.java
+++ b/api/src/main/java/marquez/db/SourceDao.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/StreamVersionDao.java
+++ b/api/src/main/java/marquez/db/StreamVersionDao.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/TagDao.java
+++ b/api/src/main/java/marquez/db/TagDao.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/main/java/marquez/db/mappers/DatasetDataMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetDataMapper.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db.mappers;
 
 import static marquez.db.Columns.stringOrNull;

--- a/api/src/main/java/marquez/db/mappers/DatasetFieldMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetFieldMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/DatasetFieldRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetFieldRowMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/DatasetMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/DatasetRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetRowMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/DatasetVersionMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetVersionMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/DatasetVersionRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetVersionRowMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/ExtendedDatasetVersionRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/ExtendedDatasetVersionRowMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/ExtendedJobVersionRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/ExtendedJobVersionRowMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/ExtendedRunRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/ExtendedRunRowMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/JobContextRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/JobContextRowMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/JobDataMapper.java
+++ b/api/src/main/java/marquez/db/mappers/JobDataMapper.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db.mappers;
 
 import static marquez.db.Columns.stringOrNull;

--- a/api/src/main/java/marquez/db/mappers/JobMapper.java
+++ b/api/src/main/java/marquez/db/mappers/JobMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/JobRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/JobRowMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/JobVersionMapper.java
+++ b/api/src/main/java/marquez/db/mappers/JobVersionMapper.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db.mappers;
 
 import static marquez.db.Columns.mapOrNull;

--- a/api/src/main/java/marquez/db/mappers/MapperUtils.java
+++ b/api/src/main/java/marquez/db/mappers/MapperUtils.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db.mappers;
 
 import static marquez.db.Columns.stringOrNull;

--- a/api/src/main/java/marquez/db/mappers/NamespaceMapper.java
+++ b/api/src/main/java/marquez/db/mappers/NamespaceMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/NamespaceRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/NamespaceRowMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/OwnerRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/OwnerRowMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/RunArgsRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/RunArgsRowMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/RunMapper.java
+++ b/api/src/main/java/marquez/db/mappers/RunMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/RunStateRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/RunStateRowMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/SearchResultMapper.java
+++ b/api/src/main/java/marquez/db/mappers/SearchResultMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/SourceMapper.java
+++ b/api/src/main/java/marquez/db/mappers/SourceMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/SourceRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/SourceRowMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/TagMapper.java
+++ b/api/src/main/java/marquez/db/mappers/TagMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/mappers/TagRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/TagRowMapper.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.mappers;
 

--- a/api/src/main/java/marquez/db/models/DatasetData.java
+++ b/api/src/main/java/marquez/db/models/DatasetData.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/api/src/main/java/marquez/db/models/DatasetFieldRow.java
+++ b/api/src/main/java/marquez/db/models/DatasetFieldRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/DatasetRow.java
+++ b/api/src/main/java/marquez/db/models/DatasetRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/DatasetVersionRow.java
+++ b/api/src/main/java/marquez/db/models/DatasetVersionRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/ExtendedDatasetVersionRow.java
+++ b/api/src/main/java/marquez/db/models/ExtendedDatasetVersionRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/ExtendedJobVersionRow.java
+++ b/api/src/main/java/marquez/db/models/ExtendedJobVersionRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/ExtendedRunRow.java
+++ b/api/src/main/java/marquez/db/models/ExtendedRunRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/JobContextRow.java
+++ b/api/src/main/java/marquez/db/models/JobContextRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/JobData.java
+++ b/api/src/main/java/marquez/db/models/JobData.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/api/src/main/java/marquez/db/models/JobRow.java
+++ b/api/src/main/java/marquez/db/models/JobRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/JobVersionRow.java
+++ b/api/src/main/java/marquez/db/models/JobVersionRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/NamespaceRow.java
+++ b/api/src/main/java/marquez/db/models/NamespaceRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/NodeData.java
+++ b/api/src/main/java/marquez/db/models/NodeData.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db.models;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;

--- a/api/src/main/java/marquez/db/models/OwnerRow.java
+++ b/api/src/main/java/marquez/db/models/OwnerRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/RunArgsRow.java
+++ b/api/src/main/java/marquez/db/models/RunArgsRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/RunRow.java
+++ b/api/src/main/java/marquez/db/models/RunRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/RunStateRow.java
+++ b/api/src/main/java/marquez/db/models/RunStateRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/SourceRow.java
+++ b/api/src/main/java/marquez/db/models/SourceRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/TagRow.java
+++ b/api/src/main/java/marquez/db/models/TagRow.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db.models;
 

--- a/api/src/main/java/marquez/db/models/UpdateLineageRow.java
+++ b/api/src/main/java/marquez/db/models/UpdateLineageRow.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db.models;
 
 import java.util.List;

--- a/api/src/main/java/marquez/graphql/GraphqlConfig.java
+++ b/api/src/main/java/marquez/graphql/GraphqlConfig.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.graphql;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/api/src/main/java/marquez/graphql/GraphqlDaos.java
+++ b/api/src/main/java/marquez/graphql/GraphqlDaos.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.graphql;
 
 import java.util.List;

--- a/api/src/main/java/marquez/graphql/GraphqlDataFetchers.java
+++ b/api/src/main/java/marquez/graphql/GraphqlDataFetchers.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.graphql;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/api/src/main/java/marquez/graphql/GraphqlSchemaBuilder.java
+++ b/api/src/main/java/marquez/graphql/GraphqlSchemaBuilder.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.graphql;
 
 import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;

--- a/api/src/main/java/marquez/graphql/MarquezGraphqlServletBuilder.java
+++ b/api/src/main/java/marquez/graphql/MarquezGraphqlServletBuilder.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.graphql;
 
 import graphql.kickstart.execution.GraphQLQueryInvoker;

--- a/api/src/main/java/marquez/graphql/mapper/LineageResultMapper.java
+++ b/api/src/main/java/marquez/graphql/mapper/LineageResultMapper.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.graphql.mapper;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/api/src/main/java/marquez/graphql/mapper/ObjectMapMapper.java
+++ b/api/src/main/java/marquez/graphql/mapper/ObjectMapMapper.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.graphql.mapper;
 
 import com.google.common.base.CaseFormat;

--- a/api/src/main/java/marquez/graphql/mapper/RowMap.java
+++ b/api/src/main/java/marquez/graphql/mapper/RowMap.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.graphql.mapper;
 
 import java.util.HashMap;

--- a/api/src/main/java/marquez/service/DatasetFieldService.java
+++ b/api/src/main/java/marquez/service/DatasetFieldService.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service;
 
 import lombok.extern.slf4j.Slf4j;

--- a/api/src/main/java/marquez/service/DatasetService.java
+++ b/api/src/main/java/marquez/service/DatasetService.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service;
 

--- a/api/src/main/java/marquez/service/DatasetVersionService.java
+++ b/api/src/main/java/marquez/service/DatasetVersionService.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service;
 
 import marquez.db.BaseDao;

--- a/api/src/main/java/marquez/service/DelegatingDaos.java
+++ b/api/src/main/java/marquez/service/DelegatingDaos.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service;
 
 import lombok.RequiredArgsConstructor;

--- a/api/src/main/java/marquez/service/JobMetrics.java
+++ b/api/src/main/java/marquez/service/JobMetrics.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service;
 
 import io.prometheus.client.Counter;

--- a/api/src/main/java/marquez/service/JobService.java
+++ b/api/src/main/java/marquez/service/JobService.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service;
 

--- a/api/src/main/java/marquez/service/LineageService.java
+++ b/api/src/main/java/marquez/service/LineageService.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service;
 
 import com.google.common.base.Functions;

--- a/api/src/main/java/marquez/service/NamespaceService.java
+++ b/api/src/main/java/marquez/service/NamespaceService.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service;
 

--- a/api/src/main/java/marquez/service/NodeIdNotFoundException.java
+++ b/api/src/main/java/marquez/service/NodeIdNotFoundException.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service;
 
 import javax.ws.rs.NotFoundException;

--- a/api/src/main/java/marquez/service/RunService.java
+++ b/api/src/main/java/marquez/service/RunService.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service;
 
 import static marquez.common.models.RunState.COMPLETED;

--- a/api/src/main/java/marquez/service/RunTransitionListener.java
+++ b/api/src/main/java/marquez/service/RunTransitionListener.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service;
 
 import java.util.List;

--- a/api/src/main/java/marquez/service/ServiceFactory.java
+++ b/api/src/main/java/marquez/service/ServiceFactory.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service;
 
 import lombok.Builder;

--- a/api/src/main/java/marquez/service/SourceService.java
+++ b/api/src/main/java/marquez/service/SourceService.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service;
 

--- a/api/src/main/java/marquez/service/TagService.java
+++ b/api/src/main/java/marquez/service/TagService.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service;
 

--- a/api/src/main/java/marquez/service/models/BaseJsonModel.java
+++ b/api/src/main/java/marquez/service/models/BaseJsonModel.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service.models;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;

--- a/api/src/main/java/marquez/service/models/Dataset.java
+++ b/api/src/main/java/marquez/service/models/Dataset.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/DatasetMeta.java
+++ b/api/src/main/java/marquez/service/models/DatasetMeta.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/DatasetVersion.java
+++ b/api/src/main/java/marquez/service/models/DatasetVersion.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/DbTable.java
+++ b/api/src/main/java/marquez/service/models/DbTable.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/DbTableMeta.java
+++ b/api/src/main/java/marquez/service/models/DbTableMeta.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/DbTableVersion.java
+++ b/api/src/main/java/marquez/service/models/DbTableVersion.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/Edge.java
+++ b/api/src/main/java/marquez/service/models/Edge.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service.models;
 
 import java.util.Comparator;

--- a/api/src/main/java/marquez/service/models/Graph.java
+++ b/api/src/main/java/marquez/service/models/Graph.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service.models;
 
 import com.google.common.collect.ImmutableSortedSet;

--- a/api/src/main/java/marquez/service/models/Job.java
+++ b/api/src/main/java/marquez/service/models/Job.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/JobMeta.java
+++ b/api/src/main/java/marquez/service/models/JobMeta.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/Lineage.java
+++ b/api/src/main/java/marquez/service/models/Lineage.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service.models;
 
 import static com.google.common.collect.ImmutableSortedSet.toImmutableSortedSet;

--- a/api/src/main/java/marquez/service/models/LineageEvent.java
+++ b/api/src/main/java/marquez/service/models/LineageEvent.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service.models;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;

--- a/api/src/main/java/marquez/service/models/Namespace.java
+++ b/api/src/main/java/marquez/service/models/Namespace.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/NamespaceMeta.java
+++ b/api/src/main/java/marquez/service/models/NamespaceMeta.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/Node.java
+++ b/api/src/main/java/marquez/service/models/Node.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service.models;
 
 import static marquez.common.base.MorePreconditions.checkNotBlank;

--- a/api/src/main/java/marquez/service/models/NodeId.java
+++ b/api/src/main/java/marquez/service/models/NodeId.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service.models;
 
 import static com.google.common.base.Preconditions.checkArgument;

--- a/api/src/main/java/marquez/service/models/NodeType.java
+++ b/api/src/main/java/marquez/service/models/NodeType.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service.models;
 
 public enum NodeType {

--- a/api/src/main/java/marquez/service/models/Run.java
+++ b/api/src/main/java/marquez/service/models/Run.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/RunMeta.java
+++ b/api/src/main/java/marquez/service/models/RunMeta.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/Source.java
+++ b/api/src/main/java/marquez/service/models/Source.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/SourceMeta.java
+++ b/api/src/main/java/marquez/service/models/SourceMeta.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/Stream.java
+++ b/api/src/main/java/marquez/service/models/Stream.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/StreamMeta.java
+++ b/api/src/main/java/marquez/service/models/StreamMeta.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/StreamVersion.java
+++ b/api/src/main/java/marquez/service/models/StreamVersion.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/service/models/Tag.java
+++ b/api/src/main/java/marquez/service/models/Tag.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/main/java/marquez/tracing/SentryConfig.java
+++ b/api/src/main/java/marquez/tracing/SentryConfig.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.tracing;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/api/src/main/java/marquez/tracing/SentryPropagating.java
+++ b/api/src/main/java/marquez/tracing/SentryPropagating.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.tracing;
 
 import io.sentry.ISpan;

--- a/api/src/main/java/marquez/tracing/TracingContainerResponseFilter.java
+++ b/api/src/main/java/marquez/tracing/TracingContainerResponseFilter.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.tracing;
 
 import io.sentry.Sentry;

--- a/api/src/main/java/marquez/tracing/TracingSQLLogger.java
+++ b/api/src/main/java/marquez/tracing/TracingSQLLogger.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.tracing;
 
 import com.codahale.metrics.jdbi3.strategies.SmartNameStrategy;

--- a/api/src/main/java/marquez/tracing/TracingServletFilter.java
+++ b/api/src/main/java/marquez/tracing/TracingServletFilter.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.tracing;
 
 import io.sentry.ITransaction;

--- a/api/src/main/resources/assets/graphql-playground/index.htm
+++ b/api/src/main/resources/assets/graphql-playground/index.htm
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <!DOCTYPE html>
 
 <html>

--- a/api/src/main/resources/marquez/db/migration/V10__drop_unique_constraint_on_job_name.sql
+++ b/api/src/main/resources/marquez/db/migration/V10__drop_unique_constraint_on_job_name.sql
@@ -1,1 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE jobs DROP CONSTRAINT jobs_name_key;

--- a/api/src/main/resources/marquez/db/migration/V11__alter_datasets_to_rename_last_modified.sql
+++ b/api/src/main/resources/marquez/db/migration/V11__alter_datasets_to_rename_last_modified.sql
@@ -1,1 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE datasets RENAME last_modified TO last_modified_at;

--- a/api/src/main/resources/marquez/db/migration/V12__alter_dataset_fields_to_change_unique_constraint.sql
+++ b/api/src/main/resources/marquez/db/migration/V12__alter_dataset_fields_to_change_unique_constraint.sql
@@ -1,2 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE dataset_fields DROP CONSTRAINT dataset_fields_dataset_uuid_name_key;
 ALTER TABLE dataset_fields ADD UNIQUE (dataset_uuid, name, type);

--- a/api/src/main/resources/marquez/db/migration/V13__alter_run_add_start_end_state.sql
+++ b/api/src/main/resources/marquez/db/migration/V13__alter_run_add_start_end_state.sql
@@ -1,2 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE runs ADD start_run_state_uuid UUID REFERENCES run_states(uuid);
 ALTER TABLE runs ADD end_run_state_uuid UUID REFERENCES run_states(uuid);

--- a/api/src/main/resources/marquez/db/migration/V14__index_datasetversion_datasetid.sql
+++ b/api/src/main/resources/marquez/db/migration/V14__index_datasetversion_datasetid.sql
@@ -1,1 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 CREATE INDEX datasetversion_datasetid_idx ON dataset_versions (dataset_uuid);

--- a/api/src/main/resources/marquez/db/migration/V15__index_created_at_and_current_run_state_on_runs.sql
+++ b/api/src/main/resources/marquez/db/migration/V15__index_created_at_and_current_run_state_on_runs.sql
@@ -1,2 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 create index runs_created_at_current_run_state_index
     on runs (created_at desc, current_run_state);

--- a/api/src/main/resources/marquez/db/migration/V16__index_created_at_on_runs.sql
+++ b/api/src/main/resources/marquez/db/migration/V16__index_created_at_on_runs.sql
@@ -1,2 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 create index runs_created_at_index
     on runs (created_at desc);

--- a/api/src/main/resources/marquez/db/migration/V17.1__unique_version_constraint.sql
+++ b/api/src/main/resources/marquez/db/migration/V17.1__unique_version_constraint.sql
@@ -1,2 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE dataset_versions ADD CONSTRAINT dataset_versions_version UNIQUE(version);
 ALTER TABLE job_versions ADD CONSTRAINT job_versions_version UNIQUE(version);

--- a/api/src/main/resources/marquez/db/migration/V17.2__open_lineage.sql
+++ b/api/src/main/resources/marquez/db/migration/V17.2__open_lineage.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 CREATE TABLE lineage_events (
   event_time timestamp with time zone,
   event jsonb,

--- a/api/src/main/resources/marquez/db/migration/V18__drop_dataset_constraint.sql
+++ b/api/src/main/resources/marquez/db/migration/V18__drop_dataset_constraint.sql
@@ -1,1 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 alter table datasets drop constraint datasets_source_uuid_physical_name_key;

--- a/api/src/main/resources/marquez/db/migration/V19__alter_run_to_add_external_id.sql
+++ b/api/src/main/resources/marquez/db/migration/V19__alter_run_to_add_external_id.sql
@@ -1,1 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE runs ADD external_id VARCHAR(255);

--- a/api/src/main/resources/marquez/db/migration/V1__initial_schema.sql
+++ b/api/src/main/resources/marquez/db/migration/V1__initial_schema.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 CREATE TABLE namespaces (
   uuid               UUID PRIMARY KEY,
   created_at         TIMESTAMP NOT NULL,

--- a/api/src/main/resources/marquez/db/migration/V2.1__alter_job_versions_to_add_job_context_uuid.sql
+++ b/api/src/main/resources/marquez/db/migration/V2.1__alter_job_versions_to_add_job_context_uuid.sql
@@ -1,1 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE job_versions ADD job_context_uuid UUID NOT NULL;

--- a/api/src/main/resources/marquez/db/migration/V20__drop_lineage_pk.sql
+++ b/api/src/main/resources/marquez/db/migration/V20__drop_lineage_pk.sql
@@ -1,1 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE lineage_events DROP CONSTRAINT lineage_event_pk;

--- a/api/src/main/resources/marquez/db/migration/V21__alter_jobs_to_add_namespace_name.sql
+++ b/api/src/main/resources/marquez/db/migration/V21__alter_jobs_to_add_namespace_name.sql
@@ -1,2 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE jobs ADD namespace_name VARCHAR(255);
 UPDATE jobs SET namespace_name = namespaces.name FROM namespaces WHERE jobs.namespace_uuid = namespaces.uuid;

--- a/api/src/main/resources/marquez/db/migration/V22__alter_job_versions_to_add_namespace.sql
+++ b/api/src/main/resources/marquez/db/migration/V22__alter_job_versions_to_add_namespace.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE job_versions ADD namespace_uuid UUID;
 ALTER TABLE job_versions ADD namespace_name VARCHAR(255);
 ALTER TABLE job_versions ADD job_name VARCHAR(255);

--- a/api/src/main/resources/marquez/db/migration/V23__alter_runs.sql
+++ b/api/src/main/resources/marquez/db/migration/V23__alter_runs.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE runs ADD namespace_name varchar;
 ALTER TABLE runs ADD job_name varchar;
 ALTER TABLE runs ADD location varchar;

--- a/api/src/main/resources/marquez/db/migration/V24__alter_jobs.sql
+++ b/api/src/main/resources/marquez/db/migration/V24__alter_jobs.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE jobs ADD current_job_context_uuid UUID;
 ALTER TABLE jobs ADD current_location varchar;
 ALTER TABLE jobs ADD current_inputs JSONB;

--- a/api/src/main/resources/marquez/db/migration/V25__alter_datasets.sql
+++ b/api/src/main/resources/marquez/db/migration/V25__alter_datasets.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE datasets ADD namespace_name varchar;
 
 UPDATE datasets SET

--- a/api/src/main/resources/marquez/db/migration/V26__alter_jobs_change_type.sql
+++ b/api/src/main/resources/marquez/db/migration/V26__alter_jobs_change_type.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE jobs
   ALTER COLUMN namespace_name TYPE VARCHAR;
 ALTER TABLE jobs

--- a/api/src/main/resources/marquez/db/migration/V27__alter_runs_add_context.sql
+++ b/api/src/main/resources/marquez/db/migration/V27__alter_runs_add_context.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE runs ADD job_context_uuid uuid;
 
 UPDATE runs SET

--- a/api/src/main/resources/marquez/db/migration/V28__update_jobs_fix_inputs.sql
+++ b/api/src/main/resources/marquez/db/migration/V28__update_jobs_fix_inputs.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 UPDATE jobs SET (current_inputs) = (select jsonb_agg(query) from
     (select distinct ds.namespace_name as "namespace", ds.name as "name"
      from job_versions_io_mapping m inner join job_versions jv on m.job_version_uuid = jv.uuid inner join datasets ds on m.dataset_uuid = ds.uuid

--- a/api/src/main/resources/marquez/db/migration/V29__alter_dataset_versions_add_fields.sql
+++ b/api/src/main/resources/marquez/db/migration/V29__alter_dataset_versions_add_fields.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 -- Denormalize fields to dataset versions
 alter table dataset_versions add column fields jsonb;
 UPDATE dataset_versions SET (fields) = (select jsonb_agg((select x from (select distinct f.name, f.type, f.description,

--- a/api/src/main/resources/marquez/db/migration/V2__add_job_contexts.sql
+++ b/api/src/main/resources/marquez/db/migration/V2__add_job_contexts.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 CREATE TABLE job_contexts (
   uuid       UUID PRIMARY KEY,
   created_at TIMESTAMP NOT NULL,

--- a/api/src/main/resources/marquez/db/migration/V30__alter_runs_change_transitioned_at_type.sql
+++ b/api/src/main/resources/marquez/db/migration/V30__alter_runs_change_transitioned_at_type.sql
@@ -1,2 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 alter table runs alter column transitioned_at type timestamp without time zone
     USING transitioned_at::timestamp without time zone;

--- a/api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql
+++ b/api/src/main/resources/marquez/db/migration/V31__alter_job_io_mapping.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 create table job_versions_io_mapping_inputs as select * from job_versions_io_mapping where io_type = 'INPUT';
 create table job_versions_io_mapping_outputs as select * from job_versions_io_mapping where io_type = 'OUTPUT';
 alter table job_versions_io_mapping_inputs add column job_uuid uuid;

--- a/api/src/main/resources/marquez/db/migration/V32__index_runs_created_at.sql
+++ b/api/src/main/resources/marquez/db/migration/V32__index_runs_created_at.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 create index runs_created_at_by_name_index
     on runs(job_name, namespace_name, created_at DESC)
     include (uuid, created_at, updated_at, nominal_start_time, nominal_end_time, current_run_state, started_at, ended_at, namespace_name, job_name, location);

--- a/api/src/main/resources/marquez/db/migration/V33__index_lineage_events_run_id.sql
+++ b/api/src/main/resources/marquez/db/migration/V33__index_lineage_events_run_id.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE lineage_events
     ADD run_uuid uuid;
 

--- a/api/src/main/resources/marquez/db/migration/V34__drop_not_null_constraint_on_field_type.sql
+++ b/api/src/main/resources/marquez/db/migration/V34__drop_not_null_constraint_on_field_type.sql
@@ -1,1 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE dataset_fields ALTER COLUMN type DROP NOT NULL;

--- a/api/src/main/resources/marquez/db/migration/V35__drop_io_mapping_tables.sql
+++ b/api/src/main/resources/marquez/db/migration/V35__drop_io_mapping_tables.sql
@@ -1,2 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 DROP TABLE job_versions_io_mapping_inputs;
 DROP TABLE job_versions_io_mapping_outputs;

--- a/api/src/main/resources/marquez/db/migration/V36__drop_run_id_column_in_lineage_events.sql
+++ b/api/src/main/resources/marquez/db/migration/V36__drop_run_id_column_in_lineage_events.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 DROP TRIGGER lineage_events_run_uuid ON lineage_events;
 DROP FUNCTION write_run_uuid;
 ALTER TABLE lineage_events DROP COLUMN run_id;

--- a/api/src/main/resources/marquez/db/migration/V37__alter_dataset_fields_to_change_type.sql
+++ b/api/src/main/resources/marquez/db/migration/V37__alter_dataset_fields_to_change_type.sql
@@ -1,1 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE dataset_fields ALTER COLUMN type TYPE TEXT;

--- a/api/src/main/resources/marquez/db/migration/V3__drop_not_null_constraint_on_job_location.sql
+++ b/api/src/main/resources/marquez/db/migration/V3__drop_not_null_constraint_on_job_location.sql
@@ -1,1 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE job_versions ALTER COLUMN location DROP NOT NULL;

--- a/api/src/main/resources/marquez/db/migration/V4__add_dataset_fields.sql
+++ b/api/src/main/resources/marquez/db/migration/V4__add_dataset_fields.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 CREATE TABLE dataset_fields (
   uuid         UUID PRIMARY KEY,
   type         VARCHAR(64) NOT NULL,

--- a/api/src/main/resources/marquez/db/migration/V5__add_tags.sql
+++ b/api/src/main/resources/marquez/db/migration/V5__add_tags.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 CREATE TABLE tags (
   uuid        UUID PRIMARY KEY,
   created_at  TIMESTAMP NOT NULL,

--- a/api/src/main/resources/marquez/db/migration/V6__alter_datasets_to_add_last_modified.sql
+++ b/api/src/main/resources/marquez/db/migration/V6__alter_datasets_to_add_last_modified.sql
@@ -1,1 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE datasets ADD last_modified TIMESTAMP;

--- a/api/src/main/resources/marquez/db/migration/V7__alter_run_args_to_change_args.sql
+++ b/api/src/main/resources/marquez/db/migration/V7__alter_run_args_to_change_args.sql
@@ -1,1 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE run_args ALTER COLUMN args TYPE TEXT;

--- a/api/src/main/resources/marquez/db/migration/V8__alter_datasets_to_change_unique_constraint.sql
+++ b/api/src/main/resources/marquez/db/migration/V8__alter_datasets_to_change_unique_constraint.sql
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE datasets DROP CONSTRAINT datasets_namespace_uuid_source_uuid_name_physical_name_key;
 ALTER TABLE datasets ADD UNIQUE (namespace_uuid, name);
 ALTER TABLE datasets ADD UNIQUE (source_uuid, physical_name);

--- a/api/src/main/resources/marquez/db/migration/V9__alter_sources_to_drop_composite_unique_constraint.sql
+++ b/api/src/main/resources/marquez/db/migration/V9__alter_sources_to_drop_composite_unique_constraint.sql
@@ -1,1 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 ALTER TABLE sources DROP CONSTRAINT sources_name_connection_url_key;

--- a/api/src/test/java/marquez/BaseIntegrationTest.java
+++ b/api/src/test/java/marquez/BaseIntegrationTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;

--- a/api/src/test/java/marquez/DatasetIntegrationTest.java
+++ b/api/src/test/java/marquez/DatasetIntegrationTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/marquez/FlowIntegrationTest.java
+++ b/api/src/test/java/marquez/FlowIntegrationTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez;
 
 import static java.util.Map.entry;

--- a/api/src/test/java/marquez/Generator.java
+++ b/api/src/test/java/marquez/Generator.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez;
 

--- a/api/src/test/java/marquez/MarquezAppIntegrationTest.java
+++ b/api/src/test/java/marquez/MarquezAppIntegrationTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez;
 
 import static java.time.Instant.EPOCH;

--- a/api/src/test/java/marquez/NamespaceIntegrationTest.java
+++ b/api/src/test/java/marquez/NamespaceIntegrationTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/marquez/OpenLineageIntegrationTest.java
+++ b/api/src/test/java/marquez/OpenLineageIntegrationTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/marquez/PostgresContainer.java
+++ b/api/src/test/java/marquez/PostgresContainer.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez;
 

--- a/api/src/test/java/marquez/RunIntegrationTest.java
+++ b/api/src/test/java/marquez/RunIntegrationTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/marquez/TagIntegrationTest.java
+++ b/api/src/test/java/marquez/TagIntegrationTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/marquez/api/ApiTestUtils.java
+++ b/api/src/test/java/marquez/api/ApiTestUtils.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.api;
 
 import static org.mockito.Mockito.mock;

--- a/api/src/test/java/marquez/api/ApiTestUtilsTest.java
+++ b/api/src/test/java/marquez/api/ApiTestUtilsTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.api;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/marquez/api/OpenLineageResourceTest.java
+++ b/api/src/test/java/marquez/api/OpenLineageResourceTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/api/src/test/java/marquez/common/UtilsTest.java
+++ b/api/src/test/java/marquez/common/UtilsTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common;
 

--- a/api/src/test/java/marquez/common/api/JobResourceIntegrationTest.java
+++ b/api/src/test/java/marquez/common/api/JobResourceIntegrationTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.common.api;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/marquez/common/base/MorePreconditionsTest.java
+++ b/api/src/test/java/marquez/common/base/MorePreconditionsTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.base;
 

--- a/api/src/test/java/marquez/common/models/CommonModelGenerator.java
+++ b/api/src/test/java/marquez/common/models/CommonModelGenerator.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/test/java/marquez/common/models/RunIdTest.java
+++ b/api/src/test/java/marquez/common/models/RunIdTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.common.models;
 

--- a/api/src/test/java/marquez/db/ColumnsTest.java
+++ b/api/src/test/java/marquez/db/ColumnsTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/test/java/marquez/db/DatasetDaoTest.java
+++ b/api/src/test/java/marquez/db/DatasetDaoTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db;
 
 import static marquez.db.LineageTestUtils.NAMESPACE;

--- a/api/src/test/java/marquez/db/DbTestUtils.java
+++ b/api/src/test/java/marquez/db/DbTestUtils.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;

--- a/api/src/test/java/marquez/db/FlywayFactoryTest.java
+++ b/api/src/test/java/marquez/db/FlywayFactoryTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/test/java/marquez/db/JobDaoTest.java
+++ b/api/src/test/java/marquez/db/JobDaoTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db;
 
 import static org.junit.Assert.assertNull;

--- a/api/src/test/java/marquez/db/JobVersionDaoTest.java
+++ b/api/src/test/java/marquez/db/JobVersionDaoTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db;
 
 import static marquez.Generator.newTimestamp;

--- a/api/src/test/java/marquez/db/LineageDaoTest.java
+++ b/api/src/test/java/marquez/db/LineageDaoTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db;
 
 import static marquez.db.LineageTestUtils.NAMESPACE;

--- a/api/src/test/java/marquez/db/LineageTestUtils.java
+++ b/api/src/test/java/marquez/db/LineageTestUtils.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db;
 
 import java.net.URI;

--- a/api/src/test/java/marquez/db/NamespaceDaoTest.java
+++ b/api/src/test/java/marquez/db/NamespaceDaoTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/test/java/marquez/db/OpenLineageDaoTest.java
+++ b/api/src/test/java/marquez/db/OpenLineageDaoTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/marquez/db/RunDaoTest.java
+++ b/api/src/test/java/marquez/db/RunDaoTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db;
 
 import static marquez.common.models.CommonModelGenerator.newJobName;

--- a/api/src/test/java/marquez/db/SearchDaoTest.java
+++ b/api/src/test/java/marquez/db/SearchDaoTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.db;
 

--- a/api/src/test/java/marquez/db/mappers/DatasetMapperTest.java
+++ b/api/src/test/java/marquez/db/mappers/DatasetMapperTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db.mappers;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/marquez/db/mappers/JobMapperTest.java
+++ b/api/src/test/java/marquez/db/mappers/JobMapperTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db.mappers;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/marquez/db/models/DbModelGenerator.java
+++ b/api/src/test/java/marquez/db/models/DbModelGenerator.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.db.models;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;

--- a/api/src/test/java/marquez/graphql/GraphqlTest.java
+++ b/api/src/test/java/marquez/graphql/GraphqlTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.graphql;
 
 import static org.mockito.Mockito.mock;

--- a/api/src/test/java/marquez/graphql/LineageTest.java
+++ b/api/src/test/java/marquez/graphql/LineageTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.graphql;
 
 import static org.junit.Assert.assertTrue;

--- a/api/src/test/java/marquez/jdbi/JdbiExternalPostgresExtension.java
+++ b/api/src/test/java/marquez/jdbi/JdbiExternalPostgresExtension.java
@@ -1,16 +1,5 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.jdbi;
 
 import java.util.ArrayList;

--- a/api/src/test/java/marquez/jdbi/MarquezJdbiExternalPostgresExtension.java
+++ b/api/src/test/java/marquez/jdbi/MarquezJdbiExternalPostgresExtension.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.jdbi;
 
 import javax.sql.DataSource;

--- a/api/src/test/java/marquez/jdbi/Migration.java
+++ b/api/src/test/java/marquez/jdbi/Migration.java
@@ -1,16 +1,5 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.jdbi;
 
 import java.util.ArrayList;

--- a/api/src/test/java/marquez/service/LineageServiceTest.java
+++ b/api/src/test/java/marquez/service/LineageServiceTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service;
 
 import static marquez.db.LineageTestUtils.NAMESPACE;

--- a/api/src/test/java/marquez/service/OpenLineageServiceIntegrationTest.java
+++ b/api/src/test/java/marquez/service/OpenLineageServiceIntegrationTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/marquez/service/models/GraphTest.java
+++ b/api/src/test/java/marquez/service/models/GraphTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service.models;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/marquez/service/models/LineageEventTest.java
+++ b/api/src/test/java/marquez/service/models/LineageEventTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service.models;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/marquez/service/models/NodeIdTest.java
+++ b/api/src/test/java/marquez/service/models/NodeIdTest.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service.models;
 
 import static marquez.service.models.NodeId.VERSION_DELIM;

--- a/api/src/test/java/marquez/service/models/ServiceModelGenerator.java
+++ b/api/src/test/java/marquez/service/models/ServiceModelGenerator.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.service.models;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;

--- a/api/src/test/java/marquez/service/models/VersionTest.java
+++ b/api/src/test/java/marquez/service/models/VersionTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.service.models;
 

--- a/api/src/test/resources/config.test.yml
+++ b/api/src/test/resources/config.test.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 server:
   applicationConnectors:
   - type: http

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v2
 appVersion: "1.0"
 dependencies:

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.ingress.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/chart/templates/marquez/configmap.yaml
+++ b/chart/templates/marquez/configmap.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/chart/templates/marquez/deployment.yaml
+++ b/chart/templates/marquez/deployment.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/templates/marquez/secret.yaml
+++ b/chart/templates/marquez/secret.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if (not .Values.marquez.existingSecretName) -}}
 apiVersion: v1
 kind: Secret

--- a/chart/templates/marquez/service.yaml
+++ b/chart/templates/marquez/service.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/chart/templates/tests/marquez-test-connection.yaml
+++ b/chart/templates/tests/marquez-test-connection.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/chart/templates/tests/marquez-web-test-connection.yaml
+++ b/chart/templates/tests/marquez-web-test-connection.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.web.enabled }}
 apiVersion: v1
 kind: Pod

--- a/chart/templates/web/deployment.yaml
+++ b/chart/templates/web/deployment.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.web.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/chart/templates/web/service.yaml
+++ b/chart/templates/web/service.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.web.enabled }}
 apiVersion: v1
 kind: Service

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 ## This can be used to override the image registry at a global level, which
 ## can be useful when pulling from private hosts.
 ##

--- a/clients/java/src/main/java/marquez/client/Clients.java
+++ b/clients/java/src/main/java/marquez/client/Clients.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.client;
 
 import java.net.URL;

--- a/clients/java/src/main/java/marquez/client/MarquezClient.java
+++ b/clients/java/src/main/java/marquez/client/MarquezClient.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client;
 

--- a/clients/java/src/main/java/marquez/client/MarquezClientException.java
+++ b/clients/java/src/main/java/marquez/client/MarquezClientException.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client;
 

--- a/clients/java/src/main/java/marquez/client/MarquezHttp.java
+++ b/clients/java/src/main/java/marquez/client/MarquezHttp.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client;
 

--- a/clients/java/src/main/java/marquez/client/MarquezHttpException.java
+++ b/clients/java/src/main/java/marquez/client/MarquezHttpException.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client;
 

--- a/clients/java/src/main/java/marquez/client/MarquezPathV1.java
+++ b/clients/java/src/main/java/marquez/client/MarquezPathV1.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.client;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/clients/java/src/main/java/marquez/client/MarquezUrl.java
+++ b/clients/java/src/main/java/marquez/client/MarquezUrl.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.client;
 
 import static com.google.common.base.Preconditions.checkArgument;

--- a/clients/java/src/main/java/marquez/client/Utils.java
+++ b/clients/java/src/main/java/marquez/client/Utils.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client;
 

--- a/clients/java/src/main/java/marquez/client/models/Dataset.java
+++ b/clients/java/src/main/java/marquez/client/models/Dataset.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/DatasetId.java
+++ b/clients/java/src/main/java/marquez/client/models/DatasetId.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.client.models;
 
 import lombok.NonNull;

--- a/clients/java/src/main/java/marquez/client/models/DatasetMeta.java
+++ b/clients/java/src/main/java/marquez/client/models/DatasetMeta.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/DatasetType.java
+++ b/clients/java/src/main/java/marquez/client/models/DatasetType.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/DatasetVersion.java
+++ b/clients/java/src/main/java/marquez/client/models/DatasetVersion.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/DbTable.java
+++ b/clients/java/src/main/java/marquez/client/models/DbTable.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/DbTableMeta.java
+++ b/clients/java/src/main/java/marquez/client/models/DbTableMeta.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/DbTableVersion.java
+++ b/clients/java/src/main/java/marquez/client/models/DbTableVersion.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/Field.java
+++ b/clients/java/src/main/java/marquez/client/models/Field.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.client.models;
 
 import com.google.common.collect.ImmutableSet;

--- a/clients/java/src/main/java/marquez/client/models/Job.java
+++ b/clients/java/src/main/java/marquez/client/models/Job.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/JobId.java
+++ b/clients/java/src/main/java/marquez/client/models/JobId.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.client.models;
 
 import lombok.NonNull;

--- a/clients/java/src/main/java/marquez/client/models/JobMeta.java
+++ b/clients/java/src/main/java/marquez/client/models/JobMeta.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/JobType.java
+++ b/clients/java/src/main/java/marquez/client/models/JobType.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/JobVersion.java
+++ b/clients/java/src/main/java/marquez/client/models/JobVersion.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.client.models;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/clients/java/src/main/java/marquez/client/models/JobVersionId.java
+++ b/clients/java/src/main/java/marquez/client/models/JobVersionId.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.client.models;
 
 import java.util.UUID;

--- a/clients/java/src/main/java/marquez/client/models/Namespace.java
+++ b/clients/java/src/main/java/marquez/client/models/Namespace.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/NamespaceMeta.java
+++ b/clients/java/src/main/java/marquez/client/models/NamespaceMeta.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/Run.java
+++ b/clients/java/src/main/java/marquez/client/models/Run.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/RunMeta.java
+++ b/clients/java/src/main/java/marquez/client/models/RunMeta.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/RunState.java
+++ b/clients/java/src/main/java/marquez/client/models/RunState.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/SearchFilter.java
+++ b/clients/java/src/main/java/marquez/client/models/SearchFilter.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/SearchResult.java
+++ b/clients/java/src/main/java/marquez/client/models/SearchResult.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.client.models;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/clients/java/src/main/java/marquez/client/models/SearchResults.java
+++ b/clients/java/src/main/java/marquez/client/models/SearchResults.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.client.models;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/clients/java/src/main/java/marquez/client/models/SearchSort.java
+++ b/clients/java/src/main/java/marquez/client/models/SearchSort.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/Source.java
+++ b/clients/java/src/main/java/marquez/client/models/Source.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/SourceMeta.java
+++ b/clients/java/src/main/java/marquez/client/models/SourceMeta.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/Stream.java
+++ b/clients/java/src/main/java/marquez/client/models/Stream.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/StreamMeta.java
+++ b/clients/java/src/main/java/marquez/client/models/StreamMeta.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/StreamVersion.java
+++ b/clients/java/src/main/java/marquez/client/models/StreamVersion.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/main/java/marquez/client/models/Tag.java
+++ b/clients/java/src/main/java/marquez/client/models/Tag.java
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
 package marquez.client.models;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/clients/java/src/main/resources/config.properties
+++ b/clients/java/src/main/resources/config.properties
@@ -1,0 +1,1 @@
+version=@version@

--- a/clients/java/src/test/java/marquez/client/MarquezClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezClientTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client;
 

--- a/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client;
 

--- a/clients/java/src/test/java/marquez/client/MarquezPathV1Test.java
+++ b/clients/java/src/test/java/marquez/client/MarquezPathV1Test.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client;
 

--- a/clients/java/src/test/java/marquez/client/MarquezUrlTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezUrlTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client;
 

--- a/clients/java/src/test/java/marquez/client/UtilsTest.java
+++ b/clients/java/src/test/java/marquez/client/UtilsTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client;
 

--- a/clients/java/src/test/java/marquez/client/models/DbTableMetaTest.java
+++ b/clients/java/src/test/java/marquez/client/models/DbTableMetaTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/test/java/marquez/client/models/DbTableTest.java
+++ b/clients/java/src/test/java/marquez/client/models/DbTableTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/test/java/marquez/client/models/DbTableVersionTest.java
+++ b/clients/java/src/test/java/marquez/client/models/DbTableVersionTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/test/java/marquez/client/models/JobMetaTest.java
+++ b/clients/java/src/test/java/marquez/client/models/JobMetaTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/test/java/marquez/client/models/JobTest.java
+++ b/clients/java/src/test/java/marquez/client/models/JobTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/test/java/marquez/client/models/JsonGenerator.java
+++ b/clients/java/src/test/java/marquez/client/models/JsonGenerator.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/test/java/marquez/client/models/ModelGenerator.java
+++ b/clients/java/src/test/java/marquez/client/models/ModelGenerator.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/test/java/marquez/client/models/NamespaceMetaTest.java
+++ b/clients/java/src/test/java/marquez/client/models/NamespaceMetaTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/test/java/marquez/client/models/NamespaceTest.java
+++ b/clients/java/src/test/java/marquez/client/models/NamespaceTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/test/java/marquez/client/models/RunMetaTest.java
+++ b/clients/java/src/test/java/marquez/client/models/RunMetaTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/test/java/marquez/client/models/RunTest.java
+++ b/clients/java/src/test/java/marquez/client/models/RunTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/test/java/marquez/client/models/SourceMetaTest.java
+++ b/clients/java/src/test/java/marquez/client/models/SourceMetaTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/test/java/marquez/client/models/SourceTest.java
+++ b/clients/java/src/test/java/marquez/client/models/SourceTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/test/java/marquez/client/models/StreamMetaTest.java
+++ b/clients/java/src/test/java/marquez/client/models/StreamMetaTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/test/java/marquez/client/models/StreamTest.java
+++ b/clients/java/src/test/java/marquez/client/models/StreamTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/java/src/test/java/marquez/client/models/StreamVersionTest.java
+++ b/clients/java/src/test/java/marquez/client/models/StreamVersionTest.java
@@ -1,16 +1,4 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/* SPDX-License-Identifier: Apache-2.0 */
 
 package marquez.client.models;
 

--- a/clients/python/examples/simple.py
+++ b/clients/python/examples/simple.py
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 from marquez_client import Clients
 from marquez_client.models import (

--- a/clients/python/marquez_client/client.py
+++ b/clients/python/marquez_client/client.py
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 import json
 import logging

--- a/clients/python/marquez_client/clients.py
+++ b/clients/python/marquez_client/clients.py
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 import os
 

--- a/clients/python/marquez_client/constants.py
+++ b/clients/python/marquez_client/constants.py
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 DEFAULT_TIMEOUT_MS = 10000
 DEFAULT_NAMESPACE_NAME = 'default'

--- a/clients/python/marquez_client/errors.py
+++ b/clients/python/marquez_client/errors.py
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 class MarquezError(Exception):
     pass

--- a/clients/python/marquez_client/models.py
+++ b/clients/python/marquez_client/models.py
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum
 

--- a/clients/python/marquez_client/utils.py
+++ b/clients/python/marquez_client/utils.py
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 import json
 import uuid

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -1,16 +1,6 @@
 #!/usr/bin/env python
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 #
 # -*- coding: utf-8 -*-
 

--- a/clients/python/tests/__init__.py
+++ b/clients/python/tests/__init__.py
@@ -1,13 +1,3 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 #
 # -*- coding: utf-8 -*-

--- a/clients/python/tests/pytest.ini
+++ b/clients/python/tests/pytest.ini
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 [pytest]
 log_cli_level = DEBUG

--- a/clients/python/tests/test_marquez_client.py
+++ b/clients/python/tests/test_marquez_client.py
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 import mock
 import pytest

--- a/clients/python/tests/test_marquez_clients.py
+++ b/clients/python/tests/test_marquez_clients.py
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 import os
 

--- a/clients/python/tests/test_utils.py
+++ b/clients/python/tests/test_utils.py
@@ -1,14 +1,5 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+
 from unittest.mock import patch, MagicMock
 
 import pytest

--- a/docker/build-and-push.sh
+++ b/docker/build-and-push.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Usage: $ ./build-and-push.sh <version>
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Usage: $ ./entrypoint.sh
 

--- a/docker/init-db.sh
+++ b/docker/init-db.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Usage: $ ./init-db.sh
 

--- a/docker/login.sh
+++ b/docker/login.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Usage: $ ./login.sh
 

--- a/docker/prune.sh
+++ b/docker/prune.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Usage: $ ./prune.sh
 
 set -e

--- a/docker/seed.sh
+++ b/docker/seed.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Usage: $ ./seed.sh
 

--- a/docker/up.sh
+++ b/docker/up.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 set -e
 

--- a/docker/wait-for-it.sh
+++ b/docker/wait-for-it.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # see: https://github.com/vishnubob/wait-for-it
 
 WAITFORIT_cmdname=${0##*/}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 title: Marquez
 description: Collect, aggregate, and visualize a data ecosystem's metadata
 

--- a/docs/_layouts/deployment-overview.html
+++ b/docs/_layouts/deployment-overview.html
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
 <head>

--- a/docs/_layouts/index.html
+++ b/docs/_layouts/index.html
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>

--- a/docs/_layouts/quickstart.html
+++ b/docs/_layouts/quickstart.html
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>

--- a/docs/_layouts/running-on-aws.html
+++ b/docs/_layouts/running-on-aws.html
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
 <head>

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 ## Migrating `marquez` database manually via [`flyway`](https://flywaydb.org)
 
 Before you can manually apply migrations to the `marquez` database, make sure you've installed `flyway`:

--- a/docs/deployment-overview.md
+++ b/docs/deployment-overview.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 ---
 layout: deployment-overview
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 ---
 layout: index
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 ---
 layout: quickstart
 ---

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # Lifecycle
 
 Marquez captures the runs of a job, and changes as they happen.

--- a/docs/run-state-transitions.md
+++ b/docs/run-state-transitions.md
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 # Run State Transitions
 Run states change based on the success or failure of a job run. The datasets consumed and/or produced

--- a/docs/running-on-aws.md
+++ b/docs/running-on-aws.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 ---
 layout: running-on-aws
 ---

--- a/examples/airflow/README.md
+++ b/examples/airflow/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # [Airflow](https://airflow.apache.org) Example
 
 In this example, we'll walk you through how to enable Airflow DAGs to send lineage metadata to Marquez using [OpenLineage](https://openlineage.io/). The example will help demonstrate some of the features of Marquez.

--- a/examples/airflow/docker-compose.yml
+++ b/examples/airflow/docker-compose.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 version: "3.7"
 services:
   airflow:

--- a/examples/airflow/docker/build.sh
+++ b/examples/airflow/docker/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 
 REPO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd ../../../ &> /dev/null && pwd )"
 cd $REPO_DIR/integrations/common && pip wheel --wheel-dir=$REPO_DIR/examples/airflow/tmp/whl .

--- a/examples/airflow/docker/init-db.sh
+++ b/examples/airflow/docker/init-db.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Usage: $ ./init-db.sh
 

--- a/examples/airflow/docker/wait-for-it.sh
+++ b/examples/airflow/docker/wait-for-it.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # see: https://github.com/vishnubob/wait-for-it
 
 WAITFORIT_cmdname=${0##*/}

--- a/marquez.example.yml
+++ b/marquez.example.yml
@@ -1,14 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 ### HTTP SERVER CONFIG ###
 

--- a/new-version.sh
+++ b/new-version.sh
@@ -1,19 +1,6 @@
 #!/bin/bash
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Requirements:
 #   * You're on the 'main' branch

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 openapi: 3.0.2
 info:
   title: Marquez

--- a/web/docker/entrypoint.sh
+++ b/web/docker/entrypoint.sh
@@ -1,16 +1,6 @@
 #!/bin/sh
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Usage: $ ./entrypoint.sh
 

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/web/src/__tests__/components/AppBar.test.tsx
+++ b/web/src/__tests__/components/AppBar.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 describe('AppBar Test', () => {
   // TODO: There's an issue with rendering this component in jest
 

--- a/web/src/__tests__/components/DatasetDetailPage.test.tsx
+++ b/web/src/__tests__/components/DatasetDetailPage.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as React from 'react'
 import { mount } from 'enzyme'
 import Typography from '@material-ui/core/Typography'

--- a/web/src/__tests__/components/Dialog.test.tsx
+++ b/web/src/__tests__/components/Dialog.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as React from 'react'
 import { shallow } from 'enzyme'
 import Button from '@material-ui/core/Button'

--- a/web/src/__tests__/components/JobDetailPage.test.tsx
+++ b/web/src/__tests__/components/JobDetailPage.test.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as React from 'react'
 import { mount } from 'enzyme'
 import Box from '@material-ui/core/Box'

--- a/web/src/__tests__/helpers/index.test.ts
+++ b/web/src/__tests__/helpers/index.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { createNetworkData, formatUpdatedAt } from '../../helpers'
 const datasets = require('../../../docker/db/data/datasets.json')
 const jobs = require('../../../docker/db/data/jobs.json')

--- a/web/src/__tests__/reducers/datasets.test.ts
+++ b/web/src/__tests__/reducers/datasets.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as actionTypes from '../../store/actionCreators/actionTypes'
 import datasetsReducer, { initialState } from '../../store/reducers/datasets'
 

--- a/web/src/__tests__/reducers/jobs.test.ts
+++ b/web/src/__tests__/reducers/jobs.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as actionTypes from '../../store/actionCreators/actionTypes'
 import jobsReducer, { initialState } from '../../store/reducers/jobs'
 

--- a/web/src/__tests__/requests/index.test.ts
+++ b/web/src/__tests__/requests/index.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 
 import * as requestUtils from '../../store/requests'
 import { parseResponse } from '../../store/requests'

--- a/web/src/__tests__/sagas/index.test.ts
+++ b/web/src/__tests__/sagas/index.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as actionTypes from '../../store/actionCreators/actionTypes'
 import * as actions from '../../store/actionCreators'
 import * as api from '../../store/requests'

--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { Box, Container, CssBaseline } from '@material-ui/core'
 import { ConnectedRouter, routerMiddleware } from 'connected-react-router'
 import { Helmet } from 'react-helmet'

--- a/web/src/components/Dialog.tsx
+++ b/web/src/components/Dialog.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as React from 'react'
 import { dialogToggle } from '../store/actionCreators'
 import Button from '@material-ui/core/Button'

--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as React from 'react'
 import { IState } from '../store/reducers'
 import { Theme } from '@material-ui/core'

--- a/web/src/components/bottom-bar/BottomBar.tsx
+++ b/web/src/components/bottom-bar/BottomBar.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react'
 
 import { Box, Container, Theme } from '@material-ui/core'

--- a/web/src/components/core/chip/MqChip.tsx
+++ b/web/src/components/core/chip/MqChip.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import { Theme, createStyles } from '@material-ui/core'
 import Box from '@material-ui/core/Box'

--- a/web/src/components/core/chip/MqChipGroup.tsx
+++ b/web/src/components/core/chip/MqChipGroup.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react'
 
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'

--- a/web/src/components/core/code/MqCode.tsx
+++ b/web/src/components/core/code/MqCode.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { THEME_EXTRA } from '../../../helpers/theme'
 import { Theme, alpha } from '@material-ui/core/styles'
 import Box from '@material-ui/core/Box'

--- a/web/src/components/core/code/MqJson.tsx
+++ b/web/src/components/core/code/MqJson.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { THEME_EXTRA, theme } from '../../../helpers/theme'
 import { alpha } from '@material-ui/core/styles'
 import { ocean } from 'react-syntax-highlighter/dist/cjs/styles/hljs'

--- a/web/src/components/core/empty/MqEmpty.tsx
+++ b/web/src/components/core/empty/MqEmpty.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { Box, Theme, createStyles } from '@material-ui/core'
 import MqText from '../text/MqText'
 import React, { ReactElement } from 'react'

--- a/web/src/components/core/icon-button/MqIconButton.tsx
+++ b/web/src/components/core/icon-button/MqIconButton.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import React, { ReactElement } from 'react'
 import classNames from 'classnames'
 

--- a/web/src/components/core/input-base/MqInputBase.tsx
+++ b/web/src/components/core/input-base/MqInputBase.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { Theme, createStyles, withStyles } from '@material-ui/core'
 import { alpha } from '@material-ui/core/styles'
 import InputBase from '@material-ui/core/InputBase'

--- a/web/src/components/core/screen-load/MqScreenLoad.tsx
+++ b/web/src/components/core/screen-load/MqScreenLoad.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { HEADER_HEIGHT } from '../../../helpers/theme'
 import Box from '@material-ui/core/Box/Box'
 import CircularProgress from '@material-ui/core/CircularProgress/CircularProgress'

--- a/web/src/components/core/small-icon/MqSmallIcon.tsx
+++ b/web/src/components/core/small-icon/MqSmallIcon.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons'
 import Box from '@material-ui/core/Box'

--- a/web/src/components/core/text/MqText.tsx
+++ b/web/src/components/core/text/MqText.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import React, { ReactElement } from 'react'
 
 import { Link } from 'react-router-dom'

--- a/web/src/components/datasets/DatasetDetailPage.tsx
+++ b/web/src/components/datasets/DatasetDetailPage.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import React, { ChangeEvent, FunctionComponent, SetStateAction, useEffect } from 'react'
 
 import * as Redux from 'redux'

--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { Box, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core'
 import { Field } from '../../types/api'
 import MqEmpty from '../core/empty/MqEmpty'

--- a/web/src/components/datasets/DatasetVersions.tsx
+++ b/web/src/components/datasets/DatasetVersions.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { ArrowBackIosRounded } from '@material-ui/icons'
 import { Box, Chip, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core'
 import { DatasetVersion } from '../../types/api'

--- a/web/src/components/header/Header.tsx
+++ b/web/src/components/header/Header.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { API_DOCS_URL } from '../../globals'
 import { AppBar, Toolbar } from '@material-ui/core'
 import { DRAWER_WIDTH } from '../../helpers/theme'

--- a/web/src/components/jobs/JobDetailPage.tsx
+++ b/web/src/components/jobs/JobDetailPage.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import React, { ChangeEvent, FunctionComponent, SetStateAction, useEffect } from 'react'
 
 import * as Redux from 'redux'

--- a/web/src/components/jobs/RunInfo.tsx
+++ b/web/src/components/jobs/RunInfo.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { Box } from '@material-ui/core'
 import { Run } from '../../types/api'
 import { formatUpdatedAt } from '../../helpers'

--- a/web/src/components/jobs/RunStatus.tsx
+++ b/web/src/components/jobs/RunStatus.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { Box, Theme, Tooltip, WithStyles, createStyles, withStyles } from '@material-ui/core'
 import { Run } from '../../types/api'
 

--- a/web/src/components/jobs/Runs.tsx
+++ b/web/src/components/jobs/Runs.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { ArrowBackIosRounded } from '@material-ui/icons'
 import {
   Box,

--- a/web/src/components/lineage/Lineage.tsx
+++ b/web/src/components/lineage/Lineage.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react'
 
 import * as Redux from 'redux'

--- a/web/src/components/lineage/components/drag-bar/DragBar.tsx
+++ b/web/src/components/lineage/components/drag-bar/DragBar.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react'
 
 import * as Redux from 'redux'

--- a/web/src/components/lineage/components/edge/Edge.tsx
+++ b/web/src/components/lineage/components/edge/Edge.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { GraphEdge } from 'dagre'
 import { LinePath } from '@visx/shape'
 import { curveMonotoneX } from '@visx/curve'

--- a/web/src/components/lineage/components/node/Node.tsx
+++ b/web/src/components/lineage/components/node/Node.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react'
 
 import * as Redux from 'redux'

--- a/web/src/components/lineage/components/node/NodeText.tsx
+++ b/web/src/components/lineage/components/node/NodeText.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { Node as GraphNode } from 'dagre'
 import { MqNode } from '../../types'
 import { theme } from '../../../../helpers/theme'

--- a/web/src/components/lineage/config.ts
+++ b/web/src/components/lineage/config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 export const DAGRE_CONFIG = {
   rankdir: 'LR',
   marginx: 140,

--- a/web/src/components/lineage/types.ts
+++ b/web/src/components/lineage/types.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { Field, Run, Tag } from '../../types/api'
 import { Nullable } from '../../types/util/Nullable'
 

--- a/web/src/components/namespace-select/NamespaceSelect.tsx
+++ b/web/src/components/namespace-select/NamespaceSelect.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as Redux from 'redux'
 import { Box, FormControl, MenuItem, Select, WithStyles, createStyles } from '@material-ui/core'
 import { IState } from '../../store/reducers'

--- a/web/src/components/search/Search.tsx
+++ b/web/src/components/search/Search.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as Redux from 'redux'
 import { Box, Theme, createStyles, darken } from '@material-ui/core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/web/src/components/search/SearchListItem.tsx
+++ b/web/src/components/search/SearchListItem.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { Box, Theme, createStyles, darken } from '@material-ui/core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { JobOrDataset } from '../lineage/types'

--- a/web/src/components/search/SearchPlaceholder.tsx
+++ b/web/src/components/search/SearchPlaceholder.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { Box, Theme, createStyles } from '@material-ui/core'
 import { theme } from '../../helpers/theme'
 import MqText from '../core/text/MqText'

--- a/web/src/components/sidenav/Sidenav.tsx
+++ b/web/src/components/sidenav/Sidenav.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react'
 
 import createStyles from '@material-ui/core/styles/createStyles'

--- a/web/src/helpers/index.ts
+++ b/web/src/helpers/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { isoParse, timeFormat } from 'd3-time-format'
 
 export const capitalize = (word: string) => {

--- a/web/src/helpers/nodes.ts
+++ b/web/src/helpers/nodes.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { JobOrDataset, LineageDataset, LineageJob, MqNode } from '../components/lineage/types'
 import { Undefinable } from '../types/util/Nullable'
 

--- a/web/src/helpers/runs.ts
+++ b/web/src/helpers/runs.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 const globalStyles = require('../global_styles.css')
 const { jobRunNew, jobRunFailed, jobRunCompleted, jobRunAborted, jobRunRunning } = globalStyles
 

--- a/web/src/helpers/theme.ts
+++ b/web/src/helpers/theme.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { createTheme } from '@material-ui/core'
 
 export const theme = createTheme({

--- a/web/src/helpers/time.ts
+++ b/web/src/helpers/time.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import moment from 'moment'
 
 function addLeadingZero(number: number) {

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 <!DOCTYPE html>
 <html>
   <head>

--- a/web/src/index.prod.html
+++ b/web/src/index.prod.html
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 <!DOCTYPE html>
 <html>
     <head>

--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as Redux from 'redux'
 import { Container, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core'
 import { Dataset } from '../../types/api'

--- a/web/src/routes/jobs/Jobs.tsx
+++ b/web/src/routes/jobs/Jobs.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as Redux from 'redux'
 import { Container, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core'
 import { IState } from '../../store/reducers'

--- a/web/src/store/actionCreators/actionTypes.ts
+++ b/web/src/store/actionCreators/actionTypes.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 export const APPLICATION_ERROR = 'APPLICATION_ERROR'
 export const DIALOG_TOGGLE = 'DIALOG_TOGGLE'
 

--- a/web/src/store/actionCreators/index.ts
+++ b/web/src/store/actionCreators/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as actionTypes from './actionTypes'
 
 import { Dataset, DatasetVersion, Job, LineageGraph, Namespace, Run, Search } from '../../types/api'

--- a/web/src/store/reducers/datasetVersions.ts
+++ b/web/src/store/reducers/datasetVersions.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { DatasetVersions } from '../../types/api'
 import {
   FETCH_DATASET_VERSIONS,

--- a/web/src/store/reducers/datasets.ts
+++ b/web/src/store/reducers/datasets.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { Dataset } from '../../types/api'
 import {
   FETCH_DATASETS,

--- a/web/src/store/reducers/display.ts
+++ b/web/src/store/reducers/display.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { APPLICATION_ERROR, DIALOG_TOGGLE } from '../actionCreators/actionTypes'
 
 interface IToggleExpandAction {

--- a/web/src/store/reducers/index.ts
+++ b/web/src/store/reducers/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { History } from 'history'
 import { Reducer, combineReducers } from 'redux'
 import { connectRouter } from 'connected-react-router'

--- a/web/src/store/reducers/jobs.ts
+++ b/web/src/store/reducers/jobs.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { FETCH_JOBS, FETCH_JOBS_SUCCESS, RESET_JOBS } from '../actionCreators/actionTypes'
 import { IJob } from '../../types'
 import { fetchJobsSuccess } from '../actionCreators'

--- a/web/src/store/reducers/lineage.ts
+++ b/web/src/store/reducers/lineage.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import {
   FETCH_LINEAGE_SUCCESS,
   RESET_LINEAGE,

--- a/web/src/store/reducers/namespaces.ts
+++ b/web/src/store/reducers/namespaces.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { Namespace } from '../../types/api'
 
 import { FETCH_NAMESPACES_SUCCESS, SELECT_NAMESPACE } from '../actionCreators/actionTypes'

--- a/web/src/store/reducers/runs.ts
+++ b/web/src/store/reducers/runs.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { FETCH_RUNS, FETCH_RUNS_SUCCESS, RESET_RUNS } from '../actionCreators/actionTypes'
 import { Run } from '../../types/api'
 import { fetchRunsSuccess } from '../actionCreators'

--- a/web/src/store/reducers/search.ts
+++ b/web/src/store/reducers/search.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { FETCH_SEARCH, FETCH_SEARCH_SUCCESS } from '../actionCreators/actionTypes'
 
 import { GroupedSearch, GroupedSearchResult } from '../../types/api'

--- a/web/src/store/requests/datasets.ts
+++ b/web/src/store/requests/datasets.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { API_URL } from '../../globals'
 import { DatasetVersions, Datasets } from '../../types/api'
 import { genericFetchWrapper } from './index'

--- a/web/src/store/requests/index.ts
+++ b/web/src/store/requests/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { APIError, HttpMethod } from '../../types'
 
 export const genericErrorMessageConstructor = (functionName: string, error: APIError): string => {

--- a/web/src/store/requests/jobs.ts
+++ b/web/src/store/requests/jobs.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { API_URL } from '../../globals'
 import { Job, Jobs, Run } from '../../types/api'
 import { genericFetchWrapper } from './index'

--- a/web/src/store/requests/lineage.ts
+++ b/web/src/store/requests/lineage.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { API_URL } from '../../globals'
 import { JobOrDataset } from '../../components/lineage/types'
 import { LineageGraph } from '../../types/api'

--- a/web/src/store/requests/namespaces.ts
+++ b/web/src/store/requests/namespaces.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { API_URL } from '../../globals'
 import { Namespaces } from '../../types/api'
 import { genericFetchWrapper } from './index'

--- a/web/src/store/requests/search.ts
+++ b/web/src/store/requests/search.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { API_URL } from '../../globals'
 import { Search } from '../../types/api'
 import { genericFetchWrapper } from './index'

--- a/web/src/store/sagas/index.ts
+++ b/web/src/store/sagas/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as Effects from 'redux-saga/effects'
 import {
   FETCH_DATASETS,

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { JobOrDataset, LineageNode } from '../components/lineage/types'
 
 export interface Tag {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { Job, Run } from './api'
 
 export type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'

--- a/web/src/types/util/Nullable.ts
+++ b/web/src/types/util/Nullable.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 export type Nullable<T> = T | null
 
 export type Undefinable<T> = T | undefined

--- a/web/src/types/util/groupBy.ts
+++ b/web/src/types/util/groupBy.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 export function groupBy<T, K extends keyof T>(list: T[], key: K) {
   const map = new Map<T[K], T[]>()
   list.forEach(item => {


### PR DESCRIPTION
### Problem

Licenses were in the block format or missing.

### Solution

Adds machine-readable SPDX licenses across the project.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
