### PR TITLE
Add java migrations for backfilling runs with job uuids and parents

### DIFF
--- a/api/src/main/java/marquez/common/Utils.java
+++ b/api/src/main/java/marquez/common/Utils.java
@@ -26,6 +26,8 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -37,6 +39,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
@@ -50,6 +53,7 @@ import marquez.common.models.Version;
 import marquez.service.models.DatasetMeta;
 import marquez.service.models.DbTableMeta;
 import marquez.service.models.LineageEvent;
+import marquez.service.models.LineageEvent.ParentRunFacet;
 import marquez.service.models.StreamMeta;
 import org.apache.commons.lang3.tuple.Triple;
 
@@ -60,6 +64,16 @@ public final class Utils {
   public static final Joiner.MapJoiner KV_JOINER = Joiner.on(KV_DELIM).withKeyValueSeparator("=");
   public static final String VERSION_DELIM = ":";
   public static final Joiner VERSION_JOINER = Joiner.on(VERSION_DELIM).skipNulls();
+
+  /**
+   * pre-defined NAMESPACE_URL defined in RFC4122. This is the namespace used by the OpenLineage
+   * Airflow integration for constructing some run IDs as UUIDs. We use the same namespace to
+   * construct the same UUIDs when absolutely necessary (e.g., backfills, backward compatibility)
+   *
+   * @see https://datatracker.ietf.org/doc/html/rfc4122#appendix-C
+   */
+  public static final UUID NAMESPACE_URL_UUID =
+      UUID.fromString("6ba7b811-9dad-11d1-80b4-00c04fd430c8");
 
   private static final ObjectMapper MAPPER = newObjectMapper();
 
@@ -139,6 +153,70 @@ public final class Utils {
         uuidString.length() == UUID_LENGTH,
         String.format("uuidString length must = %d", UUID_LENGTH));
     return UUID.fromString(uuidString);
+  }
+
+  /**
+   * Construct a name-based {@link UUID} based on the {@link #NAMESPACE_URL_UUID} namespace. Name
+   * parts are separated by a dot (.) character.
+   *
+   * @see https://datatracker.ietf.org/doc/html/rfc4122#page-13
+   * @param nameParts
+   * @return
+   */
+  public static UUID toNameBasedUuid(String... nameParts) {
+    String constructedName = String.join(".", nameParts);
+
+    final byte[] nameBytes = constructedName.getBytes(StandardCharsets.UTF_8);
+
+    ByteBuffer buffer = ByteBuffer.allocate(nameBytes.length + 16);
+    buffer.putLong(NAMESPACE_URL_UUID.getMostSignificantBits());
+    buffer.putLong(NAMESPACE_URL_UUID.getLeastSignificantBits());
+    buffer.put(nameBytes);
+
+    return UUID.nameUUIDFromBytes(buffer.array());
+  }
+
+  /**
+   * Construct a UUID from a {@link ParentRunFacet} - if the {@link
+   * marquez.service.models.LineageEvent.RunLink#runId} field is a valid {@link UUID}, use it.
+   * Otherwise, compute a {@link UUID} from the job name and the reported runId. If the job name
+   * contains a dot (.), only return the portion up to the last dot in the name (this attempts to
+   * address airflow tasks, which always report the job name as <dag_name>.<task_name>
+   *
+   * @param parent
+   * @return
+   */
+  public static UUID findParentRunUuid(ParentRunFacet parent) {
+    String jobName = parent.getJob().getName();
+    String parentRunId = parent.getRun().getRunId();
+    return findParentRunUuid(jobName, parentRunId);
+  }
+
+  public static UUID findParentRunUuid(String parentJobName, String parentRunId) {
+    String dagName = parseParentJobName(parentJobName);
+    return toUuid(parentRunId, dagName);
+  }
+
+  public static String parseParentJobName(String parentJobName) {
+    return parentJobName.contains(".")
+        ? parentJobName.substring(0, parentJobName.lastIndexOf('.'))
+        : parentJobName;
+  }
+
+  /**
+   * Compute a UUID from a RunId and a jobName
+   *
+   * @see Utils#toNameBasedUuid(String...) for details on the UUID construction.
+   * @param runId
+   * @param jobName
+   * @return
+   */
+  public static UUID toUuid(@NotNull String runId, String jobName) {
+    try {
+      return UUID.fromString(runId);
+    } catch (IllegalArgumentException e) {
+      return Utils.toNameBasedUuid(jobName, runId);
+    }
   }
 
   public static Instant toInstant(@Nullable final String asIso) {

--- a/api/src/main/java/marquez/common/Utils.java
+++ b/api/src/main/java/marquez/common/Utils.java
@@ -70,7 +70,7 @@ public final class Utils {
    * Airflow integration for constructing some run IDs as UUIDs. We use the same namespace to
    * construct the same UUIDs when absolutely necessary (e.g., backfills, backward compatibility)
    *
-   * @see https://datatracker.ietf.org/doc/html/rfc4122#appendix-C
+   * @see "https://datatracker.ietf.org/doc/html/rfc4122#appendix-C"
    */
   public static final UUID NAMESPACE_URL_UUID =
       UUID.fromString("6ba7b811-9dad-11d1-80b4-00c04fd430c8");
@@ -159,7 +159,7 @@ public final class Utils {
    * Construct a name-based {@link UUID} based on the {@link #NAMESPACE_URL_UUID} namespace. Name
    * parts are separated by a dot (.) character.
    *
-   * @see https://datatracker.ietf.org/doc/html/rfc4122#page-13
+   * @see "https://datatracker.ietf.org/doc/html/rfc4122#page-13"
    * @param nameParts
    * @return
    */
@@ -181,7 +181,7 @@ public final class Utils {
    * marquez.service.models.LineageEvent.RunLink#runId} field is a valid {@link UUID}, use it.
    * Otherwise, compute a {@link UUID} from the job name and the reported runId. If the job name
    * contains a dot (.), only return the portion up to the last dot in the name (this attempts to
-   * address airflow tasks, which always report the job name as <dag_name>.<task_name>
+   * address airflow tasks, which always report the job name as &lt;dag_name&gt;.&lt;task_name&lt;
    *
    * @param parent
    * @return

--- a/api/src/main/java/marquez/db/FlywayFactory.java
+++ b/api/src/main/java/marquez/db/FlywayFactory.java
@@ -31,7 +31,9 @@ public final class FlywayFactory {
   private static final boolean DEFAULT_CLEAN_DISABLED = false;
   private static final boolean DEFAULT_OUT_OF_ORDER = false;
   private static final String DEFAULT_LOCATION = "marquez/db/migration";
-  private static final List<String> DEFAULT_LOCATIONS = ImmutableList.of(DEFAULT_LOCATION);
+  private static final String DEFAULT_MIGRATION_CLASSPATH = "classpath:marquez/db/migrations";
+  private static final List<String> DEFAULT_LOCATIONS =
+      ImmutableList.of(DEFAULT_LOCATION, DEFAULT_MIGRATION_CLASSPATH);
   private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
   private static final String DEFAULT_TABLE = "flyway_schema_history";
   private static final boolean DEFAULT_PLACEHOLDER_REPLACEMENT = false;

--- a/api/src/main/java/marquez/db/migrations/V43_1__UpdateRunsWithJobUUID.java
+++ b/api/src/main/java/marquez/db/migrations/V43_1__UpdateRunsWithJobUUID.java
@@ -1,0 +1,83 @@
+package marquez.db.migrations;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.migration.Context;
+import org.flywaydb.core.api.migration.JavaMigration;
+
+/**
+ * This migration is dependent on the migration found in the SQL script for V43. This updates the
+ * runs table to include the <code>job_uuid</code> value for each record. We update the table in
+ * batches to avoid table-level locks so that concurrent reads and writes can continue to take
+ * place. Auto-commit is enabled, so it is entirely possible that this migration will fail partway
+ * through and some records will retain the <code>job_uuid</code> value while others will not. This
+ * is intentional as no harm will come from leaving these values in place in case of rollback.
+ */
+@Slf4j
+public class V43_1__UpdateRunsWithJobUUID implements JavaMigration {
+
+  @Override
+  public MigrationVersion getVersion() {
+    return MigrationVersion.fromVersion("43.1");
+  }
+
+  // don't execute in a transaction so each batch can be committed immediately
+  @Override
+  public boolean canExecuteInTransaction() {
+    return false;
+  }
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    Connection conn = context.getConnection();
+    try (PreparedStatement queryPs =
+            conn.prepareStatement("SELECT uuid, name, namespace_name FROM jobs");
+        PreparedStatement updatePs =
+            conn.prepareStatement(
+                "UPDATE runs SET job_uuid=? WHERE job_name=? AND namespace_name=?")) {
+
+      ResultSet resultSet = queryPs.executeQuery();
+      boolean isAutoCommit = conn.getAutoCommit();
+      conn.setAutoCommit(true);
+      try {
+        while (resultSet.next()) {
+          String uuid = resultSet.getString("uuid");
+          String jobName = resultSet.getString("name");
+          String namespace = resultSet.getString("namespace_name");
+          updatePs.setObject(1, UUID.fromString(uuid));
+          updatePs.setString(2, jobName);
+          updatePs.setString(3, namespace);
+          if (!updatePs.execute()) {
+            log.error("Unable to execute update of runs for {}.{}", jobName, namespace);
+          }
+        }
+      } finally {
+        conn.setAutoCommit(isAutoCommit);
+      }
+    }
+  }
+
+  @Override
+  public String getDescription() {
+    return "UpdateRunsWithJobUUID";
+  }
+
+  @Override
+  public Integer getChecksum() {
+    return null;
+  }
+
+  @Override
+  public boolean isUndo() {
+    return false;
+  }
+
+  @Override
+  public boolean isBaselineMigration() {
+    return false;
+  }
+}

--- a/api/src/main/java/marquez/db/migrations/V44_1__BackfillAirflowParentRuns.java
+++ b/api/src/main/java/marquez/db/migrations/V44_1__BackfillAirflowParentRuns.java
@@ -1,0 +1,193 @@
+package marquez.db.migrations;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import marquez.common.Utils;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.migration.Context;
+import org.flywaydb.core.api.migration.JavaMigration;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.result.ResultProducers;
+
+/**
+ * This migration is dependent on the migration script in V44__runs_job_versions_add_job_uuid.sql.
+ * The version returned by this code is intentionally after V44, but before V45 so that casual
+ * contributors won't accidentally create a migration script that conflicts with the version of this
+ * one.
+ *
+ * <p>This migration backfills parent jobs and runs for Airflow DAGs that reported ParentRunFacets
+ * that used the task name as the job name and the scheduled run name as the runId. For example,
+ * many Airflow tasks report the ParentRunFacet as <code>
+ *   "parentRun": {
+ *         "job": {
+ *           "name": "simple_shortrunning_dag.tasks__1_of_3",
+ *           "namespace": "abcdefg"
+ *         },
+ *         "run": {
+ *           "runId": "scheduled__2022-03-14T01:40:10+00:00"
+ *         }
+ *       }
+ * </code> The RunId can't be mapped to an existing Marquez run and the job name is actually a
+ * concatenation of the DAG name and the task (which is the name assigned to the job for the task
+ * itself).
+ *
+ * <p>This migration aims to create a real parent run, with a distinct run id, and parent job for
+ * each such run by constructing a deterministic run id from the DAG name and its runId. From each
+ * run, a job is created with the name field set to the DAG name.
+ */
+@Slf4j
+public class V44_1__BackfillAirflowParentRuns implements JavaMigration {
+
+  /**
+   * Return a numeric version that is greater than 44 (so it executes after that one) but before 45
+   */
+  public static final MigrationVersion MIGRATION_VERSION = MigrationVersion.fromVersion("44.1");
+
+  private static final String FIND_AIRFLOW_PARENT_RUNS_SQL =
+      """
+      SELECT DISTINCT(run_uuid) AS run_uuid,
+                     e.parent_run_id,
+                     e.parent_job_name,
+                     e.parent_job_namespace
+      FROM runs r
+      LEFT JOIN LATERAL (
+          SELECT run_uuid,
+                 event->'run'->'facets'->'parent'->'run'->>'runId' AS parent_run_id,
+                 event->'run'->'facets'->'parent'->'job'->>'name' AS parent_job_name,
+                 event->'run'->'facets'->'parent'->'job'->>'namespace' AS parent_job_namespace
+          FROM lineage_events le
+          WHERE le.run_uuid=r.uuid
+          AND event->'run'->'facets'->'parent'->'run'->>'runId' IS NOT NULL
+          AND event->'run'->'facets'->'airflow_version' IS NOT NULL
+          ) e ON e.run_uuid=r.uuid
+      WHERE e.parent_run_id IS NOT NULL
+""";
+  public static final String INSERT_PARENT_JOB_QUERY =
+      """
+      INSERT INTO jobs (uuid, type, created_at, updated_at, namespace_uuid, name, description,
+      namespace_name, current_location)
+      SELECT :uuid, type, created_at, updated_at, namespace_uuid, :name, description, namespace_name,
+      current_location
+      FROM jobs
+      WHERE namespace_name=:namespace AND name=:jobName
+      ON CONFLICT(name, namespace_uuid) WHERE parent_job_uuid IS NULL
+      DO UPDATE SET updated_at=now()
+      RETURNING uuid
+      """;
+  public static final String INSERT_PARENT_RUN_QUERY =
+      """
+      INSERT INTO runs (uuid, created_at, updated_at, current_run_state, external_id, namespace_name, job_name, job_uuid, location, transitioned_at, started_at, ended_at)
+      SELECT :parentRunUuid, created_at, updated_at, current_run_state, :externalRunid, :namespace, :jobName, :parentJobUuid, location, transitioned_at, started_at, ended_at
+      FROM runs
+      WHERE uuid=:runUuid
+      ON CONFLICT (uuid) DO NOTHING
+      """;
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    Jdbi jdbi = Jdbi.create(context.getConnection());
+    List<ParentRun> parentRuns =
+        jdbi.withHandle(
+            h ->
+                h.createQuery(FIND_AIRFLOW_PARENT_RUNS_SQL)
+                    .map(
+                        rs -> {
+                          String parentRunId = rs.getColumn("parent_run_id", String.class);
+                          if (parentRunId == null) {
+                            return null;
+                          }
+                          String parentJobName = rs.getColumn("parent_job_name", String.class);
+                          String dagName =
+                              parentJobName.contains(".")
+                                  ? parentJobName.substring(0, parentJobName.lastIndexOf('.'))
+                                  : parentJobName;
+                          String parentJobNamespace =
+                              rs.getColumn("parent_job_namespace", String.class);
+                          String runUuid = rs.getColumn("run_uuid", String.class);
+                          log.info(
+                              "Found likely airflow run {} with parent {}.{} run {}",
+                              runUuid,
+                              parentJobNamespace,
+                              parentJobName,
+                              parentRunId);
+                          UUID parentRunUuid;
+                          try {
+                            parentRunUuid = UUID.fromString(parentRunId);
+                          } catch (IllegalArgumentException e) {
+                            parentRunUuid = Utils.toNameBasedUuid(dagName, parentRunId);
+                          }
+
+                          return new ParentRun(
+                              UUID.fromString(runUuid),
+                              dagName,
+                              parentJobName,
+                              parentJobNamespace,
+                              parentRunId,
+                              parentRunUuid);
+                        })
+                    .list());
+    parentRuns.forEach(
+        parent -> {
+          UUID parentJobUuid =
+              jdbi.withHandle(
+                  h ->
+                      h.createQuery(INSERT_PARENT_JOB_QUERY)
+                          .bind("uuid", UUID.randomUUID())
+                          .bind("name", parent.dagName())
+                          .bind("namespace", parent.namespace())
+                          .bind("jobName", parent.jobName())
+                          .execute(ResultProducers.returningGeneratedKeys())
+                          .map((rs, ctx) -> UUID.fromString(rs.getString(1)))
+                          .first());
+          jdbi.withHandle(
+              h ->
+                  h.createQuery(INSERT_PARENT_RUN_QUERY)
+                      .bind("parentRunUuid", parent.parentRunId())
+                      .bind("externalRunid", parent.externalParentRunId())
+                      .bind("namespace", parent.namespace())
+                      .bind("jobName", parent.jobName())
+                      .bind("parentJobUuid", parentJobUuid)
+                      .bind("runUuid", parent.runUuid())
+                      .execute(ResultProducers.returningUpdateCount()));
+        });
+  }
+
+  private record ParentRun(
+      UUID runUuid,
+      String dagName,
+      String jobName,
+      String namespace,
+      String externalParentRunId,
+      UUID parentRunId) {}
+
+  @Override
+  public MigrationVersion getVersion() {
+    return MIGRATION_VERSION;
+  }
+
+  @Override
+  public String getDescription() {
+    return "BackfillAirflowParentRuns";
+  }
+
+  @Override
+  public Integer getChecksum() {
+    return null;
+  }
+
+  @Override
+  public boolean isUndo() {
+    return false;
+  }
+
+  @Override
+  public boolean canExecuteInTransaction() {
+    return false;
+  }
+
+  @Override
+  public boolean isBaselineMigration() {
+    return false;
+  }
+}

--- a/api/src/main/java/marquez/db/migrations/V44_2_BackfillJobsWithParents.java
+++ b/api/src/main/java/marquez/db/migrations/V44_2_BackfillJobsWithParents.java
@@ -1,0 +1,154 @@
+package marquez.db.migrations;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import marquez.common.Utils;
+import marquez.service.models.LineageEvent.ParentRunFacet;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.migration.Context;
+import org.flywaydb.core.api.migration.JavaMigration;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.result.ResultProducers;
+
+@Slf4j
+public class V44_2_BackfillJobsWithParents implements JavaMigration {
+
+  public static final String FIND_JOBS_WITH_PARENT_RUNS =
+      """
+      SELECT j.uuid AS job_uuid, p.parent
+      FROM jobs j
+      LEFT JOIN LATERAL(
+        SELECT uuid AS run_uuid FROM runs
+        WHERE job_name=j.name AND namespace_name=j.namespace_name
+        ORDER BY transitioned_at DESC
+        LIMIT 1
+      ) r ON true
+      LEFT JOIN LATERAL (
+        SELECT event->'run'->'facets'->'parent' parent FROM lineage_events
+        WHERE run_uuid=r.run_uuid
+        AND event->'run'->'facets'->'parent' IS NOT NULL
+        ORDER BY event_time DESC
+        LIMIT 1
+      ) p ON true
+      WHERE p.parent IS NOT NULL
+      """;
+
+  public static final String FIND_JOB_UUID_FOR_RUN =
+      """
+      SELECT job_uuid FROM runs WHERE uuid=:uuid AND job_uuid IS NOT NULL
+      """;
+  public static final String INSERT_NEW_JOB_WITH_PARENT =
+      """
+      INSERT INTO jobs(uuid, type, created_at, updated_at, namespace_uuid, name, description,
+        current_version_uuid, namespace_name, current_job_context_uuid, current_location, current_inputs,
+        parent_job_uuid)
+      SELECT :uuid, type, created_at, updated_at, namespace_uuid, name, description, current_version_uuid,
+        namespace_name, current_job_context_uuid, current_location, current_inputs, :parent_job_uuid
+        FROM jobs
+        WHERE uuid=:job_uuid
+        ON CONFLICT (name, namespace_name, parent_job_uuid) DO NOTHING
+        RETURNING uuid
+      """;
+  public static final String SYMLINK_OLD_JOB_TO_NEW =
+      "UPDATE jobs SET symlink_target_uuid=:target_uuid WHERE uuid=:job_uuid";
+
+  @Override
+  public MigrationVersion getVersion() {
+    return MigrationVersion.fromVersion("44.2");
+  }
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    Jdbi jdbi = Jdbi.create(context.getConnection());
+    List<JobParent> jobParents =
+        jdbi.withHandle(
+            h ->
+                h
+                    .createQuery(FIND_JOBS_WITH_PARENT_RUNS)
+                    .map(
+                        (rs, ctx) -> {
+                          Optional<UUID> parentRunUuid = findParentRunIdForJob(rs);
+                          UUID jobId = UUID.fromString(rs.getString("job_uuid"));
+                          return parentRunUuid.map(runId -> new JobParent(jobId, runId));
+                        })
+                    .stream()
+                    .flatMap(Optional::stream)
+                    .collect(Collectors.toList()));
+    jobParents.forEach(
+        jp -> {
+          Optional<UUID> jobUuid =
+              jdbi.withHandle(
+                      h -> h.createQuery(FIND_JOB_UUID_FOR_RUN).bind("uuid", jp.parentRunId))
+                  .map((rs, ctx) -> UUID.fromString(rs.getString("job_uuid")))
+                  .findFirst();
+          jobUuid
+              .flatMap(
+                  uuid ->
+                      jdbi.withHandle(
+                          h ->
+                              h.createQuery(INSERT_NEW_JOB_WITH_PARENT)
+                                  .bind("uuid", UUID.randomUUID())
+                                  .bind("parent_job_uuid", uuid)
+                                  .bind("job_uuid", jp.jobId)
+                                  .execute(ResultProducers.returningGeneratedKeys("uuid"))
+                                  .map(rs -> rs.getColumn("uuid", UUID.class))
+                                  .findFirst()))
+              .ifPresent(
+                  newTargetUuid -> {
+                    jdbi.withHandle(
+                            h ->
+                                h.createQuery(SYMLINK_OLD_JOB_TO_NEW)
+                                    .bind("job_uuid", jp.jobId)
+                                    .bind("target_uuid", newTargetUuid))
+                        .execute(ResultProducers.returningUpdateCount());
+                  });
+        });
+  }
+
+  private Optional<UUID> findParentRunIdForJob(ResultSet resultSet) throws SQLException {
+    String parentJson = resultSet.getString("parent");
+    try {
+      ParentRunFacet parentRunFacet = Utils.getMapper().readValue(parentJson, ParentRunFacet.class);
+      return Optional.of(Utils.findParentRunUuid(parentRunFacet));
+    } catch (JsonProcessingException e) {
+      log.warn(
+          "Unable to process parent run facet from event for run {}: {}",
+          resultSet.getString("run_uuid"),
+          parentJson);
+    }
+    return Optional.empty();
+  }
+
+  private record JobParent(UUID jobId, UUID parentRunId) {}
+
+  @Override
+  public String getDescription() {
+    return "BackfillJobsWithParents";
+  }
+
+  @Override
+  public Integer getChecksum() {
+    return null;
+  }
+
+  @Override
+  public boolean isUndo() {
+    return false;
+  }
+
+  @Override
+  public boolean canExecuteInTransaction() {
+    return false;
+  }
+
+  @Override
+  public boolean isBaselineMigration() {
+    return false;
+  }
+}

--- a/api/src/test/java/marquez/db/BackfillTestUtils.java
+++ b/api/src/test/java/marquez/db/BackfillTestUtils.java
@@ -1,0 +1,119 @@
+package marquez.db;
+
+import static marquez.db.LineageTestUtils.LOCAL_ZONE;
+import static marquez.db.LineageTestUtils.NAMESPACE;
+import static marquez.db.LineageTestUtils.PRODUCER_URL;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.UUID;
+import marquez.common.Utils;
+import marquez.common.models.JobType;
+import marquez.db.models.ExtendedRunRow;
+import marquez.db.models.JobRow;
+import marquez.db.models.NamespaceRow;
+import marquez.db.models.RunArgsRow;
+import marquez.service.models.LineageEvent;
+import marquez.service.models.LineageEvent.JobFacet;
+import marquez.service.models.LineageEvent.JobLink;
+import marquez.service.models.LineageEvent.NominalTimeRunFacet;
+import marquez.service.models.LineageEvent.ParentRunFacet;
+import marquez.service.models.LineageEvent.Run;
+import marquez.service.models.LineageEvent.RunFacet;
+import marquez.service.models.LineageEvent.RunLink;
+import org.jdbi.v3.core.Jdbi;
+import org.postgresql.util.PGobject;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+public class BackfillTestUtils {
+  public static final String COMPLETE = "COMPLETE";
+
+  public static void writeNewEvent(
+      Jdbi jdbi,
+      String jobName,
+      Instant now,
+      NamespaceRow namespace,
+      String parentRunId,
+      String parentJobName)
+      throws SQLException, JsonProcessingException {
+    OpenLineageDao openLineageDao = jdbi.onDemand(OpenLineageDao.class);
+    JobDao jobDao = jdbi.onDemand(JobDao.class);
+    RunArgsDao runArgsDao = jdbi.onDemand(RunArgsDao.class);
+    RunDao runDao = jdbi.onDemand(RunDao.class);
+    PGobject pgInputs = new PGobject();
+    pgInputs.setType("json");
+    pgInputs.setValue("[]");
+    JobRow jobRow =
+        jobDao.upsertJob(
+            UUID.randomUUID(),
+            JobType.BATCH,
+            now,
+            namespace.getUuid(),
+            NAMESPACE,
+            jobName,
+            "description",
+            null,
+            null,
+            null,
+            pgInputs);
+
+    RunArgsRow runArgsRow =
+        runArgsDao.upsertRunArgs(
+            UUID.randomUUID(), now, "{}", Utils.checksumFor(ImmutableMap.of()));
+    UUID runUuid = UUID.randomUUID();
+    ExtendedRunRow runRow =
+        runDao.upsert(
+            runUuid,
+            runUuid.toString(),
+            now,
+            jobRow.getUuid(),
+            null,
+            runArgsRow.getUuid(),
+            now,
+            now,
+            namespace.getUuid(),
+            namespace.getName(),
+            jobName,
+            null,
+            null);
+
+    NominalTimeRunFacet nominalTimeRunFacet = new NominalTimeRunFacet();
+    nominalTimeRunFacet.setNominalStartTime(
+        Instant.now().atZone(LOCAL_ZONE).truncatedTo(ChronoUnit.HOURS));
+    nominalTimeRunFacet.setNominalEndTime(
+        nominalTimeRunFacet.getNominalStartTime().plus(1, ChronoUnit.HOURS));
+    LineageEvent event =
+        new LineageEvent(
+            COMPLETE,
+            Instant.now().atZone(LOCAL_ZONE),
+            new Run(
+                runUuid.toString(),
+                new RunFacet(
+                    nominalTimeRunFacet,
+                    new ParentRunFacet(
+                        LineageTestUtils.PRODUCER_URL,
+                        LineageTestUtils.SCHEMA_URL,
+                        new RunLink(parentRunId),
+                        new JobLink(NAMESPACE, parentJobName)),
+                    ImmutableMap.of("airflow_version", ImmutableMap.of("version", "abc")))),
+            new LineageEvent.Job(
+                NAMESPACE, jobName, new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP)),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            PRODUCER_URL.toString());
+    PGobject eventJson = new PGobject();
+    eventJson.setType("json");
+    eventJson.setValue(Utils.getMapper().writeValueAsString(event));
+    openLineageDao.createLineageEvent(
+        COMPLETE,
+        Instant.now(),
+        runRow.getUuid(),
+        jobName,
+        namespace.getName(),
+        eventJson,
+        PRODUCER_URL.toString());
+  }
+}

--- a/api/src/test/java/marquez/db/LineageTestUtils.java
+++ b/api/src/test/java/marquez/db/LineageTestUtils.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import javax.validation.Valid;
 import lombok.Value;
 import marquez.common.Utils;
 import marquez.db.models.UpdateLineageRow;
@@ -61,6 +62,55 @@ public class LineageTestUtils {
       JobFacet jobFacet,
       List<Dataset> inputs,
       List<Dataset> outputs) {
+    return createLineageRow(dao, jobName, status, jobFacet, inputs, outputs, null);
+  }
+
+  /**
+   * Create an {@link UpdateLineageRow} from the input job details and datasets.
+   *
+   * @param dao
+   * @param jobName
+   * @param status
+   * @param jobFacet
+   * @param inputs
+   * @param outputs
+   * @param parentRunFacet
+   * @return
+   */
+  public static UpdateLineageRow createLineageRow(
+      OpenLineageDao dao,
+      String jobName,
+      String status,
+      JobFacet jobFacet,
+      List<Dataset> inputs,
+      List<Dataset> outputs,
+      @Valid LineageEvent.ParentRunFacet parentRunFacet) {
+    return createLineageRow(
+        dao, jobName, status, jobFacet, inputs, outputs, parentRunFacet, ImmutableMap.of());
+  }
+
+  /**
+   * Create an {@link UpdateLineageRow} from the input job details and datasets.
+   *
+   * @param dao
+   * @param jobName
+   * @param status
+   * @param jobFacet
+   * @param inputs
+   * @param outputs
+   * @param parentRunFacet
+   * @param runFacets
+   * @return
+   */
+  public static UpdateLineageRow createLineageRow(
+      OpenLineageDao dao,
+      String jobName,
+      String status,
+      JobFacet jobFacet,
+      List<Dataset> inputs,
+      List<Dataset> outputs,
+      @Valid LineageEvent.ParentRunFacet parentRunFacet,
+      ImmutableMap<String, Object> runFacets) {
     NominalTimeRunFacet nominalTimeRunFacet = new NominalTimeRunFacet();
     nominalTimeRunFacet.setNominalStartTime(
         Instant.now().atZone(LOCAL_ZONE).truncatedTo(ChronoUnit.HOURS));
@@ -72,7 +122,7 @@ public class LineageTestUtils {
         new LineageEvent(
             status,
             Instant.now().atZone(LOCAL_ZONE),
-            new Run(runId.toString(), new RunFacet(nominalTimeRunFacet, null, ImmutableMap.of())),
+            new Run(runId.toString(), new RunFacet(nominalTimeRunFacet, parentRunFacet, runFacets)),
             new Job(NAMESPACE, jobName, jobFacet),
             inputs,
             outputs,

--- a/api/src/test/java/marquez/db/migrations/V44_1__BackfillAirflowParentRunsTest.java
+++ b/api/src/test/java/marquez/db/migrations/V44_1__BackfillAirflowParentRunsTest.java
@@ -1,0 +1,95 @@
+package marquez.db.migrations;
+
+import static marquez.db.LineageTestUtils.NAMESPACE;
+import static marquez.db.LineageTestUtils.createLineageRow;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import marquez.db.BackfillTestUtils;
+import marquez.db.JobDao;
+import marquez.db.LineageTestUtils;
+import marquez.db.NamespaceDao;
+import marquez.db.OpenLineageDao;
+import marquez.db.RunArgsDao;
+import marquez.db.RunDao;
+import marquez.db.models.NamespaceRow;
+import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
+import marquez.service.models.Job;
+import marquez.service.models.LineageEvent.JobFacet;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.api.migration.Context;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MarquezJdbiExternalPostgresExtension.class)
+class V44_1__BackfillAirflowParentRunsTest {
+
+  static Jdbi jdbi;
+  private static OpenLineageDao openLineageDao;
+  private static JobDao jobDao;
+  private static RunArgsDao runArgsDao;
+  private static RunDao runDao;
+
+  @BeforeAll
+  public static void setUpOnce(Jdbi jdbi) {
+    V44_1__BackfillAirflowParentRunsTest.jdbi = jdbi;
+    openLineageDao = jdbi.onDemand(OpenLineageDao.class);
+    jobDao = jdbi.onDemand(JobDao.class);
+    runArgsDao = jdbi.onDemand(RunArgsDao.class);
+    runDao = jdbi.onDemand(RunDao.class);
+  }
+
+  @Test
+  public void testMigrateAirflowTasks() throws SQLException, JsonProcessingException {
+    String dagName = "airflowDag";
+    String task1Name = dagName + ".task1";
+    NamespaceDao namespaceDao = jdbi.onDemand(NamespaceDao.class);
+    Instant now = Instant.now();
+    NamespaceRow namespace =
+        namespaceDao.upsertNamespaceRow(UUID.randomUUID(), now, NAMESPACE, "me");
+
+    BackfillTestUtils.writeNewEvent(
+        jdbi, task1Name, now, namespace, "schedule:00:00:00", task1Name);
+    BackfillTestUtils.writeNewEvent(
+        jdbi, "airflowDag.task2", now, namespace, "schedule:00:00:00", task1Name);
+
+    createLineageRow(
+        openLineageDao,
+        "a_non_airflow_task",
+        BackfillTestUtils.COMPLETE,
+        new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP),
+        Collections.emptyList(),
+        Collections.emptyList());
+
+    jdbi.useHandle(
+        handle -> {
+          try {
+            new V44_1__BackfillAirflowParentRuns()
+                .migrate(
+                    new Context() {
+                      @Override
+                      public Configuration getConfiguration() {
+                        return null;
+                      }
+
+                      @Override
+                      public Connection getConnection() {
+                        return handle.getConnection();
+                      }
+                    });
+          } catch (Exception e) {
+            throw new AssertionError("Unable to execute migration", e);
+          }
+        });
+    Optional<Job> jobByName = jobDao.findJobByName(NAMESPACE, dagName);
+    assertThat(jobByName).isPresent();
+  }
+}

--- a/api/src/test/java/marquez/db/migrations/V44_2_BackfillJobsWithParentsTest.java
+++ b/api/src/test/java/marquez/db/migrations/V44_2_BackfillJobsWithParentsTest.java
@@ -1,0 +1,97 @@
+package marquez.db.migrations;
+
+import static marquez.db.BackfillTestUtils.writeNewEvent;
+import static marquez.db.LineageTestUtils.NAMESPACE;
+import static marquez.db.LineageTestUtils.createLineageRow;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import marquez.common.models.JobName;
+import marquez.db.JobDao;
+import marquez.db.LineageTestUtils;
+import marquez.db.NamespaceDao;
+import marquez.db.OpenLineageDao;
+import marquez.db.models.NamespaceRow;
+import marquez.db.models.UpdateLineageRow;
+import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
+import marquez.service.models.Job;
+import marquez.service.models.LineageEvent.JobFacet;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.api.migration.Context;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MarquezJdbiExternalPostgresExtension.class)
+class V44_2_BackfillJobsWithParentsTest {
+
+  static Jdbi jdbi;
+  private static OpenLineageDao openLineageDao;
+
+  @BeforeAll
+  public static void setUpOnce(Jdbi jdbi) {
+    V44_2_BackfillJobsWithParentsTest.jdbi = jdbi;
+    openLineageDao = jdbi.onDemand(OpenLineageDao.class);
+  }
+
+  @Test
+  public void testBackfill() throws SQLException, JsonProcessingException {
+    String parentName = "parentJob";
+    UpdateLineageRow parentJob =
+        createLineageRow(
+            openLineageDao,
+            parentName,
+            "COMPLETE",
+            new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP),
+            Collections.emptyList(),
+            Collections.emptyList());
+
+    NamespaceDao namespaceDao = jdbi.onDemand(NamespaceDao.class);
+    Instant now = Instant.now();
+    NamespaceRow namespace =
+        namespaceDao.upsertNamespaceRow(UUID.randomUUID(), now, NAMESPACE, "me");
+
+    String task1Name = "task1";
+    writeNewEvent(
+        jdbi, task1Name, now, namespace, parentJob.getRun().getUuid().toString(), parentName);
+    writeNewEvent(
+        jdbi, "task2", now, namespace, parentJob.getRun().getUuid().toString(), parentName);
+
+    jdbi.useHandle(
+        handle -> {
+          try {
+            Context context =
+                new Context() {
+                  @Override
+                  public Configuration getConfiguration() {
+                    return null;
+                  }
+
+                  @Override
+                  public Connection getConnection() {
+                    return handle.getConnection();
+                  }
+                };
+            // apply migrations in order
+            new V43_1__UpdateRunsWithJobUUID().migrate(context);
+            new V44_2_BackfillJobsWithParents().migrate(context);
+          } catch (Exception e) {
+            throw new AssertionError("Unable to execute migration", e);
+          }
+        });
+
+    JobDao jobDao = jdbi.onDemand(JobDao.class);
+    Optional<Job> jobByName = jobDao.findJobByName(NAMESPACE, task1Name);
+    assertThat(jobByName)
+        .isPresent()
+        .get()
+        .hasFieldOrPropertyWithValue("name", new JobName(parentName + "." + task1Name));
+  }
+}

--- a/api/src/test/java/marquez/jdbi/MarquezJdbiExternalPostgresExtension.java
+++ b/api/src/test/java/marquez/jdbi/MarquezJdbiExternalPostgresExtension.java
@@ -31,7 +31,8 @@ public class MarquezJdbiExternalPostgresExtension extends JdbiExternalPostgresEx
     database = POSTGRES.getDatabaseName();
     plugins.add(new SqlObjectPlugin());
     plugins.add(new PostgresPlugin());
-    migration = Migration.before().withPath("marquez/db/migration");
+    migration =
+        Migration.before().withPaths("marquez/db/migration", "classpath:marquez/db/migrations");
   }
 
   protected DataSource createDataSource() {


### PR DESCRIPTION
### Problem
Continuation of https://github.com/MarquezProject/marquez/pull/1935/files , this adds the migration scripts for populating job parents for Airflow runs and other runs that have explicit parent run ids. Special handling is given to the Airflow tasks to match the [behavior in OpenLineage](https://github.com/OpenLineage/OpenLineage/pull/664). Unit tests are provided to verify the behavior of the backfill scripts

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [X] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
