### PR TITLE
namespaces: allow '+' in names

### DIFF
--- a/api/src/main/java/marquez/common/models/NamespaceName.java
+++ b/api/src/main/java/marquez/common/models/NamespaceName.java
@@ -21,7 +21,7 @@ public final class NamespaceName {
   private static final int MIN_SIZE = 1;
   private static final int MAX_SIZE = 1024;
   private static final Pattern PATTERN =
-      Pattern.compile(String.format("^[a-zA-Z:;=/0-9_\\-\\.@]{%d,%d}$", MIN_SIZE, MAX_SIZE));
+      Pattern.compile(String.format("^[a-zA-Z:;=/0-9_\\-\\.@+]{%d,%d}$", MIN_SIZE, MAX_SIZE));
 
   @Getter private final String value;
 
@@ -29,7 +29,7 @@ public final class NamespaceName {
     checkArgument(
         PATTERN.matcher(value).matches(),
         "namespace '%s' must contain only letters (a-z, A-Z), numbers (0-9), "
-            + "underscores (_), at (@), dashes (-), colons (:), equals (=), semicolons (;), slashes (/) "
+            + "underscores (_), at (@), plus (+), dashes (-), colons (:), equals (=), semicolons (;), slashes (/) "
             + "or dots (.) with a maximum length of %s characters.",
         value,
         MAX_SIZE);

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -411,7 +411,7 @@ public interface OpenLineageDao extends BaseDao {
   }
 
   default String formatNamespaceName(String namespace) {
-    return namespace.replaceAll("[^a-z:/A-Z0-9\\-_.@]", "_");
+    return namespace.replaceAll("[^a-z:/A-Z0-9\\-_.@+]", "_");
   }
 
   default JobType getJobType(Job job) {

--- a/api/src/test/java/marquez/common/models/NamespaceNameTest.java
+++ b/api/src/test/java/marquez/common/models/NamespaceNameTest.java
@@ -19,7 +19,8 @@ public class NamespaceNameTest {
         "sqlserver://synapse-test-test001.sql.azuresynapse.net;databaseName=TESTPOOL1;",
         "\u003D",
         "@",
-        "abfss://something@.something-else.core.windows.net"
+        "abfss://something@.something-else.core.windows.net",
+        "databricks+connector://asdf-123456-7890.cloud.databricks.com"
       })
   void testValidNamespaceName(String name) {
     assertThat(NamespaceName.of(name).getValue()).isEqualTo(name);


### PR DESCRIPTION
Fix rejecting databricks namespaces with `+`. 

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

Closes: #2022 
