### PR TITLE
Update docker-compose setup to use volumes to support remote docker hosts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,12 @@ services:
       - "${API_PORT}:${API_PORT}"
       - "${API_ADMIN_PORT}:${API_ADMIN_PORT}"
     volumes:
-      - ./docker/wait-for-it.sh:/usr/src/app/wait-for-it.sh
+      - utils:/opt/marquez
     links:
       - "db:postgres"
     depends_on:
       - db
-    entrypoint: ["./wait-for-it.sh", "db:5432", "--", "./entrypoint.sh"]
+    entrypoint: ["/opt/marquez/wait-for-it.sh", "db:5432", "--", "./entrypoint.sh"]
 
   web:
     image: "marquezproject/marquez-web:${TAG}"
@@ -42,6 +42,10 @@ services:
       - MARQUEZ_USER=marquez
       - MARQUEZ_PASSWORD=marquez
     volumes:
-      - ./docker/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
+      - db-init:/docker-entrypoint-initdb.d
     # Enables SQL statement logging (see: https://www.postgresql.org/docs/12/runtime-config-logging.html#GUC-LOG-STATEMENT)
     # command: ["postgres", "-c", "log_statement=all"]
+
+volumes:
+  utils:
+  db-init:

--- a/docker/up.sh
+++ b/docker/up.sh
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
+set -x
+
+SCRIPTDIR=$(dirname $0)
 
 title() {
   echo -e "\033[1m${1}\033[0m"
@@ -103,5 +106,7 @@ fi
 if [[ "${SEED}" = "true" ]]; then
   compose_files+=" -f docker-compose.seed.yml"
 fi
+
+$SCRIPTDIR/volumes.sh marquez
 
 API_PORT=${API_PORT} API_ADMIN_PORT=${API_ADMIN_PORT} WEB_PORT=${WEB_PORT} TAG="${TAG}" docker-compose $compose_files up $args

--- a/docker/volumes.sh
+++ b/docker/volumes.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+VOLUME_PREFIX=$1
+
+UTILS_VOLUME="${VOLUME_PREFIX}_utils"
+DB_INIT_VOLUME="${VOLUME_PREFIX}_db-init"
+
+docker volume create $UTILS_VOLUME
+docker volume create $DB_INIT_VOLUME
+docker create --name marquez-volume-helper -v $UTILS_VOLUME:/opt/marquez-utils -v $DB_INIT_VOLUME:/opt/marquez-db-init busybox
+docker cp ./docker/wait-for-it.sh marquez-volume-helper:/opt/marquez-utils/wait-for-it.sh
+docker cp ./docker/init-db.sh marquez-volume-helper:/opt/marquez-db-init/init-db.sh
+
+docker rm marquez-volume-helper


### PR DESCRIPTION
### Problem

If you're using a remote docker host, you can't mount local directories to the running container, which makes it impossible to run the `wait-for-it.sh` and `init-db.sh` scripts. This updates the `up.sh` script to create volumes and copy the scripts, then mount those volumes to the containers. This makes development friendly for both local Docker installations and remote docker hosts.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
