### PR TITLE
remove license tags from docs dir

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-
 title: Marquez
 description: Collect, aggregate, and visualize a data ecosystem's metadata
 

--- a/docs/_layouts/deployment-overview.html
+++ b/docs/_layouts/deployment-overview.html
@@ -1,5 +1,3 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
 <head>

--- a/docs/_layouts/index.html
+++ b/docs/_layouts/index.html
@@ -1,5 +1,3 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>

--- a/docs/_layouts/quickstart.html
+++ b/docs/_layouts/quickstart.html
@@ -1,5 +1,3 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>

--- a/docs/_layouts/running-on-aws.html
+++ b/docs/_layouts/running-on-aws.html
@@ -1,5 +1,3 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
 <head>

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -1,5 +1,3 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 ## Migrating `marquez` database manually via [`flyway`](https://flywaydb.org)
 
 Before you can manually apply migrations to the `marquez` database, make sure you've installed `flyway`:

--- a/docs/deployment-overview.md
+++ b/docs/deployment-overview.md
@@ -1,5 +1,3 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 ---
 layout: deployment-overview
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,3 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 ---
 layout: index
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,3 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 ---
 layout: quickstart
 ---

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1,5 +1,3 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 # Lifecycle
 
 Marquez captures the runs of a job, and changes as they happen.

--- a/docs/run-state-transitions.md
+++ b/docs/run-state-transitions.md
@@ -1,5 +1,3 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 # Run State Transitions
 Run states change based on the success or failure of a job run. The datasets consumed and/or produced
 by a job run are immutable and do not change based on the success or failure of the run.

--- a/docs/running-on-aws.md
+++ b/docs/running-on-aws.md
@@ -1,5 +1,3 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 ---
 layout: running-on-aws
 ---


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

License tags in docs directory made the website non-functional.

### Solution

Removes all license tags from the docs.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
