### PR TITLE
Fix/rewrite jobs fqn locks

### DIFF
--- a/api/src/main/resources/marquez/db/migration/R__1_Jobs_view_and_rewrite_function.sql
+++ b/api/src/main/resources/marquez/db/migration/R__1_Jobs_view_and_rewrite_function.sql
@@ -27,6 +27,8 @@ CREATE OR REPLACE FUNCTION rewrite_jobs_fqn_table() RETURNS TRIGGER AS
 $$
 DECLARE
     job_uuid uuid;
+    new_symlink_target_uuid uuid;
+    old_symlink_target_uuid uuid;
     inserted_job jobs_view%rowtype;
 BEGIN
     INSERT INTO jobs (uuid, type, created_at, updated_at, namespace_uuid, name, description,
@@ -58,9 +60,16 @@ BEGIN
                       -- update the symlink target if null. otherwise, keep the old value
                       symlink_target_uuid      = COALESCE(jobs.symlink_target_uuid,
                               EXCLUDED.symlink_target_uuid)
-    RETURNING uuid INTO job_uuid;
-    IF TG_OP = 'INSERT' OR
-       (TG_OP = 'UPDATE' AND OLD.symlink_target_uuid IS DISTINCT FROM NEW.symlink_target_uuid) THEN
+    -- the SELECT statement below will get the OLD symlink_target_uuid in case of update and the NEW
+    -- version in case of insert
+    RETURNING uuid, symlink_target_uuid, (SELECT symlink_target_uuid FROM jobs j2 WHERE j2.uuid=jobs.uuid)
+        INTO job_uuid, new_symlink_target_uuid, old_symlink_target_uuid;
+
+    -- update the jobs_fqn table only when inserting a new record (NEW.uuid will equal the job_uuid
+    -- when inserting a new record) or when the symlink_target_uuid is being updated.
+    IF NEW.uuid = job_uuid OR
+       (new_symlink_target_uuid IS DISTINCT FROM old_symlink_target_uuid) THEN
+        RAISE LOG 'Updating jobs_fqn due to % to job % (%)', TG_OP, NEW.name, job_uuid;
         WITH RECURSIVE
             jobs_symlink AS (SELECT uuid, uuid AS link_target_uuid, symlink_target_uuid
                              FROM jobs j

--- a/api/src/main/resources/marquez/db/migration/R__1_Jobs_view_and_rewrite_function.sql
+++ b/api/src/main/resources/marquez/db/migration/R__1_Jobs_view_and_rewrite_function.sql
@@ -55,10 +55,9 @@ BEGIN
                       current_job_context_uuid = EXCLUDED.current_job_context_uuid,
                       current_location         = EXCLUDED.current_location,
                       current_inputs           = EXCLUDED.current_inputs,
-                      -- update the symlink target if not null. otherwise, keep the old value
-                      symlink_target_uuid      = COALESCE(
-                              EXCLUDED.symlink_target_uuid,
-                              jobs.symlink_target_uuid)
+                      -- update the symlink target if null. otherwise, keep the old value
+                      symlink_target_uuid      = COALESCE(jobs.symlink_target_uuid,
+                              EXCLUDED.symlink_target_uuid)
     RETURNING uuid INTO job_uuid;
     IF TG_OP = 'INSERT' OR
        (TG_OP = 'UPDATE' AND OLD.symlink_target_uuid IS DISTINCT FROM NEW.symlink_target_uuid) THEN

--- a/api/src/test/java/marquez/db/JobDaoTest.java
+++ b/api/src/test/java/marquez/db/JobDaoTest.java
@@ -171,6 +171,19 @@ public class JobDaoTest {
         jobDao.findJobByName(symlinkJob.getNamespaceName(), symlinkJob.getName()),
         targetJob.getNamespaceName(),
         targetJob.getName());
+
+    // try to update the symlink target - it should be ignored
+    JobRow anotherTargetJob =
+        createJobWithoutSymlinkTarget(
+            jdbi, namespace, "anotherTarget", "we'll attempt to update the symlink");
+    createJobWithSymlinkTarget(
+        jdbi, namespace, symlinkJobName, anotherTargetJob.getUuid(), "the symlink job");
+
+    // the original symlink target should be returned
+    assertJobIdEquals(
+        jobDao.findJobByName(symlinkJob.getNamespaceName(), symlinkJob.getName()),
+        targetJob.getNamespaceName(),
+        targetJob.getName());
   }
 
   public void testSymlinkParentJobRenamesChildren() throws SQLException {


### PR DESCRIPTION
### Problem

The `rewrite_jobs_fqn_table` function is inadvertently updating jobs even when no metadata about the job has changed. Under load, this causes significant locking issues, as the `jobs_fqn` table must be locked for every job update. 

### Solution

I updated the function to only update the table if the job is a new record or if the `symlink_target_uuid` is distinct from the previous value. These graphs show the number of blocked transactions and commits over time before and after the change. After applying the change (around 20:10 on these graphs), the number of commits goes way up and the number of active/blocked transactions drops.

<img width="1303" alt="Screen Shot 2022-08-10 at 12 08 17 PM" src="https://user-images.githubusercontent.com/40346148/183998815-c8f9c905-ea2b-49d2-8381-0cb10767fc5e.png">

I also added a test assertion to validate the update of the `jobs_fqn` table.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)