### PR TITLE
Add @FlywayTarget annotation to migration tests to control flyway upg…

### DIFF
--- a/api/src/main/java/marquez/db/migrations/V44_2__BackfillAirflowParentRuns.java
+++ b/api/src/main/java/marquez/db/migrations/V44_2__BackfillAirflowParentRuns.java
@@ -64,7 +64,7 @@ public class V44_2__BackfillAirflowParentRuns implements JavaMigration {
           FROM lineage_events le
           WHERE le.run_uuid=r.uuid
           AND event->'run'->'facets'->'parent'->'run'->>'runId' IS NOT NULL
-          AND event->'run'->'facets'->'airflow_version' IS NOT NULL
+          AND event->'run'->'facets'->>'airflow_version' IS NOT NULL
           ) e ON e.run_uuid=r.uuid
       WHERE e.parent_run_id IS NOT NULL
 """;
@@ -76,8 +76,8 @@ public class V44_2__BackfillAirflowParentRuns implements JavaMigration {
       current_location
       FROM jobs
       WHERE namespace_name=:namespace AND name=:jobName
-      ON CONFLICT(name, namespace_uuid) WHERE parent_job_uuid IS NULL
-      DO UPDATE SET updated_at=now()
+      ON CONFLICT (name, namespace_uuid) WHERE parent_job_uuid IS NULL
+      DO UPDATE SET updated_at=EXCLUDED.updated_at
       RETURNING uuid
       """;
   public static final String INSERT_PARENT_RUN_QUERY =

--- a/api/src/test/java/marquez/db/BackfillTestUtils.java
+++ b/api/src/test/java/marquez/db/BackfillTestUtils.java
@@ -14,11 +14,10 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.UUID;
 import marquez.common.Utils;
-import marquez.common.models.JobType;
 import marquez.db.models.ExtendedRunRow;
-import marquez.db.models.JobRow;
 import marquez.db.models.NamespaceRow;
 import marquez.db.models.RunArgsRow;
 import marquez.service.models.LineageEvent;
