### PR TITLE
Drop requirement to provide `marquez.yml` for seed cmd

### DIFF
--- a/api/src/main/java/marquez/cli/SeedCommand.java
+++ b/api/src/main/java/marquez/cli/SeedCommand.java
@@ -9,7 +9,7 @@ import static marquez.common.Utils.newObjectMapper;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableList;
-import io.dropwizard.cli.ConfiguredCommand;
+import io.dropwizard.cli.Command;
 import io.dropwizard.setup.Bootstrap;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineageClient;
@@ -18,7 +18,6 @@ import java.nio.file.Paths;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import marquez.MarquezConfig;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
@@ -37,7 +36,7 @@ import net.sourceforge.argparse4j.inf.Subparser;
  * For example, to override the {@code url}:
  *
  * <pre>{@code
- * java -jar marquez-api.jar seed --url http://localhost:5000 --metadata metadata.json marquez.yml
+ * java -jar marquez-api.jar seed --url http://localhost:5000 --metadata metadata.json
  * }</pre>
  *
  * <p>where, {@code metadata.json} contains metadata for run {@code
@@ -93,7 +92,7 @@ import net.sourceforge.argparse4j.inf.Subparser;
  * <p><b>Note:</b> The {@code seed} command requires a running instance of Marquez.
  */
 @Slf4j
-public final class SeedCommand extends ConfiguredCommand<MarquezConfig> {
+public final class SeedCommand extends Command {
   /* Default URL for HTTP backend. */
   private static final String DEFAULT_OL_URL = "http://localhost:8080";
 
@@ -109,7 +108,6 @@ public final class SeedCommand extends ConfiguredCommand<MarquezConfig> {
   /* Configure seed command. */
   @Override
   public void configure(@NonNull final Subparser subparser) {
-    super.configure(subparser);
     subparser
         .addArgument("--url")
         .dest("url")
@@ -126,10 +124,7 @@ public final class SeedCommand extends ConfiguredCommand<MarquezConfig> {
   }
 
   @Override
-  protected void run(
-      @NonNull Bootstrap<MarquezConfig> bootstrap,
-      @NonNull Namespace namespace,
-      @NonNull MarquezConfig config) {
+  public void run(@NonNull Bootstrap<?> bootstrap, @NonNull Namespace namespace) {
     final String olUrl = namespace.getString(CMD_ARG_OL_URL);
     final String olMetadata = namespace.getString(CMD_ARG_OL_METADATA);
     // Use HTTP transport.

--- a/docker/seed.sh
+++ b/docker/seed.sh
@@ -7,9 +7,4 @@
 
 set -e
 
-if [[ -z "${MARQUEZ_CONFIG}" ]]; then
-  MARQUEZ_CONFIG='marquez.dev.yml'
-  echo "WARNING 'MARQUEZ_CONFIG' not set, using development configuration."
-fi
-
-java -jar marquez-api-*.jar seed --url "${MARQUEZ_URL:-http://localhost:5000}" --metadata metadata.json "${MARQUEZ_CONFIG}"
+java -jar marquez-api-*.jar seed --url "${MARQUEZ_URL:-http://localhost:5000}" --metadata metadata.json


### PR DESCRIPTION
### Problem

The `marquez.yml` arg is not used in the `seed` cmd.

### Solution

Use  `io.dropwizard.cli.Command` instead of `io.dropwizard.cli.ConfiguredCommand` to no longer require passing `marquez.yml` as an arg to the `seed` cmd:

```
java -jar api/build/libs/marquez-api.jar seed --help
usage: java -jar marquez-api-0.26.0-SNAPSHOT.jar
       seed [--url URL] --metadata METADATA [-h]

seeds the HTTP API server with metadata

named arguments:
  --url URL              the HTTP API server url (default: http://localhost:8080)
  --metadata METADATA    the path to the metadata file (ex: path/to/metadata.json)
  -h, --help             show this help message and exit
```

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)