### PR TITLE
Fix `py` module release

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,12 +11,7 @@
 
 3. Visit [CI](https://app.circleci.com/pipelines/github/MarquezProject/marquez?branch=main) to see the progress of the release! :rocket:
 4. Visit [sonatype](https://oss.sonatype.org) to promote _java_ artifacts
-5. Create a [new project](https://github.com/MarquezProject/marquez/projects/new) board for the _next_ release using the _automated kanban_ template:
-
-   ![](./docs/assets/images/new-project-board.png)
-
-6. Before closing the project board for the _current_ release, move any open issues to the project board created in **step 5**
-7. Draft a [new release](https://github.com/MarquezProject/marquez/releases/new) using the release notes for `X.Y.Z` in **step 1** as the release description:
+6. Draft a [new release](https://github.com/MarquezProject/marquez/releases/new) using the release notes for `X.Y.Z` in **step 1** as the release description:
 
    ![](./docs/assets/images/new-release.png)
 
@@ -33,3 +28,4 @@ Alternatively, if after 2 days the release has received at least one +1 and no -
 If the proposed release receives no +1s in two days, it is not authorized and the proposer must make a new request to reset the clock.
 
 Once a release is authorized, it will be initiated within two business days. Releases will not be made on a Friday unless doing so will address an important defect, an issue with project infrastructure, or a security vulnerability.
+

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,4 +28,3 @@ Alternatively, if after 2 days the release has received at least one +1 and no -
 If the proposed release receives no +1s in two days, it is not authorized and the proposer must make a new request to reset the clock.
 
 Once a release is authorized, it will be initiated within two business days. Releases will not be made on a Friday unless doing so will address an important defect, an issue with project infrastructure, or a security vulnerability.
-


### PR DESCRIPTION
### Problem

Our `py` modules release fails as the result of applying the `bump2version` cmd twice in `new-version.sh` (see [failed release](https://app.circleci.com/pipelines/github/MarquezProject/marquez/6698/workflows/30b6e256-4fde-4332-9c37-024f51bb9348/jobs/49891) CI job):

```
  File "setup.py", line 27
    version="version="0.24.0"",
                         ^
SyntaxError: invalid syntax

Exited with code exit status 1
```

### Solution

Only bump the `py` module version when preparing the next development version.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)