### PR TITLE
Remove debugging set -x from docker/up.sh

### DIFF
--- a/docker/up.sh
+++ b/docker/up.sh
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
-set -x
 
 SCRIPTDIR=$(dirname $0)
 


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross@rossturk.com>

### Problem

I believe that `set -x` was inadvertently left in `docker/up.sh`, and it is now noisier than it needs to be.

### Solution

This PR removes `set -x` from `docker/up.sh`.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
