### PR TITLE
Add GitPod to Marquez

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,16 @@
+tasks:
+  - init: |
+      docker-compose pull
+  - command: |
+      ./docker/up.sh --build --seed
+ports:
+  - port: 5000
+    onOpen: ignore
+  - port: 5001
+    onOpen: ignore
+  - port: 3000
+    onOpen: open-browser
+vscode:
+  extensions:
+    - ms-azuretools.vscode-docker
+

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,7 +12,6 @@ ports:
     onOpen: ignore
   - port: 5432
     onOpen: ignore
-  onOpen: ignore
 vscode:
   extensions:
     - ms-azuretools.vscode-docker

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,8 @@
 tasks:
+  - env:
+      API_PORT: 5000
+      API_ADMIN_PORT: 5001
+      WEB_PORT: 3000
   - init: |
       docker-compose pull
   - command: |
@@ -12,6 +16,10 @@ ports:
     onOpen: ignore
   - port: 5432
     onOpen: ignore
+github:
+  prebuilds:
+    master: true
+    addCheck: prevent-merge-on-error
 vscode:
   extensions:
     - ms-azuretools.vscode-docker

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,7 @@ tasks:
   - init: |
       API_PORT=5000 API_ADMIN_PORT=5001 WEB_PORT=3000 docker-compose pull
   - command: |
-      ./docker/up.sh --build --seed
+      ./docker/up.sh --seed
 ports:
   - port: 3000
     onOpen: open-browser

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,6 @@
 tasks:
-  - env:
-      API_PORT: 5000
-      API_ADMIN_PORT: 5001
-      WEB_PORT: 3000
   - init: |
-      docker-compose pull
+      API_PORT=5000 API_ADMIN_PORT=5001 WEB_PORT=3000 docker-compose pull
   - command: |
       ./docker/up.sh --build --seed
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,12 +4,15 @@ tasks:
   - command: |
       ./docker/up.sh --build --seed
 ports:
+  - port: 3000
+    onOpen: open-browser
   - port: 5000
     onOpen: ignore
   - port: 5001
     onOpen: ignore
-  - port: 3000
-    onOpen: open-browser
+  - port: 5432
+    onOpen: ignore
+  onOpen: ignore
 vscode:
   extensions:
     - ms-azuretools.vscode-docker

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,9 @@
 tasks:
-  - init: |
-      API_PORT=5000 API_ADMIN_PORT=5001 WEB_PORT=3000 docker-compose pull
   - command: |
-      ./docker/up.sh --seed
+      DOCKER_BUILDKIT=1 ./docker/up.sh --seed
 ports:
   - port: 3000
+    visibility: public
     onOpen: open-browser
   - port: 5000
     onOpen: ignore
@@ -12,10 +11,6 @@ ports:
     onOpen: ignore
   - port: 5432
     onOpen: ignore
-github:
-  prebuilds:
-    master: true
-    addCheck: prevent-merge-on-error
 vscode:
   extensions:
     - ms-azuretools.vscode-docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,11 @@ RUN ./gradlew --version
 FROM base AS build
 WORKDIR /usr/src/app
 COPY build.gradle build.gradle
+RUN true
 COPY api ./api
+RUN true
 COPY api/build.gradle ./api/build.gradle
+RUN true
 COPY clients/java ./clients/java
 RUN ./gradlew --no-daemon :api:shadowJar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,8 @@ RUN ./gradlew --version
 FROM base AS build
 WORKDIR /usr/src/app
 COPY build.gradle build.gradle
-RUN true
 COPY api ./api
-RUN true
 COPY api/build.gradle ./api/build.gradle
-RUN true
 COPY clients/java ./clients/java
 RUN ./gradlew --no-daemon :api:shadowJar
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Marquez is an [LF AI & Data Foundation](https://lfaidata.foundation/projects/mar
 
 ## Try it!
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/MarquezProject/marquez/tree/feature/gitpod)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/MarquezProject/marquez)
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Marquez is an open source **metadata service** for the **collection**, **aggregation**, and **visualization** of a data ecosystem's metadata. It maintains the provenance of how datasets are consumed and produced, provides global visibility into job runtime and frequency of dataset access, centralization of dataset lifecycle management, and much more. Marquez was released and open sourced by [WeWork](https://www.wework.com).
 
+## Quick Demo
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/MarquezProject/marquez/tree/feature/gitpod)
 ## Badges
 
 [![CircleCI](https://circleci.com/gh/MarquezProject/marquez/tree/main.svg?style=shield)](https://circleci.com/gh/MarquezProject/marquez/tree/main)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 
 Marquez is an open source **metadata service** for the **collection**, **aggregation**, and **visualization** of a data ecosystem's metadata. It maintains the provenance of how datasets are consumed and produced, provides global visibility into job runtime and frequency of dataset access, centralization of dataset lifecycle management, and much more. Marquez was released and open sourced by [WeWork](https://www.wework.com).
 
-## Quick Demo
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/MarquezProject/marquez/tree/feature/gitpod)
 ## Badges
 
 [![CircleCI](https://circleci.com/gh/MarquezProject/marquez/tree/main.svg?style=shield)](https://circleci.com/gh/MarquezProject/marquez/tree/main)
@@ -25,6 +23,10 @@ Marquez is an open source **metadata service** for the **collection**, **aggrega
 ## Status
 
 Marquez is an [LF AI & Data Foundation](https://lfaidata.foundation/projects/marquez) incubation project under active development and we'd love your help!
+
+## Try it!
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/MarquezProject/marquez/tree/feature/gitpod)
 
 ## Quickstart
 


### PR DESCRIPTION
This adds [gitpod.io](https://gitpod.io) to Marquez along with an associated configuration file. 

The docker configuration for the api project was not working due to subsequent `COPY` instructions resulting in a noop and failing the multi-staged build. Thus, I added some separator instructions to prevent this issue from occurring. More information can be found [here.](https://stackoverflow.com/questions/51115856/docker-failed-to-export-image-failed-to-create-image-failed-to-get-layer)

This button has been added to the root readme to allow anybody to create a on demand ephemeral developer environment.
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/MarquezProject/marquez/tree/feature/gitpod)

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
