### PR TITLE
Add Postgres sub-chart to Helm deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 * Add MDC to the `LoggingMdcFilter` to include API method, path, and request ID [@fm100](https://github.com/fm100)
+* Add Postgres sub-chart to Helm deployment for easier installation option [@KevinMellott91](https://github.com/KevinMellott91)
 
 ### Changed
 

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.10.4
-digest: sha256:88cff7ed2aa17ed362cd86c82acb5b9c1f704ea89d3ee18da31ed86e79b59916
-generated: "2022-01-22T21:32:28.732684179Z"
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.16.2
+digest: sha256:b3681ea701f2a32b4a9dd7028a9a884a57244031f033d671c49e9612b03e12ac
+generated: "2022-02-02T16:58:56.272901-06:00"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-
 apiVersion: v2
 appVersion: "1.0"
 dependencies:
@@ -8,6 +6,10 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.10.4
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    version: 10.16.2
 description: Marquez is an open source metadata service for the collection, aggregation, and visualization of a data ecosystem's metadata.
 home: https://github.com/MarquezProject/marquez/tree/main/chart
 icon: https://raw.githubusercontent.com/MarquezProject/marquez/main/web/src/img/marquez-logo.png

--- a/chart/README.md
+++ b/chart/README.md
@@ -3,7 +3,7 @@
 Helm Chart for [Marquez](https://github.com/MarquezProject/marquez).
 
 ## TL;DR;
-Run all commands within the "chart" folder.
+Run all commands within the "chart" folder, with default configurations.
 
 ```bash
 helm install marquez . --dependency-update
@@ -16,13 +16,22 @@ helm install marquez . --dependency-update
 
 ## Installing the Chart
 
-To install the chart with the release name `marquez`:
+To install the chart with the release name `marquez` using a fresh Postgres instance.
 
 ```bash
-helm install marquez . --dependency-update
+helm install marquez . --dependency-update --set postgresql.enabled=true
 ```
 
 > **Note:** For a list of parameters that can be overridden during installation, see the [configuration](#configuration) section.
+
+## Testing the Chart
+
+To confirm connectivity and availability of the installed components (API and optional website). Note
+that you may need to wait a minute or so for services to fully deploy.
+
+```bash
+helm test marquez
+```
 
 ## Uninstalling the Chart
 
@@ -70,6 +79,16 @@ helm delete marquez
 | `web.resources.limits`   | K8s resource limit overrides    | `nil`          |
 | `web.resources.requests` | K8s resource requests overrides | `nil`          |
 
+### [Postgres](https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml) (sub-chart) **parameters**
+
+| Parameter                       | Description                     | Default   |
+|---------------------------------|---------------------------------|-----------|
+| `postgresql.enabled`            | Deploy PostgreSQL container(s)  | `false`   |
+| `postgresql.postgresqlUsername` | PostgreSQL username             | `buendia` |
+| `postgresql.postgresqlPassword` | PostgreSQL password             | `macondo` |
+| `postgresql.postgresqlDatabase` | PostgreSQL database             | `marquez` |
+| `postgresql.existingSecret`     | Name of existing secret object  | `nil`     |
+
 ### Common **parameters**
 
 | Parameter              | Description                         | Default |
@@ -99,9 +118,21 @@ helm delete marquez
 | `ingress.tls`         | TLS settings for hostname          | `nil`   |
 
 ## Local Installation Guide
-If you do not have an existing Postgres database, you can run the following command to create
-one using Docker. Contents of the ```./../docker-compose-postgres..yml``` file can be customized
-to better represent your target environment.
+
+### Helm Managed Postgres
+
+The quickest way to install Marquez via Kubernetes is to create a local Postgres instance.
+
+```bash
+helm install marquez . --dependency-update --set postgresql.enabled=true
+```
+
+### Docker Postgres
+
+A Postgres database is configured within the Marquez project that use Docker to launch, which provides the added
+benefit of test data seeding. You can run the following command to create this instance of Postgres via Docker.
+Contents of the ```./../docker-compose-postgres..yml``` file can be customized
+to better represent your desired setup.
 
 ```bash
 docker-compose -f ./../docker-compose.postgres.yml -p marquez-postgres up
@@ -121,6 +152,8 @@ pesky markdown escape character before running this command.
 ```bash
 helm install marquez . --dependency-update --set marquez.db.host=$marquez_db_ip
 ```
+
+### Validation
 
 Once the Kubernetes pods and services have been installed (usually within 5-10 seconds), connectivity
 tests can be executed by running the following Helm command. You should see a status message

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -55,3 +55,79 @@ Get the secret name
   {{- printf "%s" (include "common.names.fullname" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create a default fully qualified postgresql name.
+*/}}
+{{- define "marquez.postgresql.fullname" -}}
+{{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Flexible Postgres database host, using an existing or newly created instance.
+*/}}
+{{- define "marquez.database.host" -}}
+  {{- if eq .Values.postgresql.enabled true -}}
+    {{- template "marquez.postgresql.fullname" . -}}
+  {{- else -}}
+    {{- .Values.marquez.db.host -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Flexible Postgres database port, using an existing or newly created instance.
+*/}}
+{{- define "marquez.database.port" -}}
+  {{- if eq .Values.postgresql.enabled true -}}
+    {{- printf "%s" "5432" -}}
+  {{- else -}}
+    {{- .Values.marquez.db.port -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Flexible Postgres database name, using an existing or newly created instance.
+*/}}
+{{- define "marquez.database.name" -}}
+  {{- if eq .Values.postgresql.enabled true -}}
+    {{- .Values.postgresql.postgresqlDatabase -}}
+  {{- else -}}
+    {{- .Values.marquez.db.name -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Flexible Postgres database user, using an existing or newly created instance.
+*/}}
+{{- define "marquez.database.user" -}}
+  {{- if eq .Values.postgresql.enabled true -}}
+    {{- .Values.postgresql.postgresqlUsername -}}
+  {{- else -}}
+    {{- .Values.marquez.db.user -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Postgres helm chart expects a specific secret name, when an override is not provided.
+*/}}
+{{- define "marquez.postgresql.secretName" -}}
+{{- if and (.Values.postgresql.enabled) (not .Values.postgresql.existingSecret) -}}
+    {{- printf "%s" (include "marquez.postgresql.fullname" .) -}}
+{{- else if and (.Values.postgresql.enabled) (.Values.postgresql.existingSecret) -}}
+    {{- printf "%s" .Values.postgresql.existingSecret -}}
+{{- else -}}
+    {{- include "marquez.secretName" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Postgres helm chart expects the password to exist within a specific key.
+*/}}
+{{- define "marquez.database.existingsecret.key" -}}
+{{- if .Values.postgresql.enabled -}}
+    {{- printf "%s" "postgresql-password" -}}
+{{- else -}}
+    {{- printf "%s" "marquez-db-password" -}}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-
 {{- if .Values.ingress.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/chart/templates/marquez/configmap.yaml
+++ b/chart/templates/marquez/configmap.yaml
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/chart/templates/marquez/deployment.yaml
+++ b/chart/templates/marquez/deployment.yaml
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,18 +51,18 @@ spec:
             - name: MARQUEZ_CONFIG
               value: /usr/src/app/config.yml
             - name: POSTGRES_HOST
-              value: {{ .Values.marquez.db.host | quote }}
+              value: {{ include "marquez.database.host" . | quote }}
             - name: POSTGRES_PORT
-              value: {{ .Values.marquez.db.port | quote }}
+              value: {{ include "marquez.database.port" . | quote }}
             - name: POSTGRES_DB
-              value: {{ .Values.marquez.db.name }}
+              value: {{ include "marquez.database.name" . | quote }}
             - name: POSTGRES_USER
-              value: {{ .Values.marquez.db.user }}
+              value: {{ include "marquez.database.user" . | quote }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "marquez.secretName" . }}
-                  key: marquez-db-password
+                  name: {{ include "marquez.postgresql.secretName" . }}
+                  key: {{ include "marquez.database.existingsecret.key" . }}
             - name: MIGRATE_ON_STARTUP
               value: {{ .Values.marquez.migrateOnStartup | quote }}
           {{- if .Values.marquez.resources }}

--- a/chart/templates/marquez/secret.yaml
+++ b/chart/templates/marquez/secret.yaml
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-
 {{- if (not .Values.marquez.existingSecretName) -}}
 apiVersion: v1
 kind: Secret
@@ -19,4 +17,4 @@ data:
   {{ else }}
   marquez-db-password: {{ required "A Marquez DB Password is required!" .Values.marquez.db.password }}
   {{- end }}
-  {{- end }}
+{{- end }}

--- a/chart/templates/marquez/service.yaml
+++ b/chart/templates/marquez/service.yaml
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-
 apiVersion: v1
 kind: Service
 metadata:

--- a/chart/templates/tests/marquez-test-connection.yaml
+++ b/chart/templates/tests/marquez-test-connection.yaml
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-
 apiVersion: v1
 kind: Pod
 metadata:

--- a/chart/templates/tests/marquez-web-test-connection.yaml
+++ b/chart/templates/tests/marquez-web-test-connection.yaml
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-
 {{- if .Values.web.enabled }}
 apiVersion: v1
 kind: Pod

--- a/chart/templates/web/deployment.yaml
+++ b/chart/templates/web/deployment.yaml
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-
 {{- if .Values.web.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/chart/templates/web/service.yaml
+++ b/chart/templates/web/service.yaml
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-
 {{- if .Values.web.enabled }}
 apiVersion: v1
 kind: Service

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-
 ## This can be used to override the image registry at a global level, which
 ## can be useful when pulling from private hosts.
 ##
-#global:
+# global:
 #  imageRegistry: myRegistryName
 
 ## Properties related to core Marquez backend functionality and API usage
@@ -89,6 +88,33 @@ web:
     requests: {}
     #    memory: 256Mi
     #    cpu: 250m
+
+## PostgreSQL chart configuration
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
+##
+postgresql:
+  ## @param postgresql.enabled Deploy PostgreSQL container(s)
+  ##
+  enabled: false
+  ## @param postgresql.postgresqlUsername PostgreSQL username
+  ## ref: https://hub.docker.com/_/postgres/
+  ##
+  postgresqlUsername: buendia
+  ## @param postgresql.postgresqlPassword PostgreSQL password
+  ## ref: https://hub.docker.com/_/postgres/
+  ##
+  postgresqlPassword: macondo
+  ## @param postgresql.postgresqlDatabase PostgreSQL database
+  ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run
+  ##
+  postgresqlDatabase: marquez
+  ## @param postgresql.existingSecret Name of existing secret object
+  ## The secret should contain the following keys:
+  ## postgresql-postgres-password (for root user)
+  ## postgresql-password (for the unprivileged user)
+  ##
+  # existingSecret: my-secret
+  existingSecret: ""
 
 ## Additional labels to all the deployed resources; note that
 ## the following standard labels will automatically be applied.


### PR DESCRIPTION
### Problem

The current Helm chart depends on an external Postgres database to function, which introduces challenges to fully automating quality checks via CI/CD.

Additionally, the recent SPDX license update #1846 is preventing the Helm chart from installing and produces the following error message.

`Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: apiVersion not set`

### Solution

Introduced the [Postgres Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) as an optional component, which allows Marquez to deploy into Kubernetes and function without depending on an external Postgres instance. The current limitation of this approach is that the Marquez test data seeding is not available; however, it's expected that can be added as a future enhancement to the Helm chart.

SPDX license updates were reverted from the Helm chart to restore deployment functionality.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [X] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
