### PR TITLE
dataset symlinks provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased](https://github.com/MarquezProject/marquez/compare/0.26.0...HEAD)
 ### Fixed
 * Add support for `parentRun` facet as reported by older Airflow OpenLineage versions [@collado-mike](https://github.com/collado-mike)
+* Implemented dataset symlink feature which allows providing multiple names for a dataset and adds edges to lineage graph based on symlinks [`#2066`](https://github.com/MarquezProject/marquez/pull/2066) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+
 ## [0.26.0](https://github.com/MarquezProject/marquez/compare/0.25.0...0.26.0) - 2022-09-15
 
 ### Added

--- a/api/src/main/java/marquez/db/BaseDao.java
+++ b/api/src/main/java/marquez/db/BaseDao.java
@@ -31,6 +31,9 @@ public interface BaseDao extends SqlObject {
   NamespaceDao createNamespaceDao();
 
   @CreateSqlObject
+  DatasetSymlinkDao createDatasetSymlinkDao();
+
+  @CreateSqlObject
   RunDao createRunDao();
 
   @CreateSqlObject

--- a/api/src/main/java/marquez/db/Columns.java
+++ b/api/src/main/java/marquez/db/Columns.java
@@ -80,6 +80,9 @@ public final class Columns {
   public static final String FIELD_UUIDS = "field_uuids";
   public static final String LIFECYCLE_STATE = "lifecycle_state";
 
+  /* DATASET SYMLINK ROW COLUMNS */
+  public static final String IS_PRIMARY = "is_primary";
+
   /* STREAM VERSION ROW COLUMNS */
   public static final String SCHEMA_LOCATION = "schema_location";
 

--- a/api/src/main/java/marquez/db/DatasetSymlinkDao.java
+++ b/api/src/main/java/marquez/db/DatasetSymlinkDao.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.db;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import marquez.db.mappers.DatasetSymlinksRowMapper;
+import marquez.db.models.DatasetSymlinkRow;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+@RegisterRowMapper(DatasetSymlinksRowMapper.class)
+public interface DatasetSymlinkDao extends BaseDao {
+
+  default DatasetSymlinkRow upsertDatasetSymlinkRow(
+      UUID uuid, String name, UUID namespaceUuid, boolean isPrimary, String type, Instant now) {
+    doUpsertDatasetSymlinkRow(uuid, name, namespaceUuid, isPrimary, type, now);
+    return findDatasetSymlinkByNamespaceUuidAndName(namespaceUuid, name).orElseThrow();
+  }
+
+  @SqlQuery("SELECT * FROM dataset_symlinks WHERE namespace_uuid = :namespaceUuid and name = :name")
+  Optional<DatasetSymlinkRow> findDatasetSymlinkByNamespaceUuidAndName(
+      UUID namespaceUuid, String name);
+
+  @SqlUpdate(
+      """
+          INSERT INTO dataset_symlinks (
+          dataset_uuid,
+          name,
+          namespace_uuid,
+          is_primary,
+          type,
+          created_at,
+          updated_at
+          ) VALUES (
+          :uuid,
+          :name,
+          :namespaceUuid,
+          :isPrimary,
+          :type,
+          :now,
+          :now)
+          ON CONFLICT (name, namespace_uuid) DO NOTHING""")
+  void doUpsertDatasetSymlinkRow(
+      UUID uuid, String name, UUID namespaceUuid, boolean isPrimary, String type, Instant now);
+}

--- a/api/src/main/java/marquez/db/mappers/DatasetSymlinksRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetSymlinksRowMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.db.mappers;
+
+import static marquez.db.Columns.booleanOrDefault;
+import static marquez.db.Columns.stringOrNull;
+import static marquez.db.Columns.stringOrThrow;
+import static marquez.db.Columns.timestampOrThrow;
+import static marquez.db.Columns.uuidOrThrow;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import lombok.NonNull;
+import marquez.db.Columns;
+import marquez.db.models.DatasetSymlinkRow;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class DatasetSymlinksRowMapper implements RowMapper<DatasetSymlinkRow> {
+
+  @Override
+  public DatasetSymlinkRow map(@NonNull ResultSet results, @NonNull StatementContext context)
+      throws SQLException {
+    return new DatasetSymlinkRow(
+        uuidOrThrow(results, Columns.DATASET_UUID),
+        stringOrThrow(results, Columns.NAME),
+        uuidOrThrow(results, Columns.NAMESPACE_UUID),
+        stringOrNull(results, Columns.TYPE),
+        booleanOrDefault(results, Columns.IS_PRIMARY, false),
+        timestampOrThrow(results, Columns.CREATED_AT),
+        timestampOrThrow(results, Columns.UPDATED_AT));
+  }
+}

--- a/api/src/main/java/marquez/db/models/DatasetSymlinkRow.java
+++ b/api/src/main/java/marquez/db/models/DatasetSymlinkRow.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.db.models;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Value;
+
+@AllArgsConstructor
+@EqualsAndHashCode
+@Value
+public class DatasetSymlinkRow {
+  @NonNull UUID uuid;
+  @NonNull String name;
+  @NonNull UUID namespaceUuid;
+  @Nullable String type;
+  @NonNull boolean isPrimary;
+  @Getter @NonNull private final Instant createdAt;
+  @Getter @NonNull private final Instant updatedAt;
+
+  public Optional<String> getType() {
+    return Optional.ofNullable(type);
+  }
+}

--- a/api/src/main/java/marquez/service/models/LineageEvent.java
+++ b/api/src/main/java/marquez/service/models/LineageEvent.java
@@ -322,7 +322,8 @@ public class LineageEvent extends BaseJsonModel {
     "schema",
     "dataSource",
     "description",
-    "lifecycleStateChange"
+    "lifecycleStateChange",
+    "symlinks"
   })
   public static class DatasetFacets {
 
@@ -330,6 +331,7 @@ public class LineageEvent extends BaseJsonModel {
     @Valid private SchemaDatasetFacet schema;
     @Valid private LifecycleStateChangeFacet lifecycleStateChange;
     @Valid private DatasourceDatasetFacet dataSource;
+    @Valid private DatasetSymlinkFacet symlinks;
     private String description;
     @Builder.Default @JsonIgnore private Map<String, Object> additional = new LinkedHashMap<>();
 
@@ -349,6 +351,10 @@ public class LineageEvent extends BaseJsonModel {
 
     public SchemaDatasetFacet getSchema() {
       return schema;
+    }
+
+    public DatasetSymlinkFacet getSymlinks() {
+      return symlinks;
     }
 
     public LifecycleStateChangeFacet getLifecycleStateChange() {
@@ -410,6 +416,36 @@ public class LineageEvent extends BaseJsonModel {
     @NotNull private String name;
     @Nullable private String type;
     private String description;
+  }
+
+  @NoArgsConstructor
+  @Getter
+  @Setter
+  @Valid
+  @ToString
+  public static class DatasetSymlinkFacet extends BaseFacet {
+
+    @Valid private List<SymlinkIdentifier> identifiers;
+
+    @Builder
+    public DatasetSymlinkFacet(
+        @NotNull URI _producer, @NotNull URI _schemaURL, List<SymlinkIdentifier> identifiers) {
+      super(_producer, _schemaURL);
+      this.identifiers = identifiers;
+    }
+  }
+
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Setter
+  @Getter
+  @Valid
+  @ToString
+  public static class SymlinkIdentifier extends BaseJsonModel {
+
+    @NotNull private String namespace;
+    @NotNull private String name;
+    @Nullable private String type;
   }
 
   @NoArgsConstructor

--- a/api/src/main/resources/marquez/db/migration/R__3_Datasets_view.sql
+++ b/api/src/main/resources/marquez/db/migration/R__3_Datasets_view.sql
@@ -1,18 +1,22 @@
 CREATE OR REPLACE VIEW datasets_view
 AS
-SELECT uuid,
-       type,
-       created_at,
-       updated_at,
-       namespace_uuid,
-       source_uuid,
-       name,
-       physical_name,
-       description,
-       current_version_uuid,
-       last_modified_at,
-       namespace_name,
-       source_name,
-       is_deleted
-FROM datasets
-WHERE is_hidden IS FALSE;
+SELECT d.uuid,
+       d.type,
+       d.created_at,
+       d.updated_at,
+       d.namespace_uuid,
+       d.source_uuid,
+       d.name,
+       array_agg(CAST((namespaces.name, symlinks.name) AS DATASET_NAME)) AS dataset_symlinks,
+       d.physical_name,
+       d.description,
+       d.current_version_uuid,
+       d.last_modified_at,
+       d.namespace_name,
+       d.source_name,
+       d.is_deleted
+FROM datasets d
+JOIN dataset_symlinks symlinks ON d.uuid = symlinks.dataset_uuid
+INNER JOIN namespaces ON symlinks.namespace_uuid = namespaces.uuid
+WHERE d.is_hidden IS FALSE
+GROUP BY d.uuid;

--- a/api/src/main/resources/marquez/db/migration/V48__dataset_symlinks.sql
+++ b/api/src/main/resources/marquez/db/migration/V48__dataset_symlinks.sql
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+CREATE TABLE dataset_symlinks (
+  dataset_uuid      UUID,
+  name              VARCHAR(255) NOT NULL,
+  namespace_uuid    UUID REFERENCES namespaces(uuid),
+  type              VARCHAR(64),
+  is_primary        BOOLEAN DEFAULT FALSE,
+  created_at        TIMESTAMP NOT NULL,
+  updated_at        TIMESTAMP NOT NULL,
+  UNIQUE (namespace_uuid, name)
+);
+
+CREATE INDEX dataset_symlinks_dataset_uuid on dataset_symlinks (dataset_uuid);
+
+INSERT INTO dataset_symlinks (dataset_uuid, name, namespace_uuid, is_primary, created_at, updated_at)
+SELECT d.uuid, d.name, d.namespace_uuid, TRUE, d.created_at, d.updated_at FROM datasets d;
+
+DROP TYPE IF EXISTS DATASET_NAME;
+CREATE TYPE DATASET_NAME AS (
+    namespace       VARCHAR(255),
+    name            VARCHAR(255)
+);
+

--- a/api/src/test/java/marquez/db/LineageDaoTest.java
+++ b/api/src/test/java/marquez/db/LineageDaoTest.java
@@ -85,6 +85,7 @@ public class LineageDaoTest {
           handle.execute("DELETE FROM runs_input_mapping");
           handle.execute("DELETE FROM dataset_versions_field_mapping");
           handle.execute("DELETE FROM dataset_versions");
+          handle.execute("DELETE FROM dataset_symlinks");
           handle.execute("UPDATE runs SET start_run_state_uuid=NULL, end_run_state_uuid=NULL");
           handle.execute("DELETE FROM run_states");
           handle.execute("DELETE FROM runs");

--- a/api/src/test/java/marquez/db/OpenLineageDaoTest.java
+++ b/api/src/test/java/marquez/db/OpenLineageDaoTest.java
@@ -10,6 +10,7 @@ import static marquez.db.LineageTestUtils.SCHEMA_URL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import marquez.db.models.UpdateLineageRow;
 import marquez.db.models.UpdateLineageRow.DatasetRecord;
@@ -34,6 +35,8 @@ class OpenLineageDaoTest {
   public static final String DATASET_NAME = "theDataset";
 
   private static OpenLineageDao dao;
+  private static DatasetSymlinkDao symlinkDao;
+  private static NamespaceDao namespaceDao;
   private final DatasetFacets datasetFacets =
       LineageTestUtils.newDatasetFacet(
           new SchemaField("name", "STRING", "my name"), new SchemaField("age", "INT", "my age"));
@@ -41,6 +44,8 @@ class OpenLineageDaoTest {
   @BeforeAll
   public static void setUpOnce(Jdbi jdbi) {
     dao = jdbi.onDemand(OpenLineageDao.class);
+    symlinkDao = jdbi.onDemand(DatasetSymlinkDao.class);
+    namespaceDao = jdbi.onDemand(NamespaceDao.class);
   }
 
   /** When reading a dataset, the version is assumed to be the version last written */
@@ -92,6 +97,56 @@ class OpenLineageDaoTest {
     assertThat(writeJob.getOutputs()).isPresent().get().asList().size().isEqualTo(1);
     assertThat(writeJob.getOutputs().get().get(0).getDatasetVersionRow().getLifecycleState())
         .isEqualTo("TRUNCATE");
+  }
+
+  @Test
+  void testUpdateMarquezModelDatasetWithSymlinks() {
+    Dataset dataset =
+        new Dataset(
+            LineageTestUtils.NAMESPACE,
+            DATASET_NAME,
+            LineageEvent.DatasetFacets.builder()
+                .symlinks(
+                    new LineageEvent.DatasetSymlinkFacet(
+                        PRODUCER_URL,
+                        SCHEMA_URL,
+                        Collections.singletonList(
+                            new LineageEvent.SymlinkIdentifier(
+                                "symlinkNamespace", "symlinkName", "some-type"))))
+                .build());
+
+    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            dao, WRITE_JOB_NAME, "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList(dataset));
+
+    UpdateLineageRow readJob =
+        LineageTestUtils.createLineageRow(
+            dao,
+            WRITE_JOB_NAME,
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(
+                new Dataset(
+                    "symlinkNamespace",
+                    "symlinkName",
+                    LineageEvent.DatasetFacets.builder().build())),
+            Arrays.asList());
+
+    // make sure writeJob output dataset and readJob input dataset are the same (have the same uuid)
+    assertThat(writeJob.getOutputs()).isPresent().get().asList().size().isEqualTo(1);
+    assertThat(writeJob.getOutputs().get().get(0).getDatasetRow().getUuid())
+        .isEqualTo(readJob.getInputs().get().get(0).getDatasetRow().getUuid());
+    // make sure symlink is stored with type in dataset_symlinks table
+    assertThat(
+            symlinkDao
+                .findDatasetSymlinkByNamespaceUuidAndName(
+                    namespaceDao.findNamespaceByName("symlinkNamespace").get().getUuid(),
+                    "symlinkName")
+                .get()
+                .getType()
+                .get())
+        .isEqualTo("some-type");
   }
 
   /**
@@ -146,6 +201,7 @@ class OpenLineageDaoTest {
                     new SchemaField("eyeColor", "STRING", "my eye color"))),
             this.datasetFacets.getLifecycleStateChange(),
             this.datasetFacets.getDataSource(),
+            null,
             this.datasetFacets.getDescription(),
             this.datasetFacets.getAdditionalFacets());
     UpdateLineageRow readJob =

--- a/api/src/test/java/marquez/db/RunDaoTest.java
+++ b/api/src/test/java/marquez/db/RunDaoTest.java
@@ -69,6 +69,7 @@ class RunDaoTest {
           handle.execute("DELETE FROM datasets_tag_mapping");
           handle.execute("DELETE FROM dataset_versions_field_mapping");
           handle.execute("DELETE FROM dataset_versions");
+          handle.execute("DELETE FROM dataset_symlinks");
           handle.execute("UPDATE runs SET start_run_state_uuid=NULL, end_run_state_uuid=NULL");
           handle.execute("DELETE FROM run_states");
           handle.execute("DELETE FROM runs");

--- a/api/src/test/java/marquez/service/LineageServiceTest.java
+++ b/api/src/test/java/marquez/service/LineageServiceTest.java
@@ -88,6 +88,7 @@ public class LineageServiceTest {
           handle.execute("DELETE FROM dataset_versions_field_mapping");
           handle.execute("DELETE FROM stream_versions");
           handle.execute("DELETE FROM dataset_versions");
+          handle.execute("DELETE FROM dataset_symlinks");
           handle.execute("UPDATE runs SET start_run_state_uuid=NULL, end_run_state_uuid=NULL");
           handle.execute("DELETE FROM run_states");
           handle.execute("DELETE FROM runs");


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

A `SymlinkDatasetFacet` has been introduced in spec recently (https://github.com/OpenLineage/OpenLineage/pull/936) and it allows a dataset to be identified by multiple `(name, namespace)` tuples. We need to modify Marquez to handle it, as currently many joins to dataset table are done directly based on `name` and `namespace` value. 

Part of: #2066

### Solution

This PR contains:
* a refactor of current Marquez database model to allow alternative dataset names by creating an extra `dataset_symlinks` table with dataset name. 
* removal of dataset's name from dataset table.
* implementation of `SymlinkDatasetFacet` logic. 


> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)