### PR TITLE
Fix job grouping migration scripts to run in correct order

### DIFF
--- a/api/src/main/java/marquez/db/migrations/V44_1__UpdateRunsWithJobUUID.java
+++ b/api/src/main/java/marquez/db/migrations/V44_1__UpdateRunsWithJobUUID.java
@@ -23,11 +23,11 @@ import org.flywaydb.core.api.migration.JavaMigration;
  * is intentional as no harm will come from leaving these values in place in case of rollback.
  */
 @Slf4j
-public class V43_1__UpdateRunsWithJobUUID implements JavaMigration {
+public class V44_1__UpdateRunsWithJobUUID implements JavaMigration {
 
   @Override
   public MigrationVersion getVersion() {
-    return MigrationVersion.fromVersion("43.1");
+    return MigrationVersion.fromVersion("44.1");
   }
 
   // don't execute in a transaction so each batch can be committed immediately

--- a/api/src/main/java/marquez/db/migrations/V44_2__BackfillAirflowParentRuns.java
+++ b/api/src/main/java/marquez/db/migrations/V44_2__BackfillAirflowParentRuns.java
@@ -42,12 +42,12 @@ import org.jdbi.v3.core.result.ResultProducers;
  * run, a job is created with the name field set to the DAG name.
  */
 @Slf4j
-public class V44_1__BackfillAirflowParentRuns implements JavaMigration {
+public class V44_2__BackfillAirflowParentRuns implements JavaMigration {
 
   /**
    * Return a numeric version that is greater than 44 (so it executes after that one) but before 45
    */
-  public static final MigrationVersion MIGRATION_VERSION = MigrationVersion.fromVersion("44.1");
+  public static final MigrationVersion MIGRATION_VERSION = MigrationVersion.fromVersion("44.2");
 
   private static final String FIND_AIRFLOW_PARENT_RUNS_SQL =
       """

--- a/api/src/main/java/marquez/db/migrations/V44_3_BackfillJobsWithParents.java
+++ b/api/src/main/java/marquez/db/migrations/V44_3_BackfillJobsWithParents.java
@@ -22,7 +22,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.result.ResultProducers;
 
 @Slf4j
-public class V44_2_BackfillJobsWithParents implements JavaMigration {
+public class V44_3_BackfillJobsWithParents implements JavaMigration {
 
   public static final String FIND_JOBS_WITH_PARENT_RUNS =
       """
@@ -65,7 +65,7 @@ public class V44_2_BackfillJobsWithParents implements JavaMigration {
 
   @Override
   public MigrationVersion getVersion() {
-    return MigrationVersion.fromVersion("44.2");
+    return MigrationVersion.fromVersion("44.3");
   }
 
   @Override

--- a/api/src/test/java/marquez/db/migrations/V44_2__BackfillAirflowParentRunsTest.java
+++ b/api/src/test/java/marquez/db/migrations/V44_2__BackfillAirflowParentRunsTest.java
@@ -5,7 +5,6 @@
 
 package marquez.db.migrations;
 
-import static marquez.db.BackfillTestUtils.writeNewEvent;
 import static marquez.db.LineageTestUtils.NAMESPACE;
 import static marquez.db.LineageTestUtils.createLineageRow;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,13 +16,14 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
-import marquez.common.models.JobName;
+import marquez.db.BackfillTestUtils;
 import marquez.db.JobDao;
 import marquez.db.LineageTestUtils;
 import marquez.db.NamespaceDao;
 import marquez.db.OpenLineageDao;
+import marquez.db.RunArgsDao;
+import marquez.db.RunDao;
 import marquez.db.models.NamespaceRow;
-import marquez.db.models.UpdateLineageRow;
 import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
 import marquez.service.models.Job;
 import marquez.service.models.LineageEvent.JobFacet;
@@ -35,68 +35,66 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(MarquezJdbiExternalPostgresExtension.class)
-class V44_2_BackfillJobsWithParentsTest {
+class V44_2__BackfillAirflowParentRunsTest {
 
   static Jdbi jdbi;
   private static OpenLineageDao openLineageDao;
+  private static JobDao jobDao;
+  private static RunArgsDao runArgsDao;
+  private static RunDao runDao;
 
   @BeforeAll
   public static void setUpOnce(Jdbi jdbi) {
-    V44_2_BackfillJobsWithParentsTest.jdbi = jdbi;
+    V44_2__BackfillAirflowParentRunsTest.jdbi = jdbi;
     openLineageDao = jdbi.onDemand(OpenLineageDao.class);
+    jobDao = jdbi.onDemand(JobDao.class);
+    runArgsDao = jdbi.onDemand(RunArgsDao.class);
+    runDao = jdbi.onDemand(RunDao.class);
   }
 
   @Test
-  public void testBackfill() throws SQLException, JsonProcessingException {
-    String parentName = "parentJob";
-    UpdateLineageRow parentJob =
-        createLineageRow(
-            openLineageDao,
-            parentName,
-            "COMPLETE",
-            new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP),
-            Collections.emptyList(),
-            Collections.emptyList());
-
+  public void testMigrateAirflowTasks() throws SQLException, JsonProcessingException {
+    String dagName = "airflowDag";
+    String task1Name = dagName + ".task1";
     NamespaceDao namespaceDao = jdbi.onDemand(NamespaceDao.class);
     Instant now = Instant.now();
     NamespaceRow namespace =
         namespaceDao.upsertNamespaceRow(UUID.randomUUID(), now, NAMESPACE, "me");
 
-    String task1Name = "task1";
-    writeNewEvent(
-        jdbi, task1Name, now, namespace, parentJob.getRun().getUuid().toString(), parentName);
-    writeNewEvent(
-        jdbi, "task2", now, namespace, parentJob.getRun().getUuid().toString(), parentName);
+    BackfillTestUtils.writeNewEvent(
+        jdbi, task1Name, now, namespace, "schedule:00:00:00", task1Name);
+    BackfillTestUtils.writeNewEvent(
+        jdbi, "airflowDag.task2", now, namespace, "schedule:00:00:00", task1Name);
+
+    createLineageRow(
+        openLineageDao,
+        "a_non_airflow_task",
+        BackfillTestUtils.COMPLETE,
+        new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP),
+        Collections.emptyList(),
+        Collections.emptyList());
 
     jdbi.useHandle(
         handle -> {
           try {
-            Context context =
-                new Context() {
-                  @Override
-                  public Configuration getConfiguration() {
-                    return null;
-                  }
+            new V44_2__BackfillAirflowParentRuns()
+                .migrate(
+                    new Context() {
+                      @Override
+                      public Configuration getConfiguration() {
+                        return null;
+                      }
 
-                  @Override
-                  public Connection getConnection() {
-                    return handle.getConnection();
-                  }
-                };
-            // apply migrations in order
-            new V43_1__UpdateRunsWithJobUUID().migrate(context);
-            new V44_2_BackfillJobsWithParents().migrate(context);
+                      @Override
+                      public Connection getConnection() {
+                        return handle.getConnection();
+                      }
+                    });
           } catch (Exception e) {
             throw new AssertionError("Unable to execute migration", e);
           }
         });
-
-    JobDao jobDao = jdbi.onDemand(JobDao.class);
-    Optional<Job> jobByName = jobDao.findJobByName(NAMESPACE, task1Name);
-    assertThat(jobByName)
-        .isPresent()
-        .get()
-        .hasFieldOrPropertyWithValue("name", new JobName(parentName + "." + task1Name));
+    Optional<Job> jobByName = jobDao.findJobByName(NAMESPACE, dagName);
+    assertThat(jobByName).isPresent();
   }
 }

--- a/api/src/test/java/marquez/db/migrations/V44_3_BackfillJobsWithParentsTest.java
+++ b/api/src/test/java/marquez/db/migrations/V44_3_BackfillJobsWithParentsTest.java
@@ -5,6 +5,7 @@
 
 package marquez.db.migrations;
 
+import static marquez.db.BackfillTestUtils.writeNewEvent;
 import static marquez.db.LineageTestUtils.NAMESPACE;
 import static marquez.db.LineageTestUtils.createLineageRow;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,14 +17,13 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
-import marquez.db.BackfillTestUtils;
+import marquez.common.models.JobName;
 import marquez.db.JobDao;
 import marquez.db.LineageTestUtils;
 import marquez.db.NamespaceDao;
 import marquez.db.OpenLineageDao;
-import marquez.db.RunArgsDao;
-import marquez.db.RunDao;
 import marquez.db.models.NamespaceRow;
+import marquez.db.models.UpdateLineageRow;
 import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
 import marquez.service.models.Job;
 import marquez.service.models.LineageEvent.JobFacet;
@@ -35,66 +35,68 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(MarquezJdbiExternalPostgresExtension.class)
-class V44_1__BackfillAirflowParentRunsTest {
+class V44_3_BackfillJobsWithParentsTest {
 
   static Jdbi jdbi;
   private static OpenLineageDao openLineageDao;
-  private static JobDao jobDao;
-  private static RunArgsDao runArgsDao;
-  private static RunDao runDao;
 
   @BeforeAll
   public static void setUpOnce(Jdbi jdbi) {
-    V44_1__BackfillAirflowParentRunsTest.jdbi = jdbi;
+    V44_3_BackfillJobsWithParentsTest.jdbi = jdbi;
     openLineageDao = jdbi.onDemand(OpenLineageDao.class);
-    jobDao = jdbi.onDemand(JobDao.class);
-    runArgsDao = jdbi.onDemand(RunArgsDao.class);
-    runDao = jdbi.onDemand(RunDao.class);
   }
 
   @Test
-  public void testMigrateAirflowTasks() throws SQLException, JsonProcessingException {
-    String dagName = "airflowDag";
-    String task1Name = dagName + ".task1";
+  public void testBackfill() throws SQLException, JsonProcessingException {
+    String parentName = "parentJob";
+    UpdateLineageRow parentJob =
+        createLineageRow(
+            openLineageDao,
+            parentName,
+            "COMPLETE",
+            new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP),
+            Collections.emptyList(),
+            Collections.emptyList());
+
     NamespaceDao namespaceDao = jdbi.onDemand(NamespaceDao.class);
     Instant now = Instant.now();
     NamespaceRow namespace =
         namespaceDao.upsertNamespaceRow(UUID.randomUUID(), now, NAMESPACE, "me");
 
-    BackfillTestUtils.writeNewEvent(
-        jdbi, task1Name, now, namespace, "schedule:00:00:00", task1Name);
-    BackfillTestUtils.writeNewEvent(
-        jdbi, "airflowDag.task2", now, namespace, "schedule:00:00:00", task1Name);
-
-    createLineageRow(
-        openLineageDao,
-        "a_non_airflow_task",
-        BackfillTestUtils.COMPLETE,
-        new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP),
-        Collections.emptyList(),
-        Collections.emptyList());
+    String task1Name = "task1";
+    writeNewEvent(
+        jdbi, task1Name, now, namespace, parentJob.getRun().getUuid().toString(), parentName);
+    writeNewEvent(
+        jdbi, "task2", now, namespace, parentJob.getRun().getUuid().toString(), parentName);
 
     jdbi.useHandle(
         handle -> {
           try {
-            new V44_1__BackfillAirflowParentRuns()
-                .migrate(
-                    new Context() {
-                      @Override
-                      public Configuration getConfiguration() {
-                        return null;
-                      }
+            Context context =
+                new Context() {
+                  @Override
+                  public Configuration getConfiguration() {
+                    return null;
+                  }
 
-                      @Override
-                      public Connection getConnection() {
-                        return handle.getConnection();
-                      }
-                    });
+                  @Override
+                  public Connection getConnection() {
+                    return handle.getConnection();
+                  }
+                };
+            // apply migrations in order
+            new V44_1__UpdateRunsWithJobUUID().migrate(context);
+            new V44_3_BackfillJobsWithParents().migrate(context);
           } catch (Exception e) {
             throw new AssertionError("Unable to execute migration", e);
           }
         });
-    Optional<Job> jobByName = jobDao.findJobByName(NAMESPACE, dagName);
-    assertThat(jobByName).isPresent();
+
+    JobDao jobDao = jdbi.onDemand(JobDao.class);
+    Optional<Job> jobByName = jobDao.findJobByName(NAMESPACE, task1Name);
+    assertThat(jobByName)
+        .isPresent()
+        .get()
+        .hasFieldOrPropertyWithValue("name", new JobName(parentName + "." + task1Name));
   }
 }


### PR DESCRIPTION
### Problem

At some point during the development of https://github.com/MarquezProject/marquez/issues/1928 , the migration script order was changed, but the java class names didn't reflect the order required by the sql scripts. The java migrations referred to the `job_uuid` field of the runs table, which was moved to the v44 migration, but the java version names didn't change to reflect that.

### Solution

This fixes the migration script names so they'll be applied in the correct order.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
