### PR TITLE
Helm chart: Enable web app to access API

### DIFF
--- a/chart/templates/web/deployment.yaml
+++ b/chart/templates/web/deployment.yaml
@@ -39,7 +39,7 @@ spec:
               port: http
           env:
             - name: MARQUEZ_HOST
-              value: {{ .Values.marquez.hostname | quote }}
+              value: {{ include "common.names.fullname" . }}
             - name: MARQUEZ_PORT
               value: {{ .Values.marquez.port | quote }}
           {{- if .Values.web.resources }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -36,7 +36,7 @@ marquez:
   migrateOnStartup: true
   ## Marquez will run using this hostname
   ##
-  hostname: localhost
+  # hostname: localhost
   ## Marquez API will run on this port
   ##
   port: 5000

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -36,7 +36,7 @@ marquez:
   migrateOnStartup: true
   ## Marquez will run using this hostname
   ##
-  # hostname: localhost
+  hostname: localhost
   ## Marquez API will run on this port
   ##
   port: 5000


### PR DESCRIPTION
### Problem
In the helm chart `values.yaml`, `marquez.hostname` has the value `localhost`
```yaml
  ## Marquez will run using this hostname
  ##
  hostname: localhost
  ## Marquez API will run on this port
  ##
  port: 5000
```
This will not work when deployed in K8s as the web UI front-end and marquez API backend are in different pods. When the web application's proxy tries to connect to `localhost:5000`, it gives 'connection refused' as that refers to localhost:5000 within the web pod.

`localhost:5000` can only be used from within the marquez API pod, which is why the API endpoints are accessible when port-forwarding.

To enable UI frontend pod to talk to the marquez API backed pod deployed in K8s cluster, use K8s Service way of accessing (`<service-name>:<port>`) [1]

***References***
[1] https://www.tutorialworks.com/kubernetes-pod-communication/

Closes: #1967

### Solution

Modify the `MARQUEZ_HOST` environment variable used in the marquez-web deployment to use name of the service :
```yaml
env:
  - name: MARQUEZ_HOST
    value: {{ include "common.names.fullname" . }}
```
With this template, the web app should always be able to talk to the API service as it uses the K8s service address

Once the helm chart is deployed like `helm install marquez . --dependency-update --set postgresql.enabled=true`
the service name being `marquez`,  when UI tries to talk to the backend, it uses `http://marquez:5000`

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
