### PR TITLE
namespaces: allow '=' and ';' in names

### DIFF
--- a/api/src/main/java/marquez/common/models/NamespaceName.java
+++ b/api/src/main/java/marquez/common/models/NamespaceName.java
@@ -21,7 +21,7 @@ public final class NamespaceName {
   private static final int MIN_SIZE = 1;
   private static final int MAX_SIZE = 1024;
   private static final Pattern PATTERN =
-      Pattern.compile(String.format("^[a-zA-Z:/0-9_\\-\\.]{%d,%d}$", MIN_SIZE, MAX_SIZE));
+      Pattern.compile(String.format("^[a-zA-Z:;=/0-9_\\-\\.]{%d,%d}$", MIN_SIZE, MAX_SIZE));
 
   @Getter private final String value;
 
@@ -29,8 +29,8 @@ public final class NamespaceName {
     checkArgument(
         PATTERN.matcher(value).matches(),
         "namespace '%s' must contain only letters (a-z, A-Z), numbers (0-9), "
-            + "underscores (_), dashes (-), colons (:), slashes (/) or dots (.) with a maximum "
-            + "length of %s characters.",
+            + "underscores (_), dashes (-), colons (:), equals (=), semicolons (;), slashes (/) "
+            + "or dots (.) with a maximum length of %s characters.",
         value,
         MAX_SIZE);
     this.value = value;

--- a/api/src/test/java/marquez/OpenLineageIntegrationTest.java
+++ b/api/src/test/java/marquez/OpenLineageIntegrationTest.java
@@ -53,9 +53,9 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void testSendOpenLineageBadArgument() throws IOException {
-    // Namespaces can't have semi-colons, so this will get rejected
+    // Namespaces can't have emojis, so this will get rejected
     String badNamespace =
-        "sqlserver://myhost:3342;user=auser;password=XXXXXXXXXX;database=TheDatabase";
+        "sqlserver://myhost:3342;user=auser;password=\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02;database=TheDatabase";
     LineageEvent event =
         new LineageEvent(
             "COMPLETE",

--- a/api/src/test/java/marquez/common/models/NamespaceNameTest.java
+++ b/api/src/test/java/marquez/common/models/NamespaceNameTest.java
@@ -1,0 +1,31 @@
+package marquez.common.models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@org.junit.jupiter.api.Tag("UnitTests")
+public class NamespaceNameTest {
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "DEFAULT",
+        "database://localhost:1234",
+        "s3://bucket",
+        "bigquery:",
+        "sqlserver://synapse-test-test001.sql.azuresynapse.net;databaseName=TESTPOOL1;",
+        "\u003D"
+      })
+  void testValidNamespaceName(String name) {
+    assertThat(NamespaceName.of(name).getValue()).isEqualTo(name);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"@@@", "\uD83D\uDE02", "!", ""})
+  void testInvalidNamespaceName(String name) {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> NamespaceName.of(name));
+  }
+}


### PR DESCRIPTION
Solve bug in issue https://github.com/OpenLineage/OpenLineage/issues/655 by allowing ';' and '=' in namespace names.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>