### PR TITLE
[DEV] update `boring-cyborg.yml`

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -12,7 +12,7 @@ labelPRBasedOnFilePath:
   # Add 'docs' to any changes to `.md` files in root or within 'docs' folder, subfolders
     docs:
       - docs/**/*
-      - ../*.md
+      - "*.md"
 
   # Add 'client/java' to any changes within 'clients/java' folder or any subfolders
     client/java:


### PR DESCRIPTION
### Problem

The path for docs in the root directory in `boring-cyborg.yml` is incorrect.

### Solution

This fix corrects the path so changes to docs in the root directory will be labeled.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)