### PR TITLE
add lifecycleStateChange support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/MarquezProject/marquez/compare/0.21.0...HEAD)
 
+### Added
+
+* Add support for `LifecycleStateChangeFacet` with an ability to softly delete datasets. 
+
 ## [0.21.0](https://github.com/MarquezProject/marquez/compare/0.20.0...0.21.0) - 2022-03-03
 
 ### Added

--- a/api/src/main/java/marquez/common/Utils.java
+++ b/api/src/main/java/marquez/common/Utils.java
@@ -204,6 +204,7 @@ public final class Utils {
    * @param sourceName The source name of the dataset.
    * @param physicalName The physical name of the dataset.
    * @param datasetName The dataset name.
+   * @param lifecycleState The dataset change like CREATE, DROP, TRUNCATE.
    * @param fields The fields of the dataset.
    * @param runId The UUID of the run linked to the dataset.
    * @return A {@link Version} object based on the specified job meta.
@@ -213,6 +214,7 @@ public final class Utils {
       String sourceName,
       String physicalName,
       String datasetName,
+      String lifecycleState,
       List<LineageEvent.SchemaField> fields,
       UUID runId) {
     DatasetVersionData data =
@@ -221,6 +223,7 @@ public final class Utils {
             .sourceName(sourceName)
             .physicalName(physicalName)
             .datasetName(datasetName)
+            .lifecycleState(lifecycleState)
             .schemaFields(fields)
             .runId(runId)
             .build();
@@ -259,6 +262,7 @@ public final class Utils {
                 data.getPhysicalName(),
                 data.getSchemaLocation(),
                 data.getFields().stream().map(Utils::joinField).collect(joining(VERSION_DELIM)),
+                data.getLifecycleState(),
                 data.getRunId())
             .getBytes(UTF_8);
     return Version.of(UUID.nameUUIDFromBytes(bytes));
@@ -275,6 +279,7 @@ public final class Utils {
     private String sourceName;
     private String physicalName;
     private String datasetName;
+    private String lifecycleState;
     private String schemaLocation;
     private Set<Triple<String, String, String>> fields;
     private UUID runId;

--- a/api/src/main/java/marquez/db/Columns.java
+++ b/api/src/main/java/marquez/db/Columns.java
@@ -69,9 +69,11 @@ public final class Columns {
   public static final String TAG_UUIDS = "tag_uuids";
   public static final String TAGGED_AT = "tagged_at";
   public static final String LAST_MODIFIED_AT = "last_modified_at";
+  public static final String IS_DELETED = "is_deleted";
 
   /* DATASET VERSION ROW COLUMNS */
   public static final String FIELD_UUIDS = "field_uuids";
+  public static final String LIFECYCLE_STATE = "lifecycle_state";
 
   /* STREAM VERSION ROW COLUMNS */
   public static final String SCHEMA_LOCATION = "schema_location";
@@ -158,6 +160,15 @@ public final class Columns {
       throw new IllegalArgumentException();
     }
     return results.getString(column);
+  }
+
+  public static boolean booleanOrDefault(
+      final ResultSet results, final String column, final boolean defaultValue)
+      throws SQLException {
+    if (results.getObject(column) == null) {
+      return defaultValue;
+    }
+    return results.getBoolean(column);
   }
 
   public static int intOrThrow(final ResultSet results, final String column) throws SQLException {

--- a/api/src/main/java/marquez/db/DatasetVersionDao.java
+++ b/api/src/main/java/marquez/db/DatasetVersionDao.java
@@ -48,6 +48,7 @@ public interface DatasetVersionDao extends BaseDao {
       Instant now,
       String namespaceName,
       String datasetName,
+      String lifecycleState,
       DatasetMeta datasetMeta) {
     TagDao tagDao = createTagDao();
     DatasetFieldDao datasetFieldDao = createDatasetFieldDao();
@@ -63,7 +64,8 @@ public interface DatasetVersionDao extends BaseDao {
             datasetMeta.getRunId().map(RunId::getValue).orElse(null),
             toPgObjectFields(datasetMeta.getFields()),
             namespaceName,
-            datasetName);
+            datasetName,
+            lifecycleState);
     updateDatasetVersionMetric(
         namespaceName,
         datasetMeta.getType().toString(),
@@ -167,7 +169,7 @@ public interface DatasetVersionDao extends BaseDao {
           + "    FROM selected_dataset_version_runs dv\n"
           + "    LEFT JOIN lineage_events le ON le.run_uuid = dv.run_uuid\n"
           + ")\n"
-          + "SELECT d.type, d.name, d.physical_name, d.namespace_name, d.source_name, d.description,\n"
+          + "SELECT d.type, d.name, d.physical_name, d.namespace_name, d.source_name, d.description, dv.lifecycle_state, \n"
           + "    dv.created_at, dv.version, dv.fields, dv.run_uuid AS createdByRunUuid, sv.schema_location,\n"
           + "    t.tags, f.facets\n"
           + "FROM selected_dataset_versions dv\n"
@@ -209,7 +211,7 @@ public interface DatasetVersionDao extends BaseDao {
           + "    FROM selected_dataset_version_runs dv\n"
           + "    LEFT JOIN lineage_events le ON le.run_uuid = dv.run_uuid\n"
           + ")\n"
-          + "SELECT d.type, d.name, d.physical_name, d.namespace_name, d.source_name, d.description,\n"
+          + "SELECT d.type, d.name, d.physical_name, d.namespace_name, d.source_name, d.description, dv.lifecycle_state, \n"
           + "    dv.created_at, dv.version, dv.fields, dv.run_uuid AS createdByRunUuid, sv.schema_location,\n"
           + "    t.tags, f.facets\n"
           + "FROM selected_dataset_versions dv\n"
@@ -280,7 +282,7 @@ public interface DatasetVersionDao extends BaseDao {
           + "    FROM selected_dataset_version_runs dv\n"
           + "    LEFT JOIN lineage_events le ON le.run_uuid = dv.run_uuid\n"
           + ")\n"
-          + "SELECT d.type, d.name, d.physical_name, d.namespace_name, d.source_name, d.description,\n"
+          + "SELECT d.type, d.name, d.physical_name, d.namespace_name, d.source_name, d.description, dv.lifecycle_state,\n"
           + "    dv.created_at, dv.version, dv.fields, dv.run_uuid AS createdByRunUuid, sv.schema_location,\n"
           + "    t.tags, f.facets\n"
           + "FROM selected_dataset_versions dv\n"
@@ -324,9 +326,9 @@ public interface DatasetVersionDao extends BaseDao {
 
   @SqlQuery(
       "INSERT INTO dataset_versions "
-          + "(uuid, created_at, dataset_uuid, version, run_uuid, fields, namespace_name, dataset_name) "
+          + "(uuid, created_at, dataset_uuid, version, run_uuid, fields, namespace_name, dataset_name, lifecycle_state) "
           + "VALUES "
-          + "(:uuid, :now, :datasetUuid, :version, :runUuid, :fields, :namespaceName, :datasetName) "
+          + "(:uuid, :now, :datasetUuid, :version, :runUuid, :fields, :namespaceName, :datasetName, :lifecycleState) "
           + "ON CONFLICT(version) "
           + "DO UPDATE SET "
           + "run_uuid = EXCLUDED.run_uuid "
@@ -339,7 +341,8 @@ public interface DatasetVersionDao extends BaseDao {
       UUID runUuid,
       PGobject fields,
       String namespaceName,
-      String datasetName);
+      String datasetName,
+      String lifecycleState);
 
   @SqlUpdate("UPDATE dataset_versions SET fields = :fields WHERE uuid = :uuid")
   void updateFields(UUID uuid, PGobject fields);

--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -67,7 +67,7 @@ public interface LineageDao {
   Optional<UUID> getJobUuid(String jobName, String namespace);
 
   @SqlQuery(
-      "SELECT ds.*, dv.fields\n"
+      "SELECT ds.*, dv.fields, dv.lifecycle_state\n"
           + "FROM datasets ds\n"
           + "LEFT JOIN dataset_versions dv on dv.uuid = ds.current_version_uuid\n"
           + "WHERE ds.uuid IN (<dsUuids>);")

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -41,6 +41,7 @@ import marquez.service.models.LineageEvent;
 import marquez.service.models.LineageEvent.Dataset;
 import marquez.service.models.LineageEvent.DatasetFacets;
 import marquez.service.models.LineageEvent.Job;
+import marquez.service.models.LineageEvent.LifecycleStateChangeFacet;
 import marquez.service.models.LineageEvent.SchemaDatasetFacet;
 import marquez.service.models.LineageEvent.SchemaField;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -350,6 +351,12 @@ public interface OpenLineageDao extends BaseDao {
             formatNamespaceName(ds.getNamespace()),
             DEFAULT_NAMESPACE_OWNER);
 
+    String dslifecycleState =
+        Optional.ofNullable(ds.getFacets())
+            .map(DatasetFacets::getLifecycleStateChange)
+            .map(LifecycleStateChangeFacet::getLifecycleStateChange)
+            .orElse("");
+
     DatasetRow datasetRow =
         datasetDao.upsert(
             UUID.randomUUID(),
@@ -361,7 +368,8 @@ public interface OpenLineageDao extends BaseDao {
             source.getName(),
             formatDatasetName(ds.getName()),
             ds.getName(),
-            dsDescription);
+            dsDescription,
+            dslifecycleState.equalsIgnoreCase("DROP"));
 
     List<SchemaField> fields =
         Optional.ofNullable(ds.getFacets())
@@ -385,6 +393,7 @@ public interface OpenLineageDao extends BaseDao {
                               source.getName(),
                               dsRow.getPhysicalName(),
                               dsRow.getName(),
+                              dslifecycleState,
                               fields,
                               runUuid)
                           .getValue();
@@ -397,8 +406,8 @@ public interface OpenLineageDao extends BaseDao {
                           isInput ? null : runUuid,
                           datasetVersionDao.toPgObjectSchemaFields(fields),
                           dsNamespace.getName(),
-                          ds.getName());
-
+                          ds.getName(),
+                          dslifecycleState);
                   return row;
                 });
     List<DatasetFieldMapping> datasetFieldMappings = new ArrayList<>();

--- a/api/src/main/java/marquez/db/RunDao.java
+++ b/api/src/main/java/marquez/db/RunDao.java
@@ -277,6 +277,7 @@ public interface RunDao extends BaseDao {
                           d.getSourceName().getValue(),
                           d.getPhysicalName().getValue(),
                           d.getName().getValue(),
+                          null,
                           toSchemaFields(d.getFields()),
                           runUuid)
                       .getValue();
@@ -288,7 +289,8 @@ public interface RunDao extends BaseDao {
                   runUuid,
                   datasetVersionDao.toPgObjectFields(d.getFields()),
                   d.getNamespace().getValue(),
-                  d.getName().getValue());
+                  d.getName().getValue(),
+                  null);
             });
       }
     }

--- a/api/src/main/java/marquez/db/mappers/DatasetDataMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetDataMapper.java
@@ -52,7 +52,8 @@ public class DatasetDataMapper implements RowMapper<DatasetData> {
         toFields(results, "fields"),
         ImmutableSet.of(),
         timestampOrNull(results, Columns.LAST_MODIFIED_AT),
-        stringOrNull(results, Columns.DESCRIPTION));
+        stringOrNull(results, Columns.DESCRIPTION),
+        stringOrNull(results, Columns.LIFECYCLE_STATE));
   }
 
   public static ImmutableList<Field> toFields(ResultSet results, String column)

--- a/api/src/main/java/marquez/db/mappers/DatasetMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetMapper.java
@@ -2,6 +2,7 @@
 
 package marquez.db.mappers;
 
+import static marquez.db.Columns.booleanOrDefault;
 import static marquez.db.Columns.stringArrayOrThrow;
 import static marquez.db.Columns.stringOrNull;
 import static marquez.db.Columns.stringOrThrow;
@@ -62,9 +63,11 @@ public final class DatasetMapper implements RowMapper<Dataset> {
           toFields(results, "fields"),
           toTags(results, "tags"),
           timestampOrNull(results, Columns.LAST_MODIFIED_AT),
+          stringOrNull(results, Columns.LIFECYCLE_STATE),
           stringOrNull(results, Columns.DESCRIPTION),
           uuidOrNull(results, Columns.CURRENT_VERSION_UUID),
-          toFacetsOrNull(results, Columns.FACETS));
+          toFacetsOrNull(results, Columns.FACETS),
+          booleanOrDefault(results, Columns.IS_DELETED, false));
     } else {
       return new Stream(
           new DatasetId(
@@ -79,9 +82,11 @@ public final class DatasetMapper implements RowMapper<Dataset> {
           toFields(results, "fields"),
           toTags(results, "tags"),
           timestampOrNull(results, Columns.LAST_MODIFIED_AT),
+          stringOrNull(results, Columns.LIFECYCLE_STATE),
           stringOrNull(results, Columns.DESCRIPTION),
           uuidOrNull(results, Columns.CURRENT_VERSION_UUID),
-          toFacetsOrNull(results, Columns.FACETS));
+          toFacetsOrNull(results, Columns.FACETS),
+          booleanOrDefault(results, Columns.IS_DELETED, false));
     }
   }
 

