### PR TITLE
[DOCS] Add linter to check for headers in Java files

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,16 @@
+# Github Super-Linter Workflows
+
+## Purpose
+
+While technically linters, these workflows check newly added source files in the project for properly formatted license and copyright lines. This method is employed instead of CircleCI workflows because Super-Linter is more easily configurable, with little code, and offers linters for all languages in the project that are pluggable and configurable from a single yaml file.
+
+## Linters
+
+- Java: checkstyles
+
+## Configuration
+
+Linter workflows are serialized and configured in `linter.yml` using environment variables.
+
+For a list of the variables required for each linter, see the Github Actions [docs](https://github.com/marketplace/actions/super-linter#how-to-use).
+

--- a/.github/workflows/checkstyle.header
+++ b/.github/workflows/checkstyle.header
@@ -1,4 +1,4 @@
-/* 
+/*
 /* Copyright 2018-2002 contributors to the Marquez project
 /* SPDX-License-Identifier: Apache-2.0 
 */

--- a/.github/workflows/checkstyle.header
+++ b/.github/workflows/checkstyle.header
@@ -1,0 +1,4 @@
+/* 
+/* Copyright 2018-2002 contributors to the Marquez project
+/* SPDX-License-Identifier: Apache-2.0 
+*/

--- a/.github/workflows/checkstyle_checks.xml
+++ b/.github/workflows/checkstyle_checks.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+  <!--
+      If you set the basedir property below, then all reported file
+      names will be relative to the specified directory. See
+      https://checkstyle.org/config.html#Checker
+      <property name="basedir" value="${basedir}"/>
+  -->
+  
+  <metadata name="org.checkstyle.principle" value="Practice What You Preach"/>
+  <metadata name="org.checkstyle.principle.description"
+            value="In our config we should use all Checks that Checkstyle has"/>
+
+  <property name="cacheFile" value="checkstyle_cache"/>
+
+  <property name="severity" value="error"/>
+
+  <!-- <property name="fileExtensions" value="java, properties, xml, vm, g, g4, dtd"/> -->
+
+  <!-- BeforeExecutionFileFilters is required for sources that are based on java9 -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$" />
+  </module>
+
+  <!-- Headers -->
+  <module name="Header">
+    <property name="headerFile" value="checkstyle.header"/>
+  </module>
+</module>

--- a/.github/workflows/checkstyle_checks.xml
+++ b/.github/workflows/checkstyle_checks.xml
@@ -28,6 +28,6 @@
 
   <!-- Headers -->
   <module name="Header">
-    <property name="headerFile" value="checkstyle.header"/>
+    <property name="headerFile" value=".github/workflows/checkstyle.header"/>
   </module>
 </module>

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,61 @@
+---
+#################################
+#################################
+## Super Linter GitHub Actions ##
+#################################
+#################################
+name: Lint Code Base
+
+#
+# Documentation:
+# https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+    branches-ignore: [master, main]
+    # Remove the line above to run when pushing to master
+  pull_request:
+    branches: [master, main]
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: Lint Code Base
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      - name: Install Dependencies
+        run: pip install pylintfileheader
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: true
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          LINTER_RULES_PATH: /.github/workflows
+          JAVA_FILE_NAME: checkstyle_checks.xml
+          VALIDATE_JAVA: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Lint Code Base
         uses: github/super-linter@v4
         env:
-          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -35,8 +35,6 @@ jobs:
     # Load all steps #
     ##################
     steps:
-      - name: Install Dependencies
-        run: pip install pylintfileheader
       ##########################
       # Checkout the code base #
       ##########################


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

A linter as part of the Github Actions workflows could be used to automate the header checking process after the copyright/license PR is merged.

**Note: this should be merged only after #1996 has been merged.**

### Solution

This PR adds the checkstyles linter to .github/workflows for the purpose of checking Java files for a header.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
