### PR TITLE
Upgrade Flywaydb to v7.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * Enable pod specific annotations in Marquez Helm Chart via `marquez.podAnnotations` [@wslulciuc](https://github.com/wslulciuc)
 * Add support for job renaming/redirection via symlink [@collado-mike](https://github.com/collado-mike)
 
+### Changed
+
+* Upgrade Flyway to v7.6.0 [@dakshin-k](https://github.com/dakshin-k)
+
 ## [0.21.0](https://github.com/MarquezProject/marquez/compare/0.20.0...0.21.0) - 2022-03-03
 
 ### Added

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation 'com.google.guava:guava:31.1-jre'
     implementation 'org.dhatim:dropwizard-sentry:2.0.29'
     implementation "io.sentry:sentry:${sentryVersion}"
-    implementation 'org.flywaydb:flyway-core:6.5.7'
+    implementation 'org.flywaydb:flyway-core:7.6.0'
     implementation "org.postgresql:postgresql:${postgresqlVersion}"
     implementation 'com.graphql-java:graphql-java:18.0'
     implementation 'com.graphql-java-kickstart:graphql-java-servlet:12.0.0'

--- a/api/src/main/java/marquez/db/DbMigration.java
+++ b/api/src/main/java/marquez/db/DbMigration.java
@@ -7,6 +7,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.output.MigrateResult;
 
 @Slf4j
 public final class DbMigration {
@@ -31,8 +32,9 @@ public final class DbMigration {
     // issues before app termination.
     try {
       log.info("Migrating database...");
-      final int migrations = flyway.migrate();
-      log.info("Successfully applied '{}' migrations to database.", migrations);
+      final MigrateResult migrateResult = flyway.migrate();
+      log.info(
+          "Successfully applied '{}' migrations to database.", migrateResult.migrationsExecuted);
     } catch (FlywayException errorOnDbMigrate) {
       log.error("Failed to apply migration to database.", errorOnDbMigrate);
       try {


### PR DESCRIPTION
### Problem

Flywaydb [changed](https://github.com/flyway/flyway/commit/fc0f628a3b005b2026a01e7a0b88ec1c6699b6c4#diff-59e44f153051ce6261aa5ff0cb3120d6823dda25ddab4a3dccf12c0c1cfd806aR162) the public migrate API to return an object instead of a raw integer. This updates the migration script to use the new API.

Closes: #1052 

### Solution

Incorporated the API change and bumped the Flyway version in `api/build.gradle`.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
