### PR TITLE
Reduce UI limit for list datasets jobs in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/MarquezProject/marquez/compare/0.22.0...HEAD)
 
+### Changed
+
+* Set default limit for listing datasets and jobs in UI from `2000` to `25` [@wslulciuc](https://github.com/wslulciuc)
+
 ## [0.22.0](https://github.com/MarquezProject/marquez/compare/0.21.0...0.22.0) - 2022-05-16
 
 ### Added

--- a/web/src/store/requests/datasets.ts
+++ b/web/src/store/requests/datasets.ts
@@ -4,7 +4,7 @@ import { API_URL } from '../../globals'
 import { DatasetVersions, Datasets } from '../../types/api'
 import { genericFetchWrapper } from './index'
 
-export const getDatasets = async (namespace: string, limit = 2000, offset = 0) => {
+export const getDatasets = async (namespace: string, limit = 25, offset = 0) => {
   const url = `${API_URL}/namespaces/${encodeURIComponent(
     namespace
   )}/datasets?limit=${limit}&offset=${offset}`

--- a/web/src/store/requests/jobs.ts
+++ b/web/src/store/requests/jobs.ts
@@ -4,7 +4,7 @@ import { API_URL } from '../../globals'
 import { Jobs } from '../../types/api'
 import { genericFetchWrapper } from './index'
 
-export const getJobs = async (namespace: string, limit = 2000, offset = 0) => {
+export const getJobs = async (namespace: string, limit = 25, offset = 0) => {
   const url = `${API_URL}/namespaces/${encodeURIComponent(
     namespace
   )}/jobs?limit=${limit}&offset=${offset}`


### PR DESCRIPTION
### Problem

The current UI default limit to list datasets and jobs is `2000` which can be an expensive query. A more ideal approach would be to introduce paging (see https://github.com/MarquezProject/marquez/issues/1711), but for now, let's use a reasonable default `25`.

### Solution

Reduce limit for list datasets jobs from `2000` to `25`.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
