### PR TITLE
bump jacoco version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ subprojects {
     ext {
         assertjVersion = '3.22.0'
         dropwizardVersion = '2.1.0'
-        jacocoVersion = '0.8.7'
+        jacocoVersion = '0.8.8'
         junit5Version = '5.8.2'
         lombokVersion = '1.18.24'
         mockitoVersion = '4.5.1'


### PR DESCRIPTION
This makes Jacoco work on Java 18 and 19.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>