### PR TITLE
Fix OpenAPI reference to undefined parameter depth

### DIFF
--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -670,6 +670,15 @@ components:
       description: The ID of the node.
       required: true
 
+    depth:
+      name: depth
+      in: query
+      schema:
+        type: integer
+        default: 20
+      description: Depth of lineage graph to create.
+      required: false
+
     q:
       name: q
       in: query


### PR DESCRIPTION
Signed-off-by: Matt Forbes <matt.forbes@matt.r.forbes@gmail.com>

### Problem

OpenAPI code generator is currently not working due to an unresolved reference to the `depth` parameter in the `/lineage` endpoint.

Closes: #1538

### Solution

Update the openapi yaml to include the `depth` parameter component.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
