### PR TITLE
Revert changes for 0.23.0

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -107,7 +107,7 @@ postgresql:
   ## @param image.tag PostgreSQL image tag (immutable tags are recommended)
   ##
   image:
-    tag: 0.23.0
+    tag: 12.1.0
   ## Authentication parameters
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#setting-the-root-password-on-first-run
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run

--- a/clients/python/marquez_client/__init__.py
+++ b/clients/python/marquez_client/__init__.py
@@ -13,7 +13,7 @@
 # -*- coding: utf-8 -*-
 
 __author__ = """Marquez Project"""
-__version__ = "__version__ = "0.24.0""
+__version__ = "0.24.0"
 
 from marquez_client.client import MarquezClient              # noqa: F401
 from marquez_client.clients import Clients                   # noqa: F401

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -23,7 +23,7 @@ extras_require["dev"] = set(sum(extras_require.values(), []))
 
 setup(
     name="marquez-python",
-    version="version="0.24.0"",
+    version="0.24.0",
     description="Marquez Python Client",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
### Problem

Changes in release ` 0.23.0` broke the CI build for python.

### Solution

Fix the version format for the py client.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
