### PR TITLE
Update lineage query to only look at jobs with inputs or outputs

### DIFF
--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -37,35 +37,39 @@ public interface LineageDao {
    * @return
    */
   @SqlQuery(
-      // dataset_ids: all the input and output datasets of the current version of the specified jobs
-      "WITH RECURSIVE\n"
-          + "    job_io AS (\n"
-          + "        SELECT j.uuid AS job_uuid,\n"
-          + "        ARRAY_AGG(DISTINCT io.dataset_uuid) FILTER (WHERE io_type='INPUT') AS inputs,\n"
-          + "        ARRAY_AGG(DISTINCT io.dataset_uuid) FILTER (WHERE io_type='OUTPUT') AS outputs\n"
-          + "        FROM jobs_view j\n"
-          + "        LEFT JOIN jobs_view s ON s.symlink_target_uuid=j.uuid\n"
-          + "        LEFT JOIN job_versions v on COALESCE(j.current_version_uuid, s.current_version_uuid) = v.uuid\n"
-          + "        LEFT JOIN job_versions_io_mapping io on v.uuid = io.job_version_uuid\n"
-          + "        GROUP BY j.uuid\n"
-          + "    ),\n"
-          + "    lineage(job_uuid, inputs, outputs) AS (\n"
-          + "        SELECT job_uuid, inputs, outputs, 0 AS depth\n"
-          + "        FROM job_io\n"
-          + "        WHERE job_uuid IN (<jobIds>)\n"
-          + "        UNION\n"
-          + "        SELECT io.job_uuid, io.inputs, io.outputs, l.depth + 1\n"
-          + "        FROM job_io io,\n"
-          + "             lineage l\n"
-          + "        WHERE io.job_uuid != l.job_uuid AND\n"
-          + "        array_cat(io.inputs, io.outputs) && array_cat(l.inputs, l.outputs)\n"
-          + "        AND depth < :depth"
-          + "    )\n"
-          + "SELECT DISTINCT ON (j.uuid) j.*, inputs AS input_uuids, outputs AS output_uuids, jc.context\n"
-          + "FROM lineage l2\n"
-          + "INNER JOIN jobs_view s ON s.uuid=l2.job_uuid\n"
-          + "INNER JOIN jobs_view j ON j.uuid=COALESCE(s.symlink_target_uuid, s.uuid)\n"
-          + "LEFT JOIN job_contexts jc on jc.uuid = j.current_job_context_uuid")
+      """
+    WITH RECURSIVE
+        job_io AS (
+            SELECT COALESCE(j.symlink_target_uuid, j.uuid) AS job_uuid,
+            ARRAY_AGG(DISTINCT io.dataset_uuid) FILTER (WHERE io_type='INPUT') AS inputs,
+            ARRAY_AGG(DISTINCT io.dataset_uuid) FILTER (WHERE io_type='OUTPUT') AS outputs
+            FROM job_versions_io_mapping io
+            INNER JOIN job_versions v ON io.job_version_uuid=v.uuid
+            INNER JOIN jobs_view j on j.current_version_uuid = v.uuid
+            LEFT JOIN jobs_view s ON s.uuid=j.symlink_target_uuid
+            WHERE s.current_version_uuid IS NULL
+            GROUP BY COALESCE(j.symlink_target_uuid, j.uuid)
+        ),
+        lineage(job_uuid, inputs, outputs) AS (
+            SELECT COALESCE(j.symlink_target_uuid, j.uuid) AS job_uuid,
+                   COALESCE(inputs, Array[]::uuid[]) AS inputs,
+                   COALESCE(outputs, Array[]::uuid[]) AS outputs,
+                   0 AS depth
+            FROM jobs_view j
+            LEFT JOIN job_io io ON io.job_uuid=j.uuid OR j.symlink_target_uuid=io.job_uuid
+            WHERE j.uuid IN (<jobIds>)
+            UNION
+            SELECT io.job_uuid, io.inputs, io.outputs, l.depth + 1
+            FROM job_io io,
+                 lineage l
+            WHERE io.job_uuid != l.job_uuid AND
+            array_cat(io.inputs, io.outputs) && array_cat(l.inputs, l.outputs)
+            AND depth < :depth)
+    SELECT DISTINCT ON (j.uuid) j.*, inputs AS input_uuids, outputs AS output_uuids, jc.context
+    FROM lineage l2
+    INNER JOIN jobs_view j ON j.uuid=l2.job_uuid
+    LEFT JOIN job_contexts jc on jc.uuid = j.current_job_context_uuid;
+  """)
   Set<JobData> getLineage(@BindList Set<UUID> jobIds, int depth);
 
   @SqlQuery(

--- a/api/src/test/java/marquez/db/LineageDaoTest.java
+++ b/api/src/test/java/marquez/db/LineageDaoTest.java
@@ -276,6 +276,38 @@ public class LineageDaoTest {
             .map(JobData::getUuid)
             .collect(Collectors.toSet());
     assertThat(lineageForOriginalJob).isEqualTo(jobIds);
+
+    UpdateLineageRow updatedTargetJob =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            symlinkTargetJobName,
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(),
+            Arrays.asList(
+                new Dataset(
+                    NAMESPACE,
+                    "a_new_dataset",
+                    newDatasetFacet(new SchemaField("firstname", "string", "the first name")))));
+    assertThat(updatedTargetJob.getJob().getUuid()).isEqualTo(targetJob.getUuid());
+
+    // get lineage for original job - the old datasets/jobs should no longer be present
+    assertThat(
+            lineageDao
+                .getLineage(new HashSet<>(Arrays.asList(writeJob.getJob().getUuid())), 2)
+                .stream()
+                .map(JobData::getUuid)
+                .collect(Collectors.toSet()))
+        .hasSize(1)
+        .containsExactlyInAnyOrder(targetJob.getUuid());
+
+    // fetching lineage for target job should yield the same results
+    assertThat(
+            lineageDao.getLineage(new HashSet<>(Arrays.asList(targetJob.getUuid())), 2).stream()
+                .map(JobData::getUuid)
+                .collect(Collectors.toSet()))
+        .hasSize(1)
+        .containsExactlyInAnyOrder(targetJob.getUuid());
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Michael Collado <collado.mike@gmail.com>

### Problem

In many environments a large number of jobs reporting events have no inputs or outputs - e.g., PythonOperators in an Airflow deployment. If a Marquez installation has a lot of these, the lineage query spends a lot of its time searching for overlaps with jobs that have no inputs or outputs. In one installation, we have > 200K jobs, but only ~7000 jobs that have any inputs or outputs at all.

### Solution

This changes the lineage query to query the `job_versions_io_mapping` table and _INNER_ join with the `jobs_view` so that only jobs that have inputs or outputs are present in the `jobs_io` CTE. The impact of this is that table becomes very small and the recursive join in the `lineage` CTE is very fast. 

Probably notable that the missing inputs/outputs are largely due to insufficient coverage by the OpenLineage integrations - e.g., those PythonOperators are likely reading data from somewhere. This is, at best, a short term fix until OL coverage increases, at which point, the query will have to be revisited again.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)