### PR TITLE
Update rewrite_jobs_fqn_table query to reduce the size of CTE and avo…

### DIFF
--- a/api/src/main/java/marquez/db/SearchDao.java
+++ b/api/src/main/java/marquez/db/SearchDao.java
@@ -35,7 +35,7 @@ public interface SearchDao {
           + "   UNION\n"
           + "  SELECT DISTINCT ON (j.namespace_name, j.name) \n"
           + "    'JOB' AS type, j.name, j.updated_at, j.namespace_name\n"
-          + "    FROM (SELECT namespace_name, name, unnest(aliases) AS alias, updated_at \n"
+          + "    FROM (SELECT namespace_name, name, unnest(COALESCE(aliases, Array[NULL]::varchar[])) AS alias, updated_at \n"
           + "           FROM jobs_view WHERE symlink_target_uuid IS NULL\n"
           + "           ORDER BY updated_at DESC) AS j\n"
           + "   WHERE  j.name ilike '%' || :query || '%'\n"

--- a/api/src/test/java/marquez/db/SearchDaoTest.java
+++ b/api/src/test/java/marquez/db/SearchDaoTest.java
@@ -26,6 +26,7 @@ import marquez.db.models.NamespaceRow;
 import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
 import marquez.service.models.JobMeta;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.mapper.MapMapper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -109,7 +110,22 @@ public class SearchDaoTest {
   }
 
   @Test
-  public void testSearch() {
+  public void testSearch(Jdbi jdbi) {
+    jdbi.withHandle(
+            h ->
+                h.createQuery("SELECT uuid, name, namespace_name FROM jobs")
+                    .map(new MapMapper())
+                    .list())
+        .forEach(System.out::println);
+    jdbi.withHandle(h -> h.createQuery("SELECT * FROM jobs_fqn").map(new MapMapper()).list())
+        .forEach(System.out::println);
+    jdbi.withHandle(
+            h ->
+                h.createQuery(
+                        "SELECT uuid, name, namespace_name, unnest(aliases) AS alias, symlink_target_uuid FROM jobs_view")
+                    .map(new MapMapper())
+                    .list())
+        .forEach(System.out::println);
     final String query = "test";
     final List<SearchResult> results = searchDao.search(query, null, SearchSort.NAME, LIMIT);
 


### PR DESCRIPTION
### Problem

The rewrite_jobs_fqn_table function generates a CTE that contains the entire set of jobs for calculating symlinks instead of only including jobs that are actually involved in a symlink chain.

### Solution

Rewrite query to avoid the expensive CTE generation. I tested in a dev installation that was suffering from huge spikes in CPU utilization every hour. After altering the query (around 16:00 on this graph), the CPU spikes are considerably smaller.

<img width="1109" alt="Screen Shot 2022-08-15 at 10 29 29 AM" src="https://user-images.githubusercontent.com/40346148/184685363-5b6e642d-40ae-4701-9879-4ab23766ce22.png">

This query change had an impact on the search query and test, so those were adjusted accordingly.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)