### PR TITLE
[DOCS] Add flake8 linter to Github Actions workflows

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Lint Code Base
         uses: github/super-linter@v4
         env:
-          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -57,8 +57,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
           LINTER_RULES_PATH: /.github/workflows
-          JAVA_FILE_NAME: checkstyle_checks.xml
-          VALIDATE_JAVA: false
+          # JAVA_FILE_NAME: checkstyle_checks.xml
+          # VALIDATE_JAVA: false
 
           PYTHON_FLAKE8_CONFIG_FILE: setup.cfg
           VALIDATE_PYTHON: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Lint Code Base
         uses: github/super-linter@v4
         env:
-          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -56,9 +56,5 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-          LINTER_RULES_PATH: /.github/workflows
-          JAVA_FILE_NAME: checkstyle_checks.xml
-          VALIDATE_JAVA: true
-
           PYTHON_FLAKE8_CONFIG_FILE: setup.cfg
           VALIDATE_PYTHON_FLAKE8: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -36,7 +36,7 @@ jobs:
     ##################
     steps:
       - name: Install Dependencies
-      - run: pip install flake8-copyright
+        run: pip install flake8-copyright
       ##########################
       # Checkout the code base #
       ##########################
@@ -58,7 +58,7 @@ jobs:
 
           LINTER_RULES_PATH: /.github/workflows
           JAVA_FILE_NAME: checkstyle_checks.xml
-          VALIDATE_JAVA: true
+          VALIDATE_JAVA: false
 
           PYTHON_FLAKE8_CONFIG_FILE: setup.cfg
           VALIDATE_PYTHON: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -57,8 +57,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
           LINTER_RULES_PATH: /.github/workflows
-          # JAVA_FILE_NAME: checkstyle_checks.xml
-          # VALIDATE_JAVA: false
+          JAVA_FILE_NAME: checkstyle_checks.xml
+          VALIDATE_JAVA: false
 
           PYTHON_FLAKE8_CONFIG_FILE: setup.cfg
-          VALIDATE_PYTHON: true
+          VALIDATE_PYTHON_FLAKE8: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -58,7 +58,7 @@ jobs:
 
           LINTER_RULES_PATH: /.github/workflows
           JAVA_FILE_NAME: checkstyle_checks.xml
-          VALIDATE_JAVA: false
+          # VALIDATE_JAVA: true
 
           PYTHON_FLAKE8_CONFIG_FILE: setup.cfg
           VALIDATE_PYTHON_FLAKE8: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -56,5 +56,5 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-          PYTHON_FLAKE8_CONFIG_FILE: setup.cfg
+          PYTHON_FLAKE8_LINTER_RULES: setup.cfg
           VALIDATE_PYTHON_FLAKE8: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -57,8 +57,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
           LINTER_RULES_PATH: /.github/workflows
-          # JAVA_FILE_NAME: checkstyle_checks.xml
-          # VALIDATE_JAVA: true
+          JAVA_FILE_NAME: checkstyle_checks.xml
+          VALIDATE_JAVA: true
 
           PYTHON_FLAKE8_CONFIG_FILE: setup.cfg
           VALIDATE_PYTHON_FLAKE8: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -57,7 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
           LINTER_RULES_PATH: /.github/workflows
-          JAVA_FILE_NAME: checkstyle_checks.xml
+          # JAVA_FILE_NAME: checkstyle_checks.xml
           # VALIDATE_JAVA: true
 
           PYTHON_FLAKE8_CONFIG_FILE: setup.cfg

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,64 @@
+---
+#################################
+#################################
+## Super Linter GitHub Actions ##
+#################################
+#################################
+name: Lint Code Base
+
+#
+# Documentation:
+# https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+    branches-ignore: [master, main]
+    # Remove the line above to run when pushing to master
+  pull_request:
+    branches: [master, main]
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: Lint Code Base
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      - name: Install Dependencies
+      - run: pip install flake8-copyright
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          LINTER_RULES_PATH: /.github/workflows
+          JAVA_FILE_NAME: checkstyle_checks.xml
+          VALIDATE_JAVA: true
+
+          PYTHON_FLAKE8_CONFIG_FILE: setup.cfg
+          VALIDATE_PYTHON: true

--- a/.github/workflows/setup.cfg
+++ b/.github/workflows/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+copyright-check = True
+# C errors are not selected by default, so add them to your selection
+select = E,F,W,C

--- a/.github/workflows/setup.cfg
+++ b/.github/workflows/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 copyright-check = True
 # C errors are not selected by default, so add them to your selection
-select = E,F,W,C
+select = C


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

A linter could be configured to check new Python source files for copyright and license headers.

### Solution

This PR adds flake8 to Super_Linter in Github Actions and configures it with a plugin for checking files for copyright text.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
