### PR TITLE
Fix V45 migration to include initial population of jobs_fqn table

### DIFF
--- a/api/src/main/resources/marquez/db/migration/V45__update_jobs_view_rule.sql
+++ b/api/src/main/resources/marquez/db/migration/V45__update_jobs_view_rule.sql
@@ -29,3 +29,50 @@ CREATE TABlE jobs_fqn
     aliases         varchar[],
     job_fqn         varchar NOT NULL
 );
+
+WITH RECURSIVE
+    jobs_symlink AS (SELECT uuid, uuid AS link_target_uuid, symlink_target_uuid
+                     FROM jobs j
+                     WHERE symlink_target_uuid IS NULL
+                     UNION
+                     SELECT j.uuid, jn.link_target_uuid, j.symlink_target_uuid
+                     FROM jobs j
+                              INNER JOIN jobs_symlink jn ON j.symlink_target_uuid = jn.uuid),
+    fqn AS (SELECT j.uuid,
+                   j.name AS name,
+                   j.namespace_uuid,
+                   j.namespace_name,
+                   NULL::text AS parent_job_name,
+                   j.parent_job_uuid
+            FROM jobs j
+            WHERE parent_job_uuid IS NULL
+            UNION
+            SELECT j1.uuid,
+                   f.name || '.' || j1.name AS name,
+                   f.namespace_uuid         AS namespace_uuid,
+                   f.namespace_name         AS namespace_name,
+                   f.name                   AS parent_job_name,
+                   j1.parent_job_uuid
+            FROM jobs j1
+                     INNER JOIN fqn f ON j1.parent_job_uuid = f.uuid),
+    aliases AS (SELECT s.link_target_uuid,
+                       ARRAY_AGG(DISTINCT f.name) FILTER (WHERE f.name IS NOT NULL) AS aliases
+                FROM jobs_symlink s
+                INNER JOIN fqn f ON f.uuid = s.uuid
+                WHERE s.link_target_uuid != s.uuid
+                GROUP BY s.link_target_uuid)
+INSERT
+INTO jobs_fqn
+SELECT j.uuid,
+       jf.namespace_uuid,
+       jf.namespace_name,
+       jf.parent_job_name,
+       a.aliases,
+       jf.name AS job_fqn
+FROM jobs j
+         LEFT JOIN jobs_symlink js ON j.uuid = js.uuid
+         LEFT JOIN aliases a ON a.link_target_uuid = js.link_target_uuid
+         INNER JOIN fqn jf ON jf.uuid = COALESCE(js.link_target_uuid, j.uuid)
+ON CONFLICT (uuid) DO UPDATE
+    SET job_fqn=EXCLUDED.job_fqn,
+        aliases = jobs_fqn.aliases || EXCLUDED.aliases;


### PR DESCRIPTION
### Problem

The V45 migration as is will cause no jobs or runs to be visible until the `jobs_fqn` table is populated. This adds a quick step to the migration to do the initial population, relying on the trigger function to handle new jobs as they are written.

### Solution

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a database schema migration, please describe the schema modification(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)