### PR TITLE
Fix casing on lastLifecycleState

### DIFF
--- a/api/src/main/java/marquez/db/models/DatasetData.java
+++ b/api/src/main/java/marquez/db/models/DatasetData.java
@@ -39,7 +39,7 @@ public class DatasetData implements NodeData {
   @NonNull ImmutableSet<TagName> tags;
   @Nullable Instant lastModifiedAt;
   @Nullable String description;
-  @Nullable String lastlifecycleState;
+  @Nullable String lastLifecycleState;
 
   public Optional<Instant> getLastModifiedAt() {
     return Optional.ofNullable(lastModifiedAt);
@@ -50,7 +50,7 @@ public class DatasetData implements NodeData {
   }
 
   public Optional<String> getLastlifecycleState() {
-    return Optional.ofNullable(lastlifecycleState);
+    return Optional.ofNullable(lastLifecycleState);
   }
 
   @JsonIgnore

--- a/api/src/main/java/marquez/db/models/DatasetData.java
+++ b/api/src/main/java/marquez/db/models/DatasetData.java
@@ -49,7 +49,7 @@ public class DatasetData implements NodeData {
     return Optional.ofNullable(description);
   }
 
-  public Optional<String> getLastlifecycleState() {
+  public Optional<String> getLastLifecycleState() {
     return Optional.ofNullable(lastLifecycleState);
   }
 

--- a/api/src/test/java/marquez/db/LineageDaoTest.java
+++ b/api/src/test/java/marquez/db/LineageDaoTest.java
@@ -566,7 +566,7 @@ public class LineageDaoTest {
             Collections.singleton(row.getOutputs().get().get(0).getDatasetRow().getUuid()));
 
     assertThat(datasetData)
-        .extracting(ds -> ds.getLastlifecycleState().orElse(""))
+        .extracting(ds -> ds.getLastLifecycleState().orElse(""))
         .anyMatch(str -> str.contains("CREATE"));
   }
 


### PR DESCRIPTION
Signed-off-by: Sam Holmberg <sam@holmberg.dev>

### Problem

👋 Thanks for opening a [pull request]

Closes: Bug fix

### Solution

Noticed the API was returning lastlifecycleState which was breaking our type definition while consuming lineage graph api. Fixed the casing. Ideally this should now match the type definition.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)