### PR TITLE
[DOCS] add language on timing to release policy

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,3 +31,5 @@ A total of three +1s, taking into account -1s and excluding votes by the propose
 Alternatively, if after 2 days the release has received at least one +1 and no -1s, the release is also authorized.
 
 If the proposed release receives no +1s in two days, it is not authorized and the proposer must make a new request to reset the clock.
+
+Once a release is authorized, it will be initiated within two business days. Releases will not be made on a Friday unless doing so will address an important defect, an issue with project infrastructure, or a security vulnerability.


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

In RELEASING.md we are missing language about the timing of releases that we have in OpenLineage. It establishes a deadline for releases upon approval by committers.

### Solution

This change would establish a timeframe of 2 business days (not counting Fridays) to publish releases upon approval and create consistency across the projects.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)