### PR TITLE
[PROPOSAL] Add commit verification step to new-version.sh

### DIFF
--- a/new-version.sh
+++ b/new-version.sh
@@ -167,10 +167,22 @@ sed -i "" "s/version=.*/version=${NEXT_VERSION}/g" gradle.properties
 sed -i "" "s/^  version:.*/  version: ${NEXT_VERSION}/g" ./spec/openapi.yml
 
 # (10) Prepare next development version commit
-git commit -sam "Prepare next development version" --no-verify
+git commit -sam "Prepare next development version ${NEXT_VERSION}" --no-verify
 
-# (11) Push commits and tag
-if [[ ${PUSH} = "true" ]]; then
+# (11) Check for commits in log
+COMMITS=false
+MESSAGE_1=$(git log -1 --grep="Prepare for release ${RELEASE_VERSION}" --pretty=format:%s)
+MESSAGE_2=$(git log -1 --grep="Prepare next development version ${NEXT_VERSION}" --pretty=format:%s)
+
+if [[ $MESSAGE_1 ]] && [[ $MESSAGE_2 ]]; then
+  COMMITS=true
+else
+  echo "one or both commits failed; exiting..."
+  exit 0
+fi
+
+# (12) Push commits and tag
+if [[ $COMMITS = "true" ]] && [[ ${PUSH} = "true" ]]; then
   git push origin main && \
     git push origin "${RELEASE_VERSION}"
 else


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

Currently, the release script pushes to the repository even if one commit fails, which can result in a failing build if `git log` is not run separately.

### Solution

This change adds a verification step that checks the git log for both commits and exits with a message if one of the commits is missing.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
