### PR TITLE
don't replace @ in namespace name with _

### DIFF
--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -411,7 +411,7 @@ public interface OpenLineageDao extends BaseDao {
   }
 
   default String formatNamespaceName(String namespace) {
-    return namespace.replaceAll("[^a-z:/A-Z0-9\\-_.]", "_");
+    return namespace.replaceAll("[^a-z:/A-Z0-9\\-_.@]", "_");
   }
 
   default JobType getJobType(Job job) {


### PR DESCRIPTION
This will extend the [PR 1972](https://github.com/MarquezProject/marquez/pull/1972) to allow @ namespaces and not replace the @ with _ in the `formatNamespace` method. 

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
