### PR TITLE
Add `marquez.podAnnotations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-* Add support for `LifecycleStateChangeFacet` with an ability to softly delete datasets. 
+* Add support for `LifecycleStateChangeFacet` with an ability to softly delete datasets [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+* Enable pod specific annotations in Marquez Helm Chart via `marquez.podAnnotations` [@wslulciuc](https://github.com/wslulciuc)
 
 ## [0.21.0](https://github.com/MarquezProject/marquez/compare/0.20.0...0.21.0) - 2022-03-03
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -45,25 +45,26 @@ helm delete marquez
 
 ### [Marquez](https://github.com/MarquezProject/marquez) **parameters**
 
-| Parameter                    | Description                      | Default                  |
-|------------------------------|----------------------------------|--------------------------|
-| `marquez.replicaCount`       | Number of desired replicas       | `1`                      |
-| `marquez.image.registry`     | Marquez image registry           | `docker.io`              |
-| `marquez.image.repository`   | Marquez image repository         | `marquezproject/marquez` |
-| `marquez.image.tag`          | Marquez image tag                | `0.15.0`                 |
-| `marquez.image.pullPolicy`   | Image pull policy                | `IfNotPresent`           |
+| Parameter                    | Description                            | Default                  |
+|------------------------------|----------------------------------------|--------------------------|
+| `marquez.replicaCount`       | Number of desired replicas             | `1`                      |
+| `marquez.image.registry`     | Marquez image registry                 | `docker.io`              |
+| `marquez.image.repository`   | Marquez image repository               | `marquezproject/marquez` |
+| `marquez.image.tag`          | Marquez image tag                      | `0.15.0`                 |
+| `marquez.image.pullPolicy`   | Image pull policy                      | `IfNotPresent`           |
 | `marquez.existingSecretName` | Name of an existing secret containing db password ('marquez-db-password' key) | `nil` |
-| `marquez.db.host`            | PostgreSQL host                  | `localhost`              |
-| `marquez.db.port`            | PostgreSQL port                  | `5432`                   |
-| `marquez.db.name`            | PostgreSQL database              | `marquez`                |
-| `marquez.db.user`            | PostgreSQL user                  | `buendia`                |
-| `marquez.db.password`        | PostgreSQL password              | `macondo`                |
-| `marquez.migrateOnStartup`   | Execute Flyway migration         | `true`                   |
-| `marquez.hostname`           | Marquez hostname                 | `localhost`              |
-| `marquez.port`               | API host port                    | `5000`                   |
-| `marquez.adminPort`          | Heath/Liveness host port         | `5001`                   |
-| `marquez.resources.limits`   | K8s resource limit overrides     | `nil`                    |
-| `marquez.resources.requests` | K8s resource requests overrides  | `nil`                    |
+| `marquez.db.host`            | PostgreSQL host                        | `localhost`              |
+| `marquez.db.port`            | PostgreSQL port                        | `5432`                   |
+| `marquez.db.name`            | PostgreSQL database                    | `marquez`                |
+| `marquez.db.user`            | PostgreSQL user                        | `buendia`                |
+| `marquez.db.password`        | PostgreSQL password                    | `macondo`                |
+| `marquez.migrateOnStartup`   | Execute Flyway migration               | `true`                   |
+| `marquez.hostname`           | Marquez hostname                       | `localhost`              |
+| `marquez.port`               | API host port                          | `5000`                   |
+| `marquez.adminPort`          | Heath/Liveness host port               | `5001`                   |
+| `marquez.resources.limits`   | K8s resource limit overrides           | `nil`                    |
+| `marquez.resources.requests` | K8s resource requests overrides        | `nil`                    |
+| `marquez.podAnnotations`     | Additional pod annotations for Marquez | `{}`                     |
 
 ### [Marquez Web UI](https://github.com/MarquezProject/marquez-web) **parameters**
 

--- a/chart/templates/marquez/deployment.yaml
+++ b/chart/templates/marquez/deployment.yaml
@@ -7,9 +7,13 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
     app.kubernetes.io/component: marquez
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- range $key, $value := .Values.marquez.podAnnotations }}
+    {{ $key }}: {{ include "common.tplvalues.render" (dict "value" $value "context" $) | quote }}
+    {{- end }}
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -55,6 +55,10 @@ marquez:
     requests: {}
     #    memory: 256Mi
     #    cpu: 250m
+  podAnnotations: {}
+  ## - name:
+  ##   value:
+  ##
 
 ## Properties related to Marquez frontend functionality
 ##


### PR DESCRIPTION
### Problem

The helm chart does not support setting Marquez pod specific annotations.

### Solution

Add `marquez.podAnnotations` to enable users to set Marquez pod specific annotations.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
