### PR TITLE
[DOCS] Add release process language to RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,3 +19,15 @@
 7. Draft a [new release](https://github.com/MarquezProject/marquez/releases/new) using the release notes for `X.Y.Z` in **step 1** as the release description:
 
    ![](./docs/assets/images/new-release.png)
+
+# Voting on Releases
+
+Anyone may request a new release of the project in the #general Slack channel.
+
+After one is proposed, committers have 48 hours to give a +1 or -1.
+
+Three +1s authorize the release.
+
+Alternatively, if after 2 days the release has received at least one +1 and no -1s, the release is also authorized.
+
+If the proposed release receives no +1s in two days, it is not authorized and the proposer must make a new request to reset the clock.


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

The project lacks a clear, formalized process for proposing and authorizing releases.

### Solution

This PR adds language to RELEASING.md laying out a formal process for proposing and authorizing releases in the community.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
