### PR TITLE
Return the tag for postgresql to 12.1.0

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -107,7 +107,7 @@ postgresql:
   ## @param image.tag PostgreSQL image tag (immutable tags are recommended)
   ##
   image:
-    tag: 0.22.0
+    tag: 12.1.0
   ## Authentication parameters
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#setting-the-root-password-on-first-run
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross@rossturk.com>

### Problem

The tag for PostgreSQL was inadvertently updated to 0.22.0 - the Marquez version - during the last release process. This results in a broken chart + some CI consequences.

### Solution

This restores the version back to 12.1.0

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
