### PR TITLE
Remove `marquez-airflow` lib. from release

### DIFF
--- a/new-version.sh
+++ b/new-version.sh
@@ -122,7 +122,7 @@ if [[ "${RELEASE_VERSION}" == *-rc.? ]]; then
 fi
 
 # (1) Bump python module versions
-PYTHON_MODULES=(clients/python/ integrations/airflow/)
+PYTHON_MODULES=(clients/python/)
 for PYTHON_MODULE in "${PYTHON_MODULES[@]}"; do
   (cd "${PYTHON_MODULE}" && bump2version manual --new-version "${PYTHON_RELEASE_VERSION}" --allow-dirty)
 done


### PR DESCRIPTION
### Problem

The script used for the release is currently broken since removing `marquez-airflow` lib.

### Solution

Remove the `marquez-airflow` lib. from the release script.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
