### PR TITLE
document in code that JobDao.upsertJob executes trigger

### DIFF
--- a/api/src/main/java/marquez/db/JobDao.java
+++ b/api/src/main/java/marquez/db/JobDao.java
@@ -231,6 +231,10 @@ public interface JobDao extends BaseDao {
     }
   }
 
+  /*
+   Note: following SQL never executes. There is database trigger on `jobs_view` that replaces following SQL
+   with rewrite_jobs_fqn_table plpgsql function. Code of that function is at R__1 migration file.
+  */
   @SqlQuery(
       """
           INSERT INTO jobs_view AS j (
@@ -276,6 +280,10 @@ public interface JobDao extends BaseDao {
       UUID symlinkTargetId,
       PGobject inputs);
 
+  /*
+   Note: following SQL never executes. There is database trigger on `jobs_view` that replaces following SQL
+   with rewrite_jobs_fqn_table plpgsql function. Code of that function is at R__1 migration file.
+  */
   @SqlQuery(
       """
           INSERT INTO jobs_view AS j (


### PR DESCRIPTION
Just a comment for future reader that JobDao.upsertJob does not actually execute SQL in `SqlQuery` annotation.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
