### PR TITLE
deletes: 'undelete' job on subsequent OL event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased](https://github.com/MarquezProject/marquez/compare/0.25.0...HEAD)
+* Add job/dataset soft delete API [`#2032`](https://github.com/MarquezProject/marquez/pull/2032)
 
 ## [0.25.0](https://github.com/MarquezProject/marquez/compare/0.24.0...0.25.0) - 2022-08-08
 


### PR DESCRIPTION
This PR changes Postgres function that modifies `jobs_view` to clear soft delete flag from jobs table when we receive next OpenLineage event that references this job.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

Closes: #2100
