### PR TITLE
Fixed key value helm input

### DIFF
--- a/docs/running-on-aws.md
+++ b/docs/running-on-aws.md
@@ -89,9 +89,9 @@ Next, create an AWS RDS instance as outlined in the AWS RDS [documentation](http
 
    ```bash
    helm upgrade --install marquez .
-     --set marquez.db.host <AWS-RDS-HOST>
-     --set marquez.db.user <AWS-RDS-USERNAME>
-     --set marquez.db.password <AWS-RDS-PASSWORD>
+     --set marquez.db.host=<AWS-RDS-HOST>
+     --set marquez.db.user=<AWS-RDS-USERNAME>
+     --set marquez.db.password=<AWS-RDS-PASSWORD>
      --namespace marquez
      --atomic
      --wait


### PR DESCRIPTION
Signed-off-by: Julius Rentergent <julius.rentergent@thetradedesk.com>

Using `key value` pairs causes `Error: "helm upgrade" requires 2 arguments` as tested on Helm v3.8.2

Changing this to `key=value` pairs fixes the issue