### PR TITLE
Add ability to get open lineage events by run UUID.

### DIFF
--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -86,7 +86,7 @@ public interface OpenLineageDao extends BaseDao {
       String producer);
 
   @SqlQuery("SELECT event FROM lineage_events WHERE run_uuid = :runUuid")
-  List<LineageEvent> listLineageEventsByRunUuid(UUID runUuid);
+  List<LineageEvent> findOlEventsByRunUuid(UUID runUuid);
 
   default UpdateLineageRow updateMarquezModel(LineageEvent event, ObjectMapper mapper) {
     UpdateLineageRow updateLineageRow = updateBaseMarquezModel(event, mapper);

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -29,6 +29,7 @@ import marquez.common.models.RunState;
 import marquez.common.models.SourceType;
 import marquez.db.DatasetFieldDao.DatasetFieldMapping;
 import marquez.db.JobVersionDao.BagOfJobVersionInfo;
+import marquez.db.mappers.LineageEventMapper;
 import marquez.db.models.DatasetFieldRow;
 import marquez.db.models.DatasetRow;
 import marquez.db.models.DatasetVersionRow;
@@ -53,11 +54,14 @@ import marquez.service.models.LineageEvent.ParentRunFacet;
 import marquez.service.models.LineageEvent.RunFacet;
 import marquez.service.models.LineageEvent.SchemaDatasetFacet;
 import marquez.service.models.LineageEvent.SchemaField;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.postgresql.util.PGobject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@RegisterRowMapper(LineageEventMapper.class)
 public interface OpenLineageDao extends BaseDao {
   public String DEFAULT_SOURCE_NAME = "default";
   public String DEFAULT_NAMESPACE_OWNER = "anonymous";
@@ -80,6 +84,9 @@ public interface OpenLineageDao extends BaseDao {
       String jobNamespace,
       PGobject event,
       String producer);
+
+  @SqlQuery("SELECT event FROM lineage_events WHERE run_uuid = :runUuid")
+  List<LineageEvent> listLineageEventsByRunUuid(UUID runUuid);
 
   default UpdateLineageRow updateMarquezModel(LineageEvent event, ObjectMapper mapper) {
     UpdateLineageRow updateLineageRow = updateBaseMarquezModel(event, mapper);

--- a/api/src/main/java/marquez/db/mappers/LineageEventMapper.java
+++ b/api/src/main/java/marquez/db/mappers/LineageEventMapper.java
@@ -1,0 +1,31 @@
+package marquez.db.mappers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import lombok.NonNull;
+import marquez.common.Utils;
+import marquez.service.models.LineageEvent;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class LineageEventMapper implements RowMapper<LineageEvent> {
+  private static final ObjectMapper mapper = Utils.newObjectMapper();
+
+  @Override
+  public LineageEvent map(@NonNull ResultSet results, @NonNull StatementContext context)
+      throws SQLException {
+    String eventJson = results.getString("event");
+    if (eventJson == null) {
+      throw new IllegalArgumentException();
+    }
+
+    try {
+      return mapper.readValue(eventJson, new TypeReference<>() {});
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException();
+    }
+  }
+}

--- a/api/src/test/java/marquez/db/OpenLineageDaoTest.java
+++ b/api/src/test/java/marquez/db/OpenLineageDaoTest.java
@@ -10,6 +10,7 @@ import static marquez.db.LineageTestUtils.SCHEMA_URL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
+import java.util.List;
 import marquez.db.models.UpdateLineageRow;
 import marquez.db.models.UpdateLineageRow.DatasetRecord;
 import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
@@ -237,5 +238,28 @@ class OpenLineageDaoTest {
 
     assertThat(readJob2.getInputs().get().get(0).getDatasetVersionRow())
         .isEqualTo(writeJob3.getOutputs().get().get(0).getDatasetVersionRow());
+  }
+
+  @Test
+  void testGetOpenLineageEvents() {
+    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            dao,
+            WRITE_JOB_NAME,
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(),
+            Arrays.asList(new Dataset(LineageTestUtils.NAMESPACE, DATASET_NAME, datasetFacets)));
+
+    List<LineageEvent> lineageEvents = dao.listLineageEventsByRunUuid(writeJob.getRun().getUuid());
+    assertThat(lineageEvents).hasSize(1);
+
+    assertThat(lineageEvents.get(0).getEventType()).isEqualTo("COMPLETE");
+
+    LineageEvent.Job job = lineageEvents.get(0).getJob();
+    assertThat(job)
+        .extracting("namespace", "name")
+        .contains(LineageTestUtils.NAMESPACE, WRITE_JOB_NAME);
   }
 }

--- a/api/src/test/java/marquez/db/OpenLineageDaoTest.java
+++ b/api/src/test/java/marquez/db/OpenLineageDaoTest.java
@@ -252,7 +252,7 @@ class OpenLineageDaoTest {
             Arrays.asList(),
             Arrays.asList(new Dataset(LineageTestUtils.NAMESPACE, DATASET_NAME, datasetFacets)));
 
-    List<LineageEvent> lineageEvents = dao.listLineageEventsByRunUuid(writeJob.getRun().getUuid());
+    List<LineageEvent> lineageEvents = dao.findOlEventsByRunUuid(writeJob.getRun().getUuid());
     assertThat(lineageEvents).hasSize(1);
 
     assertThat(lineageEvents.get(0).getEventType()).isEqualTo("COMPLETE");


### PR DESCRIPTION
Signed-off-by: Minkyu Park <minkyu.park.200@gmail.com>

### Problem
OpenLineage events might contain lots of custom facets that marquez does not process properly, and it would be nice just
providing a way to retrieve raw events by run UUID so that the users can implement their own processing from run transition listener.

### Solution
This PR simply adds `SqlQuery` to the `OpenLineageDao` in order to provide ability to list lineage events by run UUID.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)