### PR TITLE
Runs row reduction

### DIFF
--- a/api/src/main/java/marquez/db/JobVersionDao.java
+++ b/api/src/main/java/marquez/db/JobVersionDao.java
@@ -286,22 +286,19 @@ public interface JobVersionDao extends BaseDao {
    * code location, and context. A version for a given job is created <i>only</i> when a {@link Run}
    * transitions into a {@code COMPLETED}, {@code ABORTED}, or {@code FAILED} state.
    *
-   * @param namespaceName The namespace for the job version.
-   * @param jobName The name of the job.
+   * @param jobRow The job.
    * @param runUuid The unique ID of the run associated with the job version.
    * @param runState The current run state.
    * @param transitionedAt The timestamp of the run state transition.
    * @return A {@link BagOfJobVersionInfo} object.
    */
   default BagOfJobVersionInfo upsertJobVersionOnRunTransition(
-      @NonNull String namespaceName,
-      @NonNull String jobName,
+      @NonNull JobRow jobRow,
       @NonNull UUID runUuid,
       @NonNull RunState runState,
       @NonNull Instant transitionedAt) {
     // Get the job.
     final JobDao jobDao = createJobDao();
-    final JobRow jobRow = jobDao.findJobByNameAsRow(namespaceName, jobName).get();
 
     // Get the job context.
     final UUID jobContextUuid = jobRow.getJobContextUuid().get();

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -390,8 +390,7 @@ public interface OpenLineageDao extends BaseDao {
     BagOfJobVersionInfo bagOfJobVersionInfo =
         createJobVersionDao()
             .upsertJobVersionOnRunTransition(
-                updateLineageRow.getRun().getNamespaceName(),
-                updateLineageRow.getRun().getJobName(),
+                updateLineageRow.getJob(),
                 updateLineageRow.getRun().getUuid(),
                 runState,
                 event.getEventTime().toInstant());

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -32,7 +32,6 @@ import marquez.db.JobVersionDao.BagOfJobVersionInfo;
 import marquez.db.models.DatasetFieldRow;
 import marquez.db.models.DatasetRow;
 import marquez.db.models.DatasetVersionRow;
-import marquez.db.models.ExtendedRunRow;
 import marquez.db.models.JobContextRow;
 import marquez.db.models.JobRow;
 import marquez.db.models.NamespaceRow;
@@ -161,10 +160,9 @@ public interface OpenLineageDao extends BaseDao {
                 PGobject inputs = new PGobject();
                 inputs.setType("json");
                 inputs.setValue("[]");
-                Optional<ExtendedRunRow> parentRunRow = runDao.findRunByUuidAsRow(uuid);
                 JobRow parentJobRow =
-                    parentRunRow
-                        .flatMap(run -> jobDao.findJobByUuidAsRow(run.getJobUuid()))
+                    runDao
+                        .findJobRowByRunUuid(uuid)
                         .orElseGet(
                             () -> {
                               JobRow newParentJobRow =
@@ -181,34 +179,36 @@ public interface OpenLineageDao extends BaseDao {
                                       null,
                                       inputs);
                               log.info("Created new parent job record {}", newParentJobRow);
+
+                              RunArgsRow argsRow =
+                                  runArgsDao.upsertRunArgs(
+                                      UUID.randomUUID(),
+                                      now,
+                                      "{}",
+                                      Utils.checksumFor(ImmutableMap.of()));
+                              RunRow newRow =
+                                  runDao.upsert(
+                                      uuid,
+                                      null,
+                                      facet.getRun().getRunId(),
+                                      now,
+                                      newParentJobRow.getUuid(),
+                                      null,
+                                      argsRow.getUuid(),
+                                      nominalStartTime,
+                                      nominalEndTime,
+                                      Optional.ofNullable(event.getEventType())
+                                          .map(this::getRunState)
+                                          .orElse(null),
+                                      now,
+                                      namespace.getName(),
+                                      newParentJobRow.getName(),
+                                      newParentJobRow.getLocation(),
+                                      newParentJobRow.getJobContextUuid().orElse(null));
+                              log.info("Created new parent run record {}", newRow);
                               return newParentJobRow;
                             });
                 log.debug("Found parent job record {}", parentJobRow);
-                if (parentRunRow.isEmpty()) {
-                  RunArgsRow argsRow =
-                      runArgsDao.upsertRunArgs(
-                          UUID.randomUUID(), now, "{}", Utils.checksumFor(ImmutableMap.of()));
-                  ExtendedRunRow newRow =
-                      runDao.upsert(
-                          uuid,
-                          null,
-                          facet.getRun().getRunId(),
-                          now,
-                          parentJobRow.getUuid(),
-                          null,
-                          argsRow.getUuid(),
-                          nominalStartTime,
-                          nominalEndTime,
-                          Optional.ofNullable(event.getEventType())
-                              .map(this::getRunState)
-                              .orElse(null),
-                          now,
-                          namespace.getName(),
-                          parentJobRow.getName(),
-                          parentJobRow.getLocation(),
-                          parentJobRow.getJobContextUuid().orElse(null));
-                  log.info("Created new parent run record {}", newRow);
-                }
                 return parentJobRow;
               } catch (Exception e) {
                 throw new RuntimeException("Unable to insert parent run", e);

--- a/api/src/main/java/marquez/db/mappers/RunRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/RunRowMapper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.db.mappers;
+
+import static marquez.db.Columns.stringOrNull;
+import static marquez.db.Columns.timestampOrNull;
+import static marquez.db.Columns.timestampOrThrow;
+import static marquez.db.Columns.uuidOrNull;
+import static marquez.db.Columns.uuidOrThrow;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import lombok.NonNull;
+import marquez.common.Utils;
+import marquez.common.models.DatasetVersionId;
+import marquez.db.Columns;
+import marquez.db.models.RunRow;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public final class RunRowMapper implements RowMapper<RunRow> {
+  @Override
+  public RunRow map(@NonNull ResultSet results, @NonNull StatementContext context)
+      throws SQLException {
+    Set<String> columnNames = MapperUtils.getColumnNames(results.getMetaData());
+
+    return new RunRow(
+        uuidOrThrow(results, Columns.ROW_UUID),
+        timestampOrThrow(results, Columns.CREATED_AT),
+        timestampOrThrow(results, Columns.UPDATED_AT),
+        uuidOrNull(results, Columns.JOB_UUID),
+        uuidOrNull(results, Columns.JOB_VERSION_UUID),
+        uuidOrNull(results, Columns.PARENT_RUN_UUID),
+        uuidOrThrow(results, Columns.RUN_ARGS_UUID),
+        timestampOrNull(results, Columns.NOMINAL_START_TIME),
+        timestampOrNull(results, Columns.NOMINAL_END_TIME),
+        stringOrNull(results, Columns.CURRENT_RUN_STATE),
+        columnNames.contains(Columns.STARTED_AT)
+            ? timestampOrNull(results, Columns.STARTED_AT)
+            : null,
+        uuidOrNull(results, Columns.START_RUN_STATE_UUID),
+        columnNames.contains(Columns.ENDED_AT) ? timestampOrNull(results, Columns.ENDED_AT) : null,
+        uuidOrNull(results, Columns.END_RUN_STATE_UUID));
+  }
+
+  private List<DatasetVersionId> toDatasetVersion(ResultSet rs, String column) throws SQLException {
+    String dsString = rs.getString(column);
+    if (dsString == null) {
+      return Collections.emptyList();
+    }
+    return Utils.fromJson(dsString, new TypeReference<List<DatasetVersionId>>() {});
+  }
+}

--- a/api/src/main/java/marquez/db/models/ExtendedRunRow.java
+++ b/api/src/main/java/marquez/db/models/ExtendedRunRow.java
@@ -18,6 +18,10 @@ import marquez.common.models.DatasetVersionId;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class ExtendedRunRow extends RunRow {
+  @Getter @NonNull private final List<DatasetVersionId> inputVersions;
+  @Getter @NonNull private final List<DatasetVersionId> outputVersions;
+  @Getter private final String namespaceName;
+  @Getter private final String jobName;
   @Getter private final String args;
 
   public ExtendedRunRow(
@@ -48,17 +52,21 @@ public class ExtendedRunRow extends RunRow {
         jobVersionUuid,
         parentRunUuid,
         runArgsUuid,
-        inputVersions,
-        outputVersions,
         nominalStartTime,
         nominalEndTime,
         currentRunState,
         startedAt,
         startRunStateUuid,
         endedAt,
-        endRunStateUuid,
-        namespaceName,
-        jobName);
+        endRunStateUuid);
+    this.inputVersions = inputVersions;
+    this.outputVersions = outputVersions;
     this.args = args;
+    this.jobName = jobName;
+    this.namespaceName = namespaceName;
+  }
+
+  public boolean hasInputVersionUuids() {
+    return !inputVersions.isEmpty();
   }
 }

--- a/api/src/main/java/marquez/db/models/RunRow.java
+++ b/api/src/main/java/marquez/db/models/RunRow.java
@@ -6,7 +6,6 @@
 package marquez.db.models;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -15,7 +14,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
-import marquez.common.models.DatasetVersionId;
 
 @AllArgsConstructor
 @EqualsAndHashCode
@@ -24,12 +22,10 @@ public class RunRow {
   @Getter @NonNull private final UUID uuid;
   @Getter @NonNull private final Instant createdAt;
   @Getter @NonNull private final Instant updatedAt;
-  @Getter @NonNull private final UUID jobUuid;
+  @Getter private final UUID jobUuid;
   @Nullable private final UUID jobVersionUuid;
   @Nullable private final UUID parentRunUuid;
   @Getter @NonNull private final UUID runArgsUuid;
-  @Getter @NonNull private final List<DatasetVersionId> inputVersions;
-  @Getter @NonNull private final List<DatasetVersionId> outputVersions;
   @Nullable private final Instant nominalStartTime;
   @Nullable private final Instant nominalEndTime;
   @Nullable private final String currentRunState;
@@ -37,12 +33,6 @@ public class RunRow {
   @Nullable private final UUID startRunStateUuid;
   @Nullable private final Instant endedAt;
   @Nullable private final UUID endRunStateUuid;
-  @Getter private final String namespaceName;
-  @Getter private final String jobName;
-
-  public boolean hasInputVersionUuids() {
-    return !inputVersions.isEmpty();
-  }
 
   public Optional<UUID> getParentRunUuid() {
     return Optional.ofNullable(parentRunUuid);

--- a/api/src/main/java/marquez/service/DatasetService.java
+++ b/api/src/main/java/marquez/service/DatasetService.java
@@ -62,7 +62,7 @@ public class DatasetService extends DelegatingDaos.DelegatingDatasetDao {
       @NonNull DatasetMeta datasetMeta) {
     if (datasetMeta.getRunId().isPresent()) {
       UUID runUuid = datasetMeta.getRunId().get().getValue();
-      ExtendedRunRow runRow = runDao.findRunByUuidAsRow(runUuid).get();
+      ExtendedRunRow runRow = runDao.findRunByUuidAsExtendedRow(runUuid).get();
 
       List<ExtendedDatasetVersionRow> outputs =
           datasetVersionDao.findOutputDatasetVersionsFor(runUuid);

--- a/api/src/main/java/marquez/service/JobService.java
+++ b/api/src/main/java/marquez/service/JobService.java
@@ -52,7 +52,7 @@ public class JobService extends DelegatingDaos.DelegatingJobDao {
     if (jobMeta.getRunId().isPresent()) {
       UUID runUuid = jobMeta.getRunId().get().getValue();
       runDao.notifyJobChange(runUuid, jobRow, jobMeta);
-      ExtendedRunRow runRow = runDao.findRunByUuidAsRow(runUuid).get();
+      ExtendedRunRow runRow = runDao.findRunByUuidAsExtendedRow(runUuid).get();
 
       List<ExtendedDatasetVersionRow> inputs =
           datasetVersionDao.findInputDatasetVersionsFor(runUuid);

--- a/api/src/main/java/marquez/service/OpenLineageService.java
+++ b/api/src/main/java/marquez/service/OpenLineageService.java
@@ -34,6 +34,7 @@ import marquez.db.BaseDao;
 import marquez.db.DatasetDao;
 import marquez.db.DatasetVersionDao;
 import marquez.db.models.ExtendedDatasetVersionRow;
+import marquez.db.models.JobRow;
 import marquez.db.models.RunArgsRow;
 import marquez.db.models.RunRow;
 import marquez.db.models.UpdateLineageRow;
@@ -121,7 +122,12 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
   private Optional<JobInputUpdate> buildJobInputUpdate(UpdateLineageRow record) {
     RunId runId = RunId.of(record.getRun().getUuid());
     return buildJobInput(
-        record.getRun(), record.getRunArgs(), buildJobVersionId(record), runId, record);
+        record.getRun(),
+        record.getRunArgs(),
+        record.getJob(),
+        buildJobVersionId(record),
+        runId,
+        record);
   }
 
   public JobVersionId buildJobVersionId(UpdateLineageRow record) {
@@ -161,14 +167,15 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
         new JobOutputUpdate(
             runId,
             jobVersionId,
-            JobName.of(record.getRun().getJobName()),
-            NamespaceName.of(record.getRun().getNamespaceName()),
+            JobName.of(record.getJob().getName()),
+            NamespaceName.of(record.getJob().getNamespaceName()),
             runOutputs));
   }
 
   Optional<JobInputUpdate> buildJobInput(
       RunRow run,
       RunArgsRow runArgsRow,
+      JobRow jobRow,
       JobVersionId jobVersionId,
       RunId runId,
       UpdateLineageRow record) {
@@ -203,8 +210,8 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
                 .args(runArgs)
                 .build(),
             jobVersionId,
-            JobName.of(run.getJobName()),
-            NamespaceName.of(run.getNamespaceName()),
+            JobName.of(jobRow.getName()),
+            NamespaceName.of(jobRow.getNamespaceName()),
             runInputs));
   }
 

--- a/api/src/main/java/marquez/service/RunService.java
+++ b/api/src/main/java/marquez/service/RunService.java
@@ -27,6 +27,7 @@ import marquez.common.models.NamespaceName;
 import marquez.common.models.RunId;
 import marquez.common.models.RunState;
 import marquez.db.BaseDao;
+import marquez.db.JobDao;
 import marquez.db.JobVersionDao;
 import marquez.db.JobVersionDao.BagOfJobVersionInfo;
 import marquez.db.RunStateDao;
@@ -48,6 +49,7 @@ public class RunService extends DelegatingDaos.DelegatingRunDao {
   private final JobVersionDao jobVersionDao;
   private final RunStateDao runStateDao;
   private final Collection<RunTransitionListener> runTransitionListeners;
+  private final JobDao jobDao;
 
   public RunService(
       @NonNull BaseDao baseDao, Collection<RunTransitionListener> runTransitionListeners) {
@@ -55,6 +57,7 @@ public class RunService extends DelegatingDaos.DelegatingRunDao {
     this.jobVersionDao = baseDao.createJobVersionDao();
     this.runStateDao = baseDao.createRunStateDao();
     this.runTransitionListeners = runTransitionListeners;
+    this.jobDao = baseDao.createJobDao();
   }
 
   /**
@@ -83,8 +86,9 @@ public class RunService extends DelegatingDaos.DelegatingRunDao {
     if (runState.isDone()) {
       BagOfJobVersionInfo bagOfJobVersionInfo =
           jobVersionDao.upsertJobVersionOnRunTransition(
-              runRow.getNamespaceName(),
-              runRow.getJobName(),
+              jobDao
+                  .findJobByNameAsRow(runRow.getNamespaceName(), runRow.getJobName())
+                  .orElseThrow(),
               runRow.getUuid(),
               runState,
               transitionedAt);

--- a/api/src/main/java/marquez/service/RunService.java
+++ b/api/src/main/java/marquez/service/RunService.java
@@ -77,7 +77,7 @@ public class RunService extends DelegatingDaos.DelegatingRunDao {
     if (transitionedAt == null) {
       transitionedAt = Instant.now();
     }
-    ExtendedRunRow runRow = findRunByUuidAsRow(runId.getValue()).get();
+    ExtendedRunRow runRow = findRunByUuidAsExtendedRow(runId.getValue()).get();
     runStateDao.updateRunStateFor(runId.getValue(), runState, transitionedAt);
 
     if (runState.isDone()) {

--- a/api/src/test/java/marquez/db/BackfillTestUtils.java
+++ b/api/src/test/java/marquez/db/BackfillTestUtils.java
@@ -17,9 +17,9 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
 import marquez.common.Utils;
-import marquez.db.models.ExtendedRunRow;
 import marquez.db.models.NamespaceRow;
 import marquez.db.models.RunArgsRow;
+import marquez.db.models.RunRow;
 import marquez.service.models.LineageEvent;
 import marquez.service.models.LineageEvent.JobFacet;
 import marquez.service.models.LineageEvent.JobLink;
@@ -35,7 +35,7 @@ import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 public class BackfillTestUtils {
   public static final String COMPLETE = "COMPLETE";
 
-  public static ExtendedRunRow writeNewEvent(
+  public static RunRow writeNewEvent(
       Jdbi jdbi,
       String jobName,
       Instant now,
@@ -52,7 +52,7 @@ public class BackfillTestUtils {
         runArgsDao.upsertRunArgs(
             UUID.randomUUID(), now, "{}", Utils.checksumFor(ImmutableMap.of()));
     UUID runUuid = UUID.randomUUID();
-    ExtendedRunRow runRow =
+    RunRow runRow =
         runDao.upsert(
             runUuid,
             null,

--- a/api/src/test/java/marquez/db/DbTestUtils.java
+++ b/api/src/test/java/marquez/db/DbTestUtils.java
@@ -41,7 +41,6 @@ import marquez.common.models.NamespaceName;
 import marquez.common.models.RunState;
 import marquez.db.models.DatasetRow;
 import marquez.db.models.ExtendedJobVersionRow;
-import marquez.db.models.ExtendedRunRow;
 import marquez.db.models.JobContextRow;
 import marquez.db.models.JobRow;
 import marquez.db.models.JobVersionRow;
@@ -256,7 +255,7 @@ final class DbTestUtils {
   }
 
   /** Adds a new {@link RunRow} object to the {@code runs} table. */
-  static ExtendedRunRow newRun(
+  static RunRow newRun(
       final Jdbi jdbi,
       final UUID jobUuid,
       final UUID jobVersionUuid,

--- a/api/src/test/java/marquez/db/JobVersionDaoTest.java
+++ b/api/src/test/java/marquez/db/JobVersionDaoTest.java
@@ -27,7 +27,6 @@ import marquez.common.models.Version;
 import marquez.db.models.DatasetRow;
 import marquez.db.models.ExtendedDatasetVersionRow;
 import marquez.db.models.ExtendedJobVersionRow;
-import marquez.db.models.ExtendedRunRow;
 import marquez.db.models.JobRow;
 import marquez.db.models.NamespaceRow;
 import marquez.db.models.RunArgsRow;
@@ -128,7 +127,7 @@ public class JobVersionDaoTest extends BaseIntegrationTest {
 
     // (2) Add a new run.
     final RunArgsRow runArgsRow = DbTestUtils.newRunArgs(jdbiForTesting);
-    final ExtendedRunRow runRow =
+    final RunRow runRow =
         DbTestUtils.newRun(
             jdbiForTesting,
             jobVersionRow.getJobUuid(),

--- a/api/src/test/java/marquez/db/JobVersionDaoTest.java
+++ b/api/src/test/java/marquez/db/JobVersionDaoTest.java
@@ -215,11 +215,7 @@ public class JobVersionDaoTest extends BaseIntegrationTest {
             jdbiForTesting, runRow.getUuid(), RunState.COMPLETED, jobMeta.getOutputs());
 
     jobVersionDao.upsertJobVersionOnRunTransition(
-        jobRow.getNamespaceName(),
-        jobRow.getName(),
-        runRow.getUuid(),
-        RunState.COMPLETED,
-        Instant.now());
+        jobRow, runRow.getUuid(), RunState.COMPLETED, Instant.now());
 
     List<JobVersion> jobVersions =
         jobVersionDao.findAllJobVersions(namespaceRow.getName(), jobRow.getName(), 10, 0);
@@ -288,11 +284,7 @@ public class JobVersionDaoTest extends BaseIntegrationTest {
     // (6) Add a new job version on the run state transition to COMPLETED.
     final BagOfJobVersionInfo bagOfJobVersionInfo =
         jobVersionDao.upsertJobVersionOnRunTransition(
-            jobRow.getNamespaceName(),
-            jobRow.getName(),
-            runRow.getUuid(),
-            RunState.COMPLETED,
-            newTimestamp());
+            jobRow, runRow.getUuid(), RunState.COMPLETED, newTimestamp());
 
     // Ensure the job version is associated with the latest run.
     final RunRow latestRunRowForJobVersion = runDao.findRunByUuidAsRow(runRow.getUuid()).get();

--- a/api/src/test/java/marquez/db/RunDaoTest.java
+++ b/api/src/test/java/marquez/db/RunDaoTest.java
@@ -97,11 +97,7 @@ class RunDaoTest {
         jdbi, runRow.getUuid(), RunState.COMPLETED, jobMeta.getOutputs());
 
     jobVersionDao.upsertJobVersionOnRunTransition(
-        jobRow.getNamespaceName(),
-        jobRow.getName(),
-        runRow.getUuid(),
-        RunState.COMPLETED,
-        Instant.now());
+        jobRow, runRow.getUuid(), RunState.COMPLETED, Instant.now());
 
     Optional<Run> run = runDao.findRunByUuid(runRow.getUuid());
     assertThat(run)
@@ -211,11 +207,7 @@ class RunDaoTest {
                   jdbi, runRow.getUuid(), RunState.COMPLETED, outputs);
 
               jobVersionDao.upsertJobVersionOnRunTransition(
-                  jobRow.getNamespaceName(),
-                  jobRow.getName(),
-                  runRow.getUuid(),
-                  RunState.COMPLETED,
-                  Instant.now());
+                  jobRow, runRow.getUuid(), RunState.COMPLETED, Instant.now());
               return runRow;
             });
   }

--- a/api/src/test/java/marquez/db/RunDaoTest.java
+++ b/api/src/test/java/marquez/db/RunDaoTest.java
@@ -243,7 +243,7 @@ class RunDaoTest {
             null,
             namespaceRow.getUuid(),
             namespaceRow.getName(),
-            row.getJobName(),
+            jobRow.getName(),
             null,
             null);
 

--- a/api/src/test/java/marquez/db/migrations/V44_3_BackfillJobsWithParentsTest.java
+++ b/api/src/test/java/marquez/db/migrations/V44_3_BackfillJobsWithParentsTest.java
@@ -17,8 +17,8 @@ import java.util.Optional;
 import java.util.UUID;
 import marquez.db.NamespaceDao;
 import marquez.db.OpenLineageDao;
-import marquez.db.models.ExtendedRunRow;
 import marquez.db.models.NamespaceRow;
+import marquez.db.models.RunRow;
 import marquez.jdbi.JdbiExternalPostgresExtension.FlywayTarget;
 import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
 import org.flywaydb.core.api.configuration.Configuration;
@@ -50,7 +50,7 @@ class V44_3_BackfillJobsWithParentsTest {
     NamespaceRow namespace =
         namespaceDao.upsertNamespaceRow(UUID.randomUUID(), now, NAMESPACE, "me");
     String parentName = "parentJob";
-    ExtendedRunRow parentRun = writeNewEvent(jdbi, parentName, now, namespace, null, null);
+    RunRow parentRun = writeNewEvent(jdbi, parentName, now, namespace, null, null);
 
     String task1Name = "task1";
     writeNewEvent(jdbi, task1Name, now, namespace, parentRun.getUuid().toString(), parentName);


### PR DESCRIPTION
### Problem
A lot of the runs queries we use unnecessarily join with the `jobs_view` when no job information is necessary. As part of the effort to remove the proliferation of job names, I reduced the scope of `RunRow` to exclude job information and changed consumers to depend on `RunRow` rather than `ExtendedRunRow` where only the run information was needed (often only the run UUID).


> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)