### PR TITLE
Fix references in SQL to runs and jobs table to point to views

### DIFF
--- a/api/src/main/java/marquez/graphql/GraphqlDaos.java
+++ b/api/src/main/java/marquez/graphql/GraphqlDaos.java
@@ -84,7 +84,7 @@ public interface GraphqlDaos extends SqlObject {
   List<RowMap<String, Object>> getDistinctJobVersionsByDatasetVersion(UUID datasetVersionUuid);
 
   @SqlQuery(
-      "SELECT distinct jv.* from dataset_versions dv inner join runs r on r.uuid = dv.run_uuid inner join job_versions jv on jv.uuid = r.job_version_uuid where dv.uuid = :datasetVersionUuid")
+      "SELECT distinct jv.* from dataset_versions dv inner join runs_view r on r.uuid = dv.run_uuid inner join job_versions jv on jv.uuid = r.job_version_uuid where dv.uuid = :datasetVersionUuid")
   List<RowMap<String, Object>> getDistinctJobVersionsByDatasetVersionOutput(
       UUID datasetVersionUuid);
 
@@ -222,7 +222,7 @@ public interface GraphqlDaos extends SqlObject {
           -- output jobs for each input dataset
               left outer join (
                    select io_of_in.dataset_uuid, jsonb_agg((select x from (select j_of_in.name, j_of_in.namespace_name as namespace) as x)) as in_agg
-                   from jobs j_of_in
+                   from jobs_view j_of_in
                    left outer join job_versions_io_mapping io_of_in on io_of_in.job_version_uuid = j_of_in.current_version_uuid
                     and io_of_in.io_type = 'INPUT'
                    group by io_of_in.dataset_uuid

--- a/api/src/test/java/marquez/OpenLineageIntegrationTest.java
+++ b/api/src/test/java/marquez/OpenLineageIntegrationTest.java
@@ -261,6 +261,9 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
     assertThat(runsList).isNotEmpty().hasSize(1);
     UUID parentRunUuid = Utils.toNameBasedUuid(dagName, airflowParentRunId);
     assertThat(runsList.get(0)).hasFieldOrPropertyWithValue("id", parentRunUuid.toString());
+
+    List<Run> taskRunsList = client.listRuns(NAMESPACE_NAME, dagName + "." + task1Name);
+    assertThat(taskRunsList).hasSize(1);
   }
 
   @Test


### PR DESCRIPTION
### Problem

Fixes some dangling references to the `jobs` and `runs` table rather than the views. I updated an existing unit test to verify the issue (verified it fails before the fix)
> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
