### PR TITLE
Avoid locking common records and remove transaction annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 
 * Set default limit for listing datasets and jobs in UI from `2000` to `25` [#2018](https://github.com/MarquezProject/marquez/pull/2018) [@wslulciuc](https://github.com/wslulciuc)
+* Update OpenLineage write API to be non-transactional and avoid unnecessary locks on records under heavy contention [@collado-mike](https://github.com/collado-mike)
 
 ### Fixed
 

--- a/api/src/main/java/marquez/db/JobContextDao.java
+++ b/api/src/main/java/marquez/db/JobContextDao.java
@@ -12,20 +12,26 @@ import marquez.db.mappers.JobContextRowMapper;
 import marquez.db.models.JobContextRow;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 @RegisterRowMapper(JobContextRowMapper.class)
 public interface JobContextDao {
   @SqlQuery("SELECT * FROM job_contexts WHERE uuid = :uuid")
   Optional<JobContextRow> findContextByUuid(UUID uuid);
 
-  @SqlQuery(
+  @SqlQuery("SELECT * FROM job_contexts WHERE checksum=:checksum")
+  Optional<JobContextRow> findContextByChecksum(String checksum);
+
+  default JobContextRow upsert(UUID uuid, Instant now, String context, String checksum) {
+    doUpsert(uuid, now, context, checksum);
+    return findContextByChecksum(checksum).orElseThrow();
+  }
+
+  @SqlUpdate(
       "INSERT INTO job_contexts "
           + "(uuid, created_at, context, checksum) "
           + "VALUES "
           + "(:uuid, :now, :context, :checksum) "
-          + "ON CONFLICT (checksum) DO "
-          + "UPDATE SET "
-          + "context = EXCLUDED.context "
-          + "RETURNING *")
-  JobContextRow upsert(UUID uuid, Instant now, String context, String checksum);
+          + "ON CONFLICT (checksum) DO NOTHING")
+  void doUpsert(UUID uuid, Instant now, String context, String checksum);
 }

--- a/api/src/main/java/marquez/db/JobVersionDao.java
+++ b/api/src/main/java/marquez/db/JobVersionDao.java
@@ -36,7 +36,6 @@ import marquez.service.models.Run;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
-import org.jdbi.v3.sqlobject.transaction.Transaction;
 
 /** The DAO for {@code JobVersion}. */
 @RegisterRowMapper(ExtendedJobVersionRowMapper.class)
@@ -294,7 +293,6 @@ public interface JobVersionDao extends BaseDao {
    * @param transitionedAt The timestamp of the run state transition.
    * @return A {@link BagOfJobVersionInfo} object.
    */
-  @Transaction
   default BagOfJobVersionInfo upsertJobVersionOnRunTransition(
       @NonNull String namespaceName,
       @NonNull String jobName,
@@ -327,7 +325,10 @@ public interface JobVersionDao extends BaseDao {
     final Version jobVersion =
         Utils.newJobVersionFor(
             NamespaceName.of(jobRow.getNamespaceName()),
-            JobName.of(jobRow.getName()),
+            JobName.of(
+                Optional.ofNullable(jobRow.getParentJobName())
+                    .map(pn -> pn + "." + jobRow.getSimpleName())
+                    .orElse(jobRow.getName())),
             toDatasetIds(jobVersionInputs),
             toDatasetIds(jobVersionOutputs),
             jobContext,

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -55,7 +55,6 @@ import marquez.service.models.LineageEvent.RunFacet;
 import marquez.service.models.LineageEvent.SchemaDatasetFacet;
 import marquez.service.models.LineageEvent.SchemaField;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
-import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.postgresql.util.PGobject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,7 +82,6 @@ public interface OpenLineageDao extends BaseDao {
       PGobject event,
       String producer);
 
-  @Transaction
   default UpdateLineageRow updateMarquezModel(LineageEvent event, ObjectMapper mapper) {
     UpdateLineageRow updateLineageRow = updateBaseMarquezModel(event, mapper);
     RunState runState = getRunState(event.getEventType());


### PR DESCRIPTION
### Problem
The OpenLineage API implementation is unnecessarily wrapped in a `@Transaction` annotation, which means that under heavy write load, there's a lot of unnecessary contention. For example, we lock the `Namespace` record in the `upsertNamespaceRow` method, even though we don't really update the namespace. Since the whole request is wrapped in a transaction, the namespace record is locked for the entire time we write new jobs, runs, and datasets. If many jobs for the same namespace run simultaneously, each OpenLineage request will wait until the namespace record is unlocked, forming a queue of requests, rather than handling each in parallel. This also happens for `JobContext`s and `RunArg`s, as oftentimes, many jobs will run with no arguments, no source code location, and no SQL facet. Many completely unrelated jobs will block while awaiting a lock on an empty `JobContext` and/or empty `RunArgs`. 

I updated each of these `upsert` queries to do nothing on conflict (they're really immutable records) to avoid locking the impacted record.

Moreover, I don't see a reason for this API to be wrapped in a transaction at all. These changes don't need to be made atomically. OpenLineage requests are mostly idempotent, so if only partial database updates are applied and the same request made twice, there's no duplication in the data. `Job`s, `Run`s, `Dataset`s, `JobContext`s, and `RunArg`s created in the first request will be found and used in the second. Foreign key constraints require us to always write a new record before updating an existing one to reference it, so there's no opportunity to leave the database in an inconsistent state. 

This screenshot shows the database under heavy write load - note that waits are dominated by `transactionid` ([Waiting for a transaction to finish](https://www.postgresql.org/docs/current/monitoring-stats.html#WAIT-EVENT-TABLE)) and the primary contender in this case is the `NamespaceDao`.

![Screen Shot 2022-07-14 at 1 41 37 PM](https://user-images.githubusercontent.com/40346148/179079535-013a2330-229e-4a83-92a3-a5fe33cb3683.png)


> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)