--- a/api/src/main/java/marquez/db/mappers/DatasetRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetRowMapper.java
@@ -2,6 +2,7 @@
 
 package marquez.db.mappers;
 
+import static marquez.db.Columns.booleanOrDefault;
 import static marquez.db.Columns.stringOrNull;
 import static marquez.db.Columns.stringOrThrow;
 import static marquez.db.Columns.timestampOrNull;
@@ -32,6 +33,7 @@ public final class DatasetRowMapper implements RowMapper<DatasetRow> {
         stringOrThrow(results, Columns.PHYSICAL_NAME),
         timestampOrNull(results, Columns.LAST_MODIFIED_AT),
         stringOrNull(results, Columns.DESCRIPTION),
-        uuidOrNull(results, Columns.CURRENT_VERSION_UUID));
+        uuidOrNull(results, Columns.CURRENT_VERSION_UUID),
+        booleanOrDefault(results, Columns.IS_DELETED, false));
   }
 }

--- a/api/src/main/java/marquez/db/mappers/DatasetVersionMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetVersionMapper.java
@@ -54,6 +54,7 @@ public final class DatasetVersionMapper implements RowMapper<DatasetVersion> {
               toFields(results, "fields"),
               columnNames.contains("tags") ? toTags(results, "tags") : null,
               stringOrNull(results, Columns.DESCRIPTION),
+              stringOrNull(results, Columns.LIFECYCLE_STATE),
               null,
               toFacetsOrNull(results, Columns.FACETS));
     } else {
@@ -71,6 +72,7 @@ public final class DatasetVersionMapper implements RowMapper<DatasetVersion> {
               toFields(results, "fields"),
               columnNames.contains("tags") ? toTags(results, "tags") : null,
               stringOrNull(results, Columns.DESCRIPTION),
+              stringOrNull(results, Columns.LIFECYCLE_STATE),
               null,
               toFacetsOrNull(results, Columns.FACETS));
     }

