### PR TITLE
Fix incorrect postgressql version

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -107,7 +107,7 @@ postgresql:
   ## @param image.tag PostgreSQL image tag (immutable tags are recommended)
   ##
   image:
-    tag: 0.25.0
+    tag: 12.1.0
   ## Authentication parameters
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#setting-the-root-password-on-first-run
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run


### PR DESCRIPTION
### Problem

No such tag exists for postgressql. This appears to be an accidental change.
