### PR TITLE
allow @ characters at namespace names

### DIFF
--- a/api/src/main/java/marquez/common/models/NamespaceName.java
+++ b/api/src/main/java/marquez/common/models/NamespaceName.java
@@ -21,7 +21,7 @@ public final class NamespaceName {
   private static final int MIN_SIZE = 1;
   private static final int MAX_SIZE = 1024;
   private static final Pattern PATTERN =
-      Pattern.compile(String.format("^[a-zA-Z:;=/0-9_\\-\\.]{%d,%d}$", MIN_SIZE, MAX_SIZE));
+      Pattern.compile(String.format("^[a-zA-Z:;=/0-9_\\-\\.@]{%d,%d}$", MIN_SIZE, MAX_SIZE));
 
   @Getter private final String value;
 
@@ -29,7 +29,7 @@ public final class NamespaceName {
     checkArgument(
         PATTERN.matcher(value).matches(),
         "namespace '%s' must contain only letters (a-z, A-Z), numbers (0-9), "
-            + "underscores (_), dashes (-), colons (:), equals (=), semicolons (;), slashes (/) "
+            + "underscores (_), at (@), dashes (-), colons (:), equals (=), semicolons (;), slashes (/) "
             + "or dots (.) with a maximum length of %s characters.",
         value,
         MAX_SIZE);

--- a/api/src/test/java/marquez/common/models/NamespaceNameTest.java
+++ b/api/src/test/java/marquez/common/models/NamespaceNameTest.java
@@ -17,14 +17,16 @@ public class NamespaceNameTest {
         "s3://bucket",
         "bigquery:",
         "sqlserver://synapse-test-test001.sql.azuresynapse.net;databaseName=TESTPOOL1;",
-        "\u003D"
+        "\u003D",
+        "@",
+        "abfss://something@.something-else.core.windows.net"
       })
   void testValidNamespaceName(String name) {
     assertThat(NamespaceName.of(name).getValue()).isEqualTo(name);
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"@@@", "\uD83D\uDE02", "!", ""})
+  @ValueSource(strings = {"\uD83D\uDE02", "!", ""})
   void testInvalidNamespaceName(String name) {
     Assertions.assertThrows(IllegalArgumentException.class, () -> NamespaceName.of(name));
   }


### PR DESCRIPTION
This should finally fix https://github.com/MarquezProject/marquez/issues/1839 and https://github.com/MarquezProject/marquez/issues/1793 by allowing `abfss:` like `abfss://root@datalakedev.dfs.core.windows.net` to work. 

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