--- a/api/src/main/java/marquez/db/mappers/DatasetVersionRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetVersionRowMapper.java
@@ -2,6 +2,7 @@
 
 package marquez.db.mappers;
 
+import static marquez.db.Columns.stringOrNull;
 import static marquez.db.Columns.timestampOrThrow;
 import static marquez.db.Columns.uuidOrNull;
 import static marquez.db.Columns.uuidOrThrow;
@@ -23,6 +24,7 @@ public final class DatasetVersionRowMapper implements RowMapper<DatasetVersionRo
         timestampOrThrow(results, Columns.CREATED_AT),
         uuidOrThrow(results, Columns.DATASET_UUID),
         uuidOrThrow(results, Columns.VERSION),
+        stringOrNull(results, Columns.LIFECYCLE_STATE),
         uuidOrNull(results, Columns.RUN_UUID));
   }
 }

--- a/api/src/main/java/marquez/db/mappers/ExtendedDatasetVersionRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/ExtendedDatasetVersionRowMapper.java
@@ -24,6 +24,7 @@ public final class ExtendedDatasetVersionRowMapper implements RowMapper<Extended
         timestampOrThrow(results, Columns.CREATED_AT),
         uuidOrThrow(results, Columns.DATASET_UUID),
         uuidOrThrow(results, Columns.VERSION),
