### PR TITLE
Add javadoc check in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
             - v1-api-{{ .Branch }}
       - run: ./.circleci/get-jdk17.sh
       - run: echo "checks.disable=true" > ~/.testcontainers.properties
+      - run: ./gradlew --no-daemon --stacktrace api:javadoc
       - run: ./gradlew --no-daemon --stacktrace api:build
       - run: ./gradlew --no-daemon api:jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)
@@ -95,6 +96,7 @@ jobs:
             - v1-client-java-{{ .Branch }}-{{ .Revision }}
             - v1-client-java-{{ .Branch }}
       - run: ./.circleci/get-jdk17.sh
+      - run: ./gradlew --no-daemon --stacktrace api:javadoc
       - run: ./gradlew --no-daemon --stacktrace clients:java:build
       - run: ./gradlew --no-daemon clients:java:jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)
@@ -132,7 +134,7 @@ jobs:
             - ./dist/*.whl
             - ./dist/*.tar.gz
 
-  lint-docs-api:
+  lint-spec-api:
     working_directory: ~/marquez
     docker:
       - image: cimg/node:12.22.7
@@ -187,7 +189,7 @@ workflows:
       - build-client-java
       - unit-test-web
       - unit-test-client-python
-      - lint-docs-api
+      - lint-spec-api
   release:
     jobs:
       - build-client-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
             - v1-client-java-{{ .Branch }}-{{ .Revision }}
             - v1-client-java-{{ .Branch }}
       - run: ./.circleci/get-jdk17.sh
-      - run: ./gradlew --no-daemon --stacktrace api:javadoc
+      - run: ./gradlew --no-daemon --stacktrace clients:java:javadoc
       - run: ./gradlew --no-daemon --stacktrace clients:java:build
       - run: ./gradlew --no-daemon clients:java:jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)

--- a/api/src/main/java/marquez/cli/SeedCommand.java
+++ b/api/src/main/java/marquez/cli/SeedCommand.java
@@ -53,7 +53,7 @@ import marquez.client.models.SourceMeta;
  * --port}. This command is meant to be used to explore the features of Marquez. For example,
  * lineage graph, dataset schemas, job run history, etc.
  *
- * <h3>Usage</h3>
+ * <h2>Usage</h2>
  *
  * For example, to override the {@code port}:
  *


### PR DESCRIPTION
### Problem

On a release, we don't have a check for valid javadocs. This results in the `release-java` CI job failing.

### Solution

Add javadoc check in CI for `build-api` and `build-client-java`.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