@@ -36,7 +35,7 @@ import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 public class BackfillTestUtils {
   public static final String COMPLETE = "COMPLETE";
 
-  public static void writeNewEvent(
+  public static ExtendedRunRow writeNewEvent(
       Jdbi jdbi,
       String jobName,
       Instant now,
@@ -45,25 +44,9 @@ public class BackfillTestUtils {
       String parentJobName)
       throws SQLException, JsonProcessingException {
     OpenLineageDao openLineageDao = jdbi.onDemand(OpenLineageDao.class);
-    JobDao jobDao = jdbi.onDemand(JobDao.class);
     RunArgsDao runArgsDao = jdbi.onDemand(RunArgsDao.class);
     RunDao runDao = jdbi.onDemand(RunDao.class);
-    PGobject pgInputs = new PGobject();
-    pgInputs.setType("json");
-    pgInputs.setValue("[]");
-    JobRow jobRow =
-        jobDao.upsertJob(
-            UUID.randomUUID(),
-            JobType.BATCH,
-            now,
-            namespace.getUuid(),
-            NAMESPACE,
-            jobName,
-            "description",
-            null,
-            null,
-            null,
-            pgInputs);
+    UUID jobUuid = writeJob(jdbi, jobName, now, namespace);
 
     RunArgsRow runArgsRow =
         runArgsDao.upsertRunArgs(
@@ -75,7 +58,7 @@ public class BackfillTestUtils {
             null,
             runUuid.toString(),
             now,
-            jobRow.getUuid(),
+            jobUuid,
             null,
             runArgsRow.getUuid(),
             now,
@@ -91,6 +74,15 @@ public class BackfillTestUtils {
         Instant.now().atZone(LOCAL_ZONE).truncatedTo(ChronoUnit.HOURS));
     nominalTimeRunFacet.setNominalEndTime(
         nominalTimeRunFacet.getNominalStartTime().plus(1, ChronoUnit.HOURS));
+    Optional<ParentRunFacet> parentRun =
+        Optional.ofNullable(parentRunId)
+            .map(
+                runId ->
+                    new ParentRunFacet(
+                        PRODUCER_URL,
+                        LineageTestUtils.SCHEMA_URL,
+                        new RunLink(runId),
+                        new JobLink(NAMESPACE, parentJobName)));
     LineageEvent event =
         new LineageEvent(
             COMPLETE,
@@ -99,11 +91,7 @@ public class BackfillTestUtils {
                 runUuid.toString(),
                 new RunFacet(
                     nominalTimeRunFacet,
-                    new ParentRunFacet(
-                        LineageTestUtils.PRODUCER_URL,
-                        LineageTestUtils.SCHEMA_URL,
-                        new RunLink(parentRunId),
-                        new JobLink(NAMESPACE, parentJobName)),
+                    parentRun.orElse(null),
                     ImmutableMap.of("airflow_version", ImmutableMap.of("version", "abc")))),
             new LineageEvent.Job(
                 NAMESPACE, jobName, new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP)),
@@ -121,5 +109,45 @@ public class BackfillTestUtils {
         namespace.getName(),
         eventJson,
         PRODUCER_URL.toString());
+    return runRow;
+  }
+
+  public static UUID writeJob(Jdbi jdbi, String jobName, Instant now, NamespaceRow namespace)
+      throws SQLException {
+    PGobject pgInputs = new PGobject();
+    pgInputs.setType("json");
+    pgInputs.setValue("[]");
+    return jdbi.withHandle(
+        h -> {
+          UUID jobContextUuid =
+              h.createQuery(
+                      """
+INSERT INTO job_contexts (uuid, created_at, context, checksum) VALUES (:uuid, :now, :context, :checksum)
+ON CONFLICT (checksum) DO UPDATE SET created_at=EXCLUDED.created_at
+RETURNING uuid
+""")
+                  .bind("uuid", UUID.randomUUID())
+                  .bind("now", now)
+                  .bind("context", "")
+                  .bind("checksum", "")
+                  .mapTo(UUID.class)
+                  .first();
+          return h.createQuery(
+                  """
+                  INSERT INTO jobs (uuid, type, created_at, updated_at, namespace_uuid, name, namespace_name, current_job_context_uuid, current_inputs)
+                  VALUES (:uuid, :type, :now, :now, :namespaceUuid, :name, :namespaceName, :currentJobContextUuid, :currentInputs)
+                  RETURNING uuid
+                  """)
+              .bind("uuid", UUID.randomUUID())
+              .bind("type", marquez.client.models.JobType.BATCH)
+              .bind("now", now)
+              .bind("namespaceUuid", namespace.getUuid())
+              .bind("name", jobName)
+              .bind("namespaceName", namespace.getName())
+              .bind("currentJobContextUuid", jobContextUuid)
+              .bind("currentInputs", pgInputs)
+              .mapTo(UUID.class)
+              .first();
+        });
   }
 }

--- a/api/src/test/java/marquez/db/migrations/V44_2__BackfillAirflowParentRunsTest.java
+++ b/api/src/test/java/marquez/db/migrations/V44_2__BackfillAirflowParentRunsTest.java
@@ -6,27 +6,23 @@
 package marquez.db.migrations;
 
 import static marquez.db.LineageTestUtils.NAMESPACE;
-import static marquez.db.LineageTestUtils.createLineageRow;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
 import marquez.db.BackfillTestUtils;
 import marquez.db.JobDao;
-import marquez.db.LineageTestUtils;
 import marquez.db.NamespaceDao;
 import marquez.db.OpenLineageDao;
 import marquez.db.RunArgsDao;
 import marquez.db.RunDao;
 import marquez.db.models.NamespaceRow;
+import marquez.jdbi.JdbiExternalPostgresExtension.FlywayTarget;
 import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
-import marquez.service.models.Job;
-import marquez.service.models.LineageEvent.JobFacet;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.api.migration.Context;
 import org.jdbi.v3.core.Jdbi;
@@ -35,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(MarquezJdbiExternalPostgresExtension.class)
+@FlywayTarget("44")
 class V44_2__BackfillAirflowParentRunsTest {
 
   static Jdbi jdbi;
@@ -66,13 +63,7 @@ class V44_2__BackfillAirflowParentRunsTest {
     BackfillTestUtils.writeNewEvent(
         jdbi, "airflowDag.task2", now, namespace, "schedule:00:00:00", task1Name);
 
-    createLineageRow(
-        openLineageDao,
-        "a_non_airflow_task",
-        BackfillTestUtils.COMPLETE,
-        new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP),
-        Collections.emptyList(),
-        Collections.emptyList());
+    BackfillTestUtils.writeNewEvent(jdbi, "a_non_airflow_task", now, namespace, null, null);
 
     jdbi.useHandle(
         handle -> {
@@ -94,7 +85,18 @@ class V44_2__BackfillAirflowParentRunsTest {
             throw new AssertionError("Unable to execute migration", e);
           }
         });
-    Optional<Job> jobByName = jobDao.findJobByName(NAMESPACE, dagName);
-    assertThat(jobByName).isPresent();
+    Optional<String> jobNameResult =
+        jdbi.withHandle(
+            h ->
+                h.createQuery(
+                        """
+            SELECT name FROM jobs_view
+            WHERE namespace_name=:namespace AND simple_name=:jobName
+            """)
+                    .bind("namespace", NAMESPACE)
+                    .bind("jobName", dagName)
+                    .mapTo(String.class)
+                    .findFirst());
+    assertThat(jobNameResult).isPresent();
   }
 }

--- a/api/src/test/java/marquez/db/migrations/V44_2__BackfillAirflowParentRunsTest.java
+++ b/api/src/test/java/marquez/db/migrations/V44_2__BackfillAirflowParentRunsTest.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(MarquezJdbiExternalPostgresExtension.class)
+// fix the flyway migration up to v44 since we depend on the database structure as it exists at this
+// point in time. The migration will only ever be applied on a database at this version.
 @FlywayTarget("44")
 class V44_2__BackfillAirflowParentRunsTest {
 

--- a/api/src/test/java/marquez/db/migrations/V44_3_BackfillJobsWithParentsTest.java
+++ b/api/src/test/java/marquez/db/migrations/V44_3_BackfillJobsWithParentsTest.java
@@ -7,26 +7,20 @@ package marquez.db.migrations;
 
 import static marquez.db.BackfillTestUtils.writeNewEvent;
 import static marquez.db.LineageTestUtils.NAMESPACE;
-import static marquez.db.LineageTestUtils.createLineageRow;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
-import marquez.common.models.JobName;
-import marquez.db.JobDao;
-import marquez.db.LineageTestUtils;
 import marquez.db.NamespaceDao;
 import marquez.db.OpenLineageDao;
+import marquez.db.models.ExtendedRunRow;
 import marquez.db.models.NamespaceRow;
-import marquez.db.models.UpdateLineageRow;
+import marquez.jdbi.JdbiExternalPostgresExtension.FlywayTarget;
 import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
-import marquez.service.models.Job;
-import marquez.service.models.LineageEvent.JobFacet;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.api.migration.Context;
 import org.jdbi.v3.core.Jdbi;
@@ -35,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(MarquezJdbiExternalPostgresExtension.class)
+@FlywayTarget("44") // apply migrations up to and including v44 but not beyond
 class V44_3_BackfillJobsWithParentsTest {
 
   static Jdbi jdbi;
@@ -48,26 +43,16 @@ class V44_3_BackfillJobsWithParentsTest {
 
   @Test
   public void testBackfill() throws SQLException, JsonProcessingException {
-    String parentName = "parentJob";
-    UpdateLineageRow parentJob =
-        createLineageRow(
-            openLineageDao,
-            parentName,
-            "COMPLETE",
-            new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP),
-            Collections.emptyList(),
-            Collections.emptyList());
-
     NamespaceDao namespaceDao = jdbi.onDemand(NamespaceDao.class);
     Instant now = Instant.now();
     NamespaceRow namespace =
         namespaceDao.upsertNamespaceRow(UUID.randomUUID(), now, NAMESPACE, "me");
+    String parentName = "parentJob";
+    ExtendedRunRow parentRun = writeNewEvent(jdbi, parentName, now, namespace, null, null);
 
     String task1Name = "task1";
-    writeNewEvent(
-        jdbi, task1Name, now, namespace, parentJob.getRun().getUuid().toString(), parentName);
-    writeNewEvent(
-        jdbi, "task2", now, namespace, parentJob.getRun().getUuid().toString(), parentName);
+    writeNewEvent(jdbi, task1Name, now, namespace, parentRun.getUuid().toString(), parentName);
+    writeNewEvent(jdbi, "task2", now, namespace, parentRun.getUuid().toString(), parentName);
 
     jdbi.useHandle(
         handle -> {
@@ -92,11 +77,13 @@ class V44_3_BackfillJobsWithParentsTest {
           }
         });
 
-    JobDao jobDao = jdbi.onDemand(JobDao.class);
-    Optional<Job> jobByName = jobDao.findJobByName(NAMESPACE, task1Name);
-    assertThat(jobByName)
-        .isPresent()
-        .get()
-        .hasFieldOrPropertyWithValue("name", new JobName(parentName + "." + task1Name));
+    Optional<String> jobName =
+        jdbi.withHandle(
+            h ->
+                h.createQuery("SELECT name FROM jobs_view WHERE simple_name=:jobName")
+                    .bind("jobName", task1Name)
+                    .mapTo(String.class)
+                    .findFirst());
+    assertThat(jobName).isPresent().get().isEqualTo(parentName + "." + task1Name);
   }
 }

--- a/api/src/test/java/marquez/db/migrations/V44_3_BackfillJobsWithParentsTest.java
+++ b/api/src/test/java/marquez/db/migrations/V44_3_BackfillJobsWithParentsTest.java
@@ -29,7 +29,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(MarquezJdbiExternalPostgresExtension.class)
-@FlywayTarget("44") // apply migrations up to and including v44 but not beyond
+// fix the flyway migration up to v44 since we depend on the database structure as it exists at this
+// point in time. The migration will only ever be applied on a database at this version.
+@FlywayTarget("44")
 class V44_3_BackfillJobsWithParentsTest {
 
   static Jdbi jdbi;


### PR DESCRIPTION
### Problem
Changes in the database schema can break the Java migration scripts if all flyway migrations are applied prior to running unit tests. This allows tests to specify fixed migration versions so that no future migrations are applied for that test. Also updated backfill tests to stop relying on sql in DAOs since they change with future migrations.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)