+        stringOrNull(results, Columns.LIFECYCLE_STATE),
         uuidOrNull(results, Columns.RUN_UUID),
         stringOrNull(results, Columns.NAMESPACE_NAME),
         stringOrNull(results, Columns.DATASET_NAME));

--- a/api/src/main/java/marquez/db/models/DatasetData.java
+++ b/api/src/main/java/marquez/db/models/DatasetData.java
@@ -36,6 +36,7 @@ public class DatasetData implements NodeData {
   @NonNull ImmutableSet<TagName> tags;
   @Nullable Instant lastModifiedAt;
   @Nullable String description;
+  @Nullable String lastlifecycleState;
 
   public Optional<Instant> getLastModifiedAt() {
     return Optional.ofNullable(lastModifiedAt);
@@ -43,6 +44,10 @@ public class DatasetData implements NodeData {
 
   public Optional<String> getDescription() {
     return Optional.ofNullable(description);
+  }
+
+  public Optional<String> getLastlifecycleState() {
+    return Optional.ofNullable(lastlifecycleState);
   }
 
   @JsonIgnore

--- a/api/src/main/java/marquez/db/models/DatasetRow.java
+++ b/api/src/main/java/marquez/db/models/DatasetRow.java
@@ -28,6 +28,7 @@ public class DatasetRow {
   @Nullable private final Instant lastModifiedAt;
   @Nullable private final String description;
   @With @Nullable private final UUID currentVersionUuid;
+  @Getter private final boolean isDeleted;
 
   public Optional<Instant> getLastModifiedAt() {
     return Optional.ofNullable(lastModifiedAt);

--- a/api/src/main/java/marquez/db/models/DatasetVersionRow.java
+++ b/api/src/main/java/marquez/db/models/DatasetVersionRow.java
@@ -20,6 +20,7 @@ public class DatasetVersionRow {
   @Getter @NonNull private final Instant createdAt;
   @Getter @NonNull private final UUID datasetUuid;
   @Getter @NonNull private final UUID version;
+  @Getter @Nullable private final String lifecycleState;
   @Nullable private final UUID runUuid;
 
   public Optional<UUID> getRunUuid() {

--- a/api/src/main/java/marquez/db/models/ExtendedDatasetVersionRow.java
+++ b/api/src/main/java/marquez/db/models/ExtendedDatasetVersionRow.java
@@ -4,6 +4,7 @@ package marquez.db.models;
 
 import java.time.Instant;
 import java.util.UUID;
+import javax.annotation.Nullable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
@@ -20,10 +21,11 @@ public class ExtendedDatasetVersionRow extends DatasetVersionRow {
       @NonNull Instant createdAt,
       @NonNull UUID datasetUuid,
       @NonNull UUID version,
+      @Nullable String lifecycleState,
       UUID runUuid,
       @NonNull final String namespaceName,
       @NonNull final String datasetName) {
-    super(uuid, createdAt, datasetUuid, version, runUuid);
+    super(uuid, createdAt, datasetUuid, version, lifecycleState, runUuid);
     this.namespaceName = namespaceName;
     this.datasetName = datasetName;
   }

--- a/api/src/main/java/marquez/service/models/Dataset.java
+++ b/api/src/main/java/marquez/service/models/Dataset.java
@@ -47,9 +47,11 @@ public abstract class Dataset {
   @Getter @Setter private List<Field> fields;
   @Getter private final ImmutableSet<TagName> tags;
   @Nullable private final Instant lastModifiedAt;
+  @Nullable private final String lastLifecycleState;
   @Nullable private final String description;
   @Nullable private final UUID currentVersion;
   @Getter ImmutableMap<String, Object> facets;
+  @Getter private final boolean isDeleted;
 
   public Dataset(
       @NonNull final DatasetId id,
@@ -62,9 +64,11 @@ public abstract class Dataset {
       @Nullable final ImmutableList<Field> fields,
       @Nullable final ImmutableSet<TagName> tags,
       @Nullable final Instant lastModifiedAt,
+      @Nullable final String lastLifecycleState,
       @Nullable final String description,
       @Nullable final UUID currentVersion,
-      @Nullable final ImmutableMap<String, Object> facets) {
+      @Nullable final ImmutableMap<String, Object> facets,
+      boolean isDeleted) {
     this.id = id;
     this.type = type;
     this.name = name;
@@ -76,9 +80,11 @@ public abstract class Dataset {
     this.fields = (fields == null) ? ImmutableList.of() : fields;
     this.tags = (tags == null) ? ImmutableSet.of() : tags;
     this.lastModifiedAt = lastModifiedAt;
+    this.lastLifecycleState = lastLifecycleState;
     this.description = description;
     this.currentVersion = currentVersion;
     this.facets = (facets == null) ? ImmutableMap.of() : facets;
+    this.isDeleted = isDeleted;
   }
 
   public Optional<Instant> getLastModifiedAt() {
@@ -87,6 +93,10 @@ public abstract class Dataset {
 
   public Optional<String> getDescription() {
     return Optional.ofNullable(description);
+  }
+
+  public Optional<String> getLastLifecycleState() {
+    return Optional.ofNullable(lastLifecycleState);
   }
 
   public Optional<UUID> getCurrentVersion() {

--- a/api/src/main/java/marquez/service/models/DatasetVersion.java
+++ b/api/src/main/java/marquez/service/models/DatasetVersion.java
@@ -47,6 +47,7 @@ public abstract class DatasetVersion {
   @Getter private final SourceName sourceName;
   @Getter @Setter private ImmutableList<Field> fields;
   @Getter @Setter private ImmutableSet<TagName> tags;
+  @Nullable private final String lifecycleState;
   @Nullable private final String description;
   @Nullable @Setter private Run createdByRun;
   @Nullable @Setter private UUID createdByRunUuid;
@@ -62,6 +63,7 @@ public abstract class DatasetVersion {
       @NonNull final SourceName sourceName,
       @Nullable final ImmutableList<Field> fields,
       @Nullable final ImmutableSet<TagName> tags,
+      @Nullable final String lifecycleState,
       @Nullable final String description,
       @Nullable final Run createdByRun,
       @Nullable final ImmutableMap<String, Object> facets) {
@@ -75,6 +77,7 @@ public abstract class DatasetVersion {
     this.sourceName = sourceName;
     this.fields = (fields == null) ? ImmutableList.of() : fields;
     this.tags = (tags == null) ? ImmutableSet.of() : tags;
+    this.lifecycleState = lifecycleState;
     this.description = description;
     this.createdByRun = createdByRun;
     this.facets = (facets == null) ? ImmutableMap.of() : facets;
@@ -86,6 +89,10 @@ public abstract class DatasetVersion {
 
   public Optional<Run> getCreatedByRun() {
     return Optional.ofNullable(createdByRun);
+  }
+
+  public Optional<String> getLifecycleState() {
+    return Optional.ofNullable(lifecycleState);
   }
 
   @JsonIgnore

--- a/api/src/main/java/marquez/service/models/DbTable.java
+++ b/api/src/main/java/marquez/service/models/DbTable.java
@@ -31,9 +31,11 @@ public final class DbTable extends Dataset {
       @Nullable final ImmutableList<Field> fields,
       @Nullable final ImmutableSet<TagName> tags,
       @Nullable final Instant lastModifiedAt,
+      @Nullable final String lastLifecycleState,
       @Nullable final String description,
       @Nullable final UUID currentVersion,
-      @Nullable final ImmutableMap<String, Object> facets) {
+      @Nullable final ImmutableMap<String, Object> facets,
+      final boolean isDeleted) {
     super(
         id,
         DB_TABLE,
@@ -45,8 +47,10 @@ public final class DbTable extends Dataset {
         fields,
         tags,
         lastModifiedAt,
+        lastLifecycleState,
         description,
         currentVersion,
-        facets);
+        facets,
+        isDeleted);
   }
 }

--- a/api/src/main/java/marquez/service/models/DbTableVersion.java
+++ b/api/src/main/java/marquez/service/models/DbTableVersion.java
@@ -31,6 +31,7 @@ public final class DbTableVersion extends DatasetVersion {
       @Nullable final ImmutableList<Field> fields,
       @Nullable final ImmutableSet<TagName> tags,
       @Nullable final String description,
+      @Nullable final String lifecycleState,
       @Nullable final Run createdByRun,
       @Nullable final ImmutableMap<String, Object> facets) {
     super(
@@ -43,6 +44,7 @@ public final class DbTableVersion extends DatasetVersion {
         sourceName,
         fields,
         tags,
+        lifecycleState,
         description,
         createdByRun,
         facets);

--- a/api/src/main/java/marquez/service/models/LineageEvent.java
+++ b/api/src/main/java/marquez/service/models/LineageEvent.java
@@ -309,11 +309,18 @@ public class LineageEvent extends BaseJsonModel {
   @Setter
   @Valid
   @ToString
-  @JsonPropertyOrder({"documentation", "schema", "dataSource", "description"})
+  @JsonPropertyOrder({
+    "documentation",
+    "schema",
+    "dataSource",
+    "description",
+    "lifecycleStateChange"
+  })
   public static class DatasetFacets {
 
     @Valid private DocumentationDatasetFacet documentation;
     @Valid private SchemaDatasetFacet schema;
+    @Valid private LifecycleStateChangeFacet lifecycleStateChange;
     @Valid private DatasourceDatasetFacet dataSource;
     private String description;
     @Builder.Default @JsonIgnore private Map<String, Object> additional = new LinkedHashMap<>();
@@ -334,6 +341,10 @@ public class LineageEvent extends BaseJsonModel {
 
     public SchemaDatasetFacet getSchema() {
       return schema;
+    }
+
+    public LifecycleStateChangeFacet getLifecycleStateChange() {
+      return lifecycleStateChange;
     }
 
     public DatasourceDatasetFacet getDataSource() {
@@ -409,6 +420,23 @@ public class LineageEvent extends BaseJsonModel {
       super(_producer, _schemaURL);
       this.name = name;
       this.uri = uri;
+    }
+  }
+
+  @NoArgsConstructor
+  @Getter
+  @Setter
+  @Valid
+  @ToString
+  public static class LifecycleStateChangeFacet extends BaseFacet {
+
+    private String lifecycleStateChange;
+
+    @Builder
+    public LifecycleStateChangeFacet(
+        @NotNull URI _producer, @NotNull URI _schemaURL, String lifecycleStateChange) {
+      super(_producer, _schemaURL);
+      this.lifecycleStateChange = lifecycleStateChange;
     }
   }
 }

--- a/api/src/main/java/marquez/service/models/Stream.java
+++ b/api/src/main/java/marquez/service/models/Stream.java
@@ -37,9 +37,11 @@ public final class Stream extends Dataset {
       @Nullable final ImmutableList<Field> fields,
       @Nullable final ImmutableSet<TagName> tags,
       @Nullable final Instant lastModifiedAt,
+      @Nullable final String lastLifecycleState,
       @Nullable final String description,
       @Nullable final UUID currentVersion,
-      @Nullable final ImmutableMap<String, Object> facets) {
+      @Nullable final ImmutableMap<String, Object> facets,
+      final boolean isDeleted) {
     super(
         id,
         STREAM,
@@ -51,9 +53,11 @@ public final class Stream extends Dataset {
         fields,
         tags,
         lastModifiedAt,
+        lastLifecycleState,
         description,
         currentVersion,
-        facets);
+        facets,
+        isDeleted);
     this.schemaLocation = schemaLocation;
   }
 }

--- a/api/src/main/java/marquez/service/models/StreamVersion.java
+++ b/api/src/main/java/marquez/service/models/StreamVersion.java
@@ -37,6 +37,7 @@ public final class StreamVersion extends DatasetVersion {
       @Nullable final ImmutableList<Field> fields,
       @Nullable final ImmutableSet<TagName> tags,
       @Nullable final String description,
+      @Nullable final String lifecycleState,
       @Nullable final Run createdByRun,
       @Nullable final ImmutableMap<String, Object> facets) {
     super(
@@ -49,6 +50,7 @@ public final class StreamVersion extends DatasetVersion {
         sourceName,
         fields,
         tags,
+        lifecycleState,
         description,
         createdByRun,
         facets);

--- a/api/src/main/resources/marquez/db/migration/V41__add_operation_to_dataset_versions.sql
+++ b/api/src/main/resources/marquez/db/migration/V41__add_operation_to_dataset_versions.sql
@@ -1,0 +1,2 @@
+alter table dataset_versions add column lifecycle_state VARCHAR(63);
+alter table datasets add column is_deleted BOOLEAN DEFAULT FALSE;

--- a/api/src/test/java/marquez/common/UtilsTest.java
+++ b/api/src/test/java/marquez/common/UtilsTest.java
@@ -5,6 +5,7 @@ package marquez.common;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static marquez.common.models.CommonModelGenerator.newDatasetName;
 import static marquez.common.models.CommonModelGenerator.newJobName;
+import static marquez.common.models.CommonModelGenerator.newLifecycleState;
 import static marquez.common.models.CommonModelGenerator.newNamespaceName;
 import static marquez.common.models.CommonModelGenerator.newRunId;
 import static marquez.common.models.CommonModelGenerator.newSchemaFields;
@@ -259,6 +260,7 @@ public class UtilsTest {
     DatasetName datasetName = newDatasetName();
     DatasetName physicalName = newDatasetName();
     SourceName sourceName = newSourceName();
+    String lifecycleState = newLifecycleState();
     List<LineageEvent.SchemaField> schemaFields = newSchemaFields(2);
     RunId runId = newRunId();
 
@@ -268,6 +270,7 @@ public class UtilsTest {
             sourceName.getValue(),
             physicalName.getValue(),
             datasetName.getValue(),
+            lifecycleState,
             schemaFields,
             runId.getValue());
     Version second =
@@ -276,6 +279,7 @@ public class UtilsTest {
             sourceName.getValue(),
             physicalName.getValue(),
             datasetName.getValue(),
+            lifecycleState,
             schemaFields,
             runId.getValue());
 
@@ -320,6 +324,7 @@ public class UtilsTest {
             newSourceName().getValue(),
             newDatasetName().getValue(),
             newDatasetName().getValue(),
+            newLifecycleState(),
             schemaFields,
             newRunId().getValue());
 
@@ -329,6 +334,7 @@ public class UtilsTest {
             newSourceName().getValue(),
             newDatasetName().getValue(),
             newDatasetName().getValue(),
+            newLifecycleState(),
             schemaFields,
             newRunId().getValue());
 
@@ -337,7 +343,7 @@ public class UtilsTest {
 
   @Test
   public void testDatasetVersionWithNullFields() {
-    Version version = Utils.newDatasetVersionFor(null, null, null, null, null, null);
+    Version version = Utils.newDatasetVersionFor(null, null, null, null, null, null, null);
 
     assertThat(version.getValue()).isNotNull();
   }
@@ -355,6 +361,7 @@ public class UtilsTest {
     DatasetName datasetName = newDatasetName();
     DatasetName physicalName = newDatasetName();
     SourceName sourceName = newSourceName();
+    String lifecycleState = newLifecycleState();
     List<LineageEvent.SchemaField> schemaFields = newSchemaFields(2);
     RunId runId = newRunId();
 
@@ -364,6 +371,7 @@ public class UtilsTest {
             sourceName.getValue(),
             physicalName.getValue(),
             datasetName.getValue(),
+            lifecycleState,
             schemaFields,
             runId.getValue());
 
@@ -375,6 +383,7 @@ public class UtilsTest {
             sourceName.getValue(),
             physicalName.getValue(),
             datasetName.getValue(),
+            lifecycleState,
             shuffleSchemaFields,
             runId.getValue());
 

--- a/api/src/test/java/marquez/common/models/CommonModelGenerator.java
+++ b/api/src/test/java/marquez/common/models/CommonModelGenerator.java
@@ -157,6 +157,10 @@ public final class CommonModelGenerator extends Generator {
     return RunId.of(UUID.randomUUID());
   }
 
+  public static String newLifecycleState() {
+    return "TRUNCATE";
+  }
+
   public static Version newVersion() {
     return Version.of(UUID.randomUUID());
   }

--- a/api/src/test/java/marquez/db/ColumnsTest.java
+++ b/api/src/test/java/marquez/db/ColumnsTest.java
@@ -285,4 +285,23 @@ public class ColumnsTest {
     final URI actual = Columns.uriOrNull(results, column);
     assertThat(actual).isNull();
   }
+
+  @Test
+  public void testBooleanOrDefault() throws SQLException {
+    final String column = "is_deleted";
+    when(results.getObject(column)).thenReturn(true);
+    when(results.getBoolean(column)).thenReturn(true);
+
+    final boolean actual = Columns.booleanOrDefault(results, column, false);
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  public void testBooleanOrDefaultWhenNoValue() throws SQLException {
+    final String column = "is_deleted";
+    when(results.getObject(column)).thenReturn(null);
+
+    final boolean actual = Columns.booleanOrDefault(results, column, true);
+    assertThat(actual).isTrue();
+  }
 }

--- a/api/src/test/java/marquez/db/mappers/DatasetMapperTest.java
+++ b/api/src/test/java/marquez/db/mappers/DatasetMapperTest.java
@@ -42,6 +42,8 @@ class DatasetMapperTest {
     when(resultSet.getObject(Columns.PHYSICAL_NAME)).thenReturn("PHYSICAL_NAME");
     when(resultSet.getString(Columns.TYPE)).thenReturn("DB_TABLE");
     when(resultSet.getObject(Columns.TYPE)).thenReturn("DB_TABLE");
+    when(resultSet.getString(Columns.LIFECYCLE_STATE)).thenReturn("TRUNCATE");
+    when(resultSet.getObject(Columns.LIFECYCLE_STATE)).thenReturn("TRUNCATE");
     when(resultSet.getString(Columns.DESCRIPTION)).thenReturn("DESCRIPTION");
     when(resultSet.getObject(Columns.DESCRIPTION)).thenReturn("DESCRIPTION");
     when(resultSet.getString(Columns.SOURCE_NAME)).thenReturn("POSTGRES");

--- a/api/src/test/java/marquez/service/models/ServiceModelGenerator.java
+++ b/api/src/test/java/marquez/service/models/ServiceModelGenerator.java
@@ -11,6 +11,7 @@ import static marquez.common.models.CommonModelGenerator.newDatasetName;
 import static marquez.common.models.CommonModelGenerator.newDescription;
 import static marquez.common.models.CommonModelGenerator.newFields;
 import static marquez.common.models.CommonModelGenerator.newJobType;
+import static marquez.common.models.CommonModelGenerator.newLifecycleState;
 import static marquez.common.models.CommonModelGenerator.newLocation;
 import static marquez.common.models.CommonModelGenerator.newNamespaceName;
 import static marquez.common.models.CommonModelGenerator.newOwnerName;
@@ -59,9 +60,11 @@ public final class ServiceModelGenerator extends Generator {
         newFields(4),
         newTagNames(2),
         null,
+        newLifecycleState(),
         newDescription(),
         null,
-        null);
+        null,
+        false);
   }
 
   /** Returns a new {@link DbTableMeta} object. */

--- a/api/src/test/resources/mappers/full_dataset_mapper.json
+++ b/api/src/test/resources/mappers/full_dataset_mapper.json
@@ -4,6 +4,7 @@
     "name": "NAME"
   },
   "type": "DB_TABLE",
+  "lastLifecycleState": "TRUNCATE",
   "description": "DESCRIPTION",
   "name": "NAME",
   "physicalName": "PHYSICAL_NAME",

--- a/web/src/components/datasets/DatasetVersions.tsx
+++ b/web/src/components/datasets/DatasetVersions.tsx
@@ -25,7 +25,7 @@ const styles = (theme: ITheme) => {
   })
 }
 
-const DATASET_VERSIONS_COLUMNS = ['Version', 'Created At', 'Field Count']
+const DATASET_VERSIONS_COLUMNS = ['Version', 'Created At', 'Field Count', 'Lifecycle State']
 
 interface DatasetVersionsProps {
   versions: DatasetVersion[]
@@ -83,6 +83,7 @@ const DatasetVersions: FunctionComponent<
               <TableCell align='left'>{version.version}</TableCell>
               <TableCell align='left'>{formatUpdatedAt(version.createdAt)}</TableCell>
               <TableCell align='left'>{version.fields.length}</TableCell>
+              <TableCell align='left'>{version.lifecycleState}</TableCell>
             </TableRow>
           )
         })}

--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -88,7 +88,7 @@ class Datasets extends React.Component<DatasetsProps> {
                     </TableRow>
                   </TableHead>
                   <TableBody>
-                    {datasets.map(dataset => {
+                    {datasets.filter(dataset => !dataset.deleted).map(dataset => {
                       return (
                         <TableRow key={dataset.name}>
                           <TableCell align='left'>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -40,6 +40,7 @@ export interface Dataset {
   lastModifiedAt: string
   description: string
   facets: object
+  deleted: boolean
 }
 
 export interface DatasetVersions {
@@ -60,6 +61,7 @@ export interface DatasetVersion {
   tags: string[]
   lastModifiedAt: string
   description: string
+  lifecycleState: string
   facets: object
 }
 


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Lacking support for table operations reported from OpenLineage

Closes: #1800

### Solution

Store `stateChange` field in backend database and expose the property over API. 

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
