### PR TITLE
Add java opts override support

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,5 +11,8 @@ if [[ -z "${MARQUEZ_CONFIG}" ]]; then
   echo "WARNING 'MARQUEZ_CONFIG' not set, using development configuration."
 fi
 
-# Start http server with configuration
-java -Duser.timezone=UTC -Dlog4j2.formatMsgNoLookups=true -jar marquez-*.jar server "${MARQUEZ_CONFIG}"
+# Adjust java options for the http server
+JAVA_OPTS="${JAVA_OPTS} -Duser.timezone=UTC -Dlog4j2.formatMsgNoLookups=true"
+
+# Start http server with java options and configuration
+java ${JAVA_OPTS} -jar marquez-*.jar server ${MARQUEZ_CONFIG}


### PR DESCRIPTION
### Problem

Users cannot set java opts when running Marquez via Docker.

### Solution

In [`docker/entrypoint.sh`](https://github.com/MarquezProject/marquez/blob/main/docker/entrypoint.sh), allow users to set `JAVA_OPTS` to adjust java opts for the HTTP server on startup.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
