### PR TITLE
Add fix and tests for handling Airflow dags with dots and task groups

### DIFF
--- a/api/src/test/java/marquez/OpenLineageIntegrationTest.java
+++ b/api/src/test/java/marquez/OpenLineageIntegrationTest.java
@@ -199,11 +199,127 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
     String dagName = "the_dag";
     RunEvent airflowTask1 =
         createAirflowRunEvent(
-            ol, startOfHour, endOfHour, airflowParentRunId, task1Name, dagName, NAMESPACE_NAME);
+            ol,
+            startOfHour,
+            endOfHour,
+            airflowParentRunId,
+            dagName,
+            dagName + "." + task1Name,
+            NAMESPACE_NAME);
 
     RunEvent airflowTask2 =
         createAirflowRunEvent(
-            ol, startOfHour, endOfHour, airflowParentRunId, task2Name, dagName, NAMESPACE_NAME);
+            ol,
+            startOfHour,
+            endOfHour,
+            airflowParentRunId,
+            dagName,
+            dagName + "." + task2Name,
+            NAMESPACE_NAME);
+
+    CompletableFuture<Integer> future = sendAllEvents(airflowTask1, airflowTask2);
+    future.get(5, TimeUnit.SECONDS);
+
+    Job job = client.getJob(NAMESPACE_NAME, dagName + "." + task1Name);
+    assertThat(job)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("id", new JobId(NAMESPACE_NAME, dagName + "." + task1Name))
+        .hasFieldOrPropertyWithValue("parentJobName", dagName);
+
+    Job parentJob = client.getJob(NAMESPACE_NAME, dagName);
+    assertThat(parentJob)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("id", new JobId(NAMESPACE_NAME, dagName))
+        .hasFieldOrPropertyWithValue("parentJobName", null);
+    List<Run> runsList = client.listRuns(NAMESPACE_NAME, dagName);
+    assertThat(runsList).isNotEmpty().hasSize(1);
+  }
+
+  @Test
+  public void testOpenLineageJobHierarchyAirflowIntegrationWithDagNameWithDot()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    OpenLineage ol = new OpenLineage(URI.create("http://openlineage.test.com/"));
+    ZonedDateTime startOfHour =
+        Instant.now()
+            .atZone(LineageTestUtils.LOCAL_ZONE)
+            .with(ChronoField.MINUTE_OF_HOUR, 0)
+            .with(ChronoField.SECOND_OF_MINUTE, 0);
+    ZonedDateTime endOfHour = startOfHour.plusHours(1);
+    String airflowParentRunId = UUID.randomUUID().toString();
+    String task1Name = "task1";
+    String task2Name = "task2";
+    String dagName = "the.dag";
+    RunEvent airflowTask1 =
+        createAirflowRunEvent(
+            ol,
+            startOfHour,
+            endOfHour,
+            airflowParentRunId,
+            dagName,
+            dagName + "." + task1Name,
+            NAMESPACE_NAME);
+
+    RunEvent airflowTask2 =
+        createAirflowRunEvent(
+            ol,
+            startOfHour,
+            endOfHour,
+            airflowParentRunId,
+            dagName,
+            dagName + "." + task2Name,
+            NAMESPACE_NAME);
+
+    CompletableFuture<Integer> future = sendAllEvents(airflowTask1, airflowTask2);
+    future.get(5, TimeUnit.SECONDS);
+
+    Job job = client.getJob(NAMESPACE_NAME, dagName + "." + task1Name);
+    assertThat(job)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("id", new JobId(NAMESPACE_NAME, dagName + "." + task1Name))
+        .hasFieldOrPropertyWithValue("parentJobName", dagName);
+
+    Job parentJob = client.getJob(NAMESPACE_NAME, dagName);
+    assertThat(parentJob)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("id", new JobId(NAMESPACE_NAME, dagName))
+        .hasFieldOrPropertyWithValue("parentJobName", null);
+    List<Run> runsList = client.listRuns(NAMESPACE_NAME, dagName);
+    assertThat(runsList).isNotEmpty().hasSize(1);
+  }
+
+  @Test
+  public void testOpenLineageJobHierarchyAirflowIntegrationWithTaskGroup()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    OpenLineage ol = new OpenLineage(URI.create("http://openlineage.test.com/"));
+    ZonedDateTime startOfHour =
+        Instant.now()
+            .atZone(LineageTestUtils.LOCAL_ZONE)
+            .with(ChronoField.MINUTE_OF_HOUR, 0)
+            .with(ChronoField.SECOND_OF_MINUTE, 0);
+    ZonedDateTime endOfHour = startOfHour.plusHours(1);
+    String airflowParentRunId = UUID.randomUUID().toString();
+    String task1Name = "task_group.task1";
+    String task2Name = "task_group.task2";
+    String dagName = "dag_with_task_group";
+    RunEvent airflowTask1 =
+        createAirflowRunEvent(
+            ol,
+            startOfHour,
+            endOfHour,
+            airflowParentRunId,
+            dagName,
+            dagName + "." + task1Name,
+            NAMESPACE_NAME);
+
+    RunEvent airflowTask2 =
+        createAirflowRunEvent(
+            ol,
+            startOfHour,
+            endOfHour,
+            airflowParentRunId,
+            dagName,
+            dagName + "." + task2Name,
+            NAMESPACE_NAME);
 
     CompletableFuture<Integer> future = sendAllEvents(airflowTask1, airflowTask2);
     future.get(5, TimeUnit.SECONDS);
@@ -242,13 +358,27 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
     String task1Name = "task1";
     String task2Name = "task2";
     String dagName = "the_dag";
+
+    // the old integration also used the fully qualified task name as the parent job name
     RunEvent airflowTask1 =
         createAirflowRunEvent(
-            ol, startOfHour, endOfHour, airflowParentRunId, task1Name, dagName, NAMESPACE_NAME);
+            ol,
+            startOfHour,
+            endOfHour,
+            airflowParentRunId,
+            dagName + "." + task1Name,
+            dagName + "." + task1Name,
+            NAMESPACE_NAME);
 
     RunEvent airflowTask2 =
         createAirflowRunEvent(
-            ol, startOfHour, endOfHour, airflowParentRunId, task2Name, dagName, NAMESPACE_NAME);
+            ol,
+            startOfHour,
+            endOfHour,
+            airflowParentRunId,
+            dagName + "." + task2Name,
+            dagName + "." + task2Name,
+            NAMESPACE_NAME);
 
     CompletableFuture<Integer> future = sendAllEvents(airflowTask1, airflowTask2);
     future.get(5, TimeUnit.SECONDS);
@@ -291,12 +421,24 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
     // two dag runs with different namespaces - should result in two distinct jobs
     RunEvent airflowTask1 =
         createAirflowRunEvent(
-            ol, startOfHour, endOfHour, airflowParentRunId, task1Name, dagName, NAMESPACE_NAME);
+            ol,
+            startOfHour,
+            endOfHour,
+            airflowParentRunId,
+            dagName,
+            dagName + "." + task1Name,
+            NAMESPACE_NAME);
 
     String secondNamespace = "another_namespace";
     RunEvent airflowTask2 =
         createAirflowRunEvent(
-            ol, startOfHour, endOfHour, airflowParentRunId, task1Name, dagName, secondNamespace);
+            ol,
+            startOfHour,
+            endOfHour,
+            airflowParentRunId,
+            dagName,
+            dagName + "." + task1Name,
+            secondNamespace);
 
     CompletableFuture<Integer> future = sendAllEvents(airflowTask1, airflowTask2);
     future.get(5, TimeUnit.SECONDS);
@@ -332,7 +474,13 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
     String dagName = "the_dag";
     RunEvent airflowTask1 =
         createAirflowRunEvent(
-            ol, startOfHour, endOfHour, airflowParentRunId, task1Name, dagName, NAMESPACE_NAME);
+            ol,
+            startOfHour,
+            endOfHour,
+            airflowParentRunId,
+            dagName,
+            dagName + "." + task1Name,
+            NAMESPACE_NAME);
 
     RunEvent sparkTask =
         createRunEvent(
@@ -340,8 +488,8 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
             startOfHour,
             endOfHour,
             airflowTask1.getRun().getRunId().toString(),
-            sparkTaskName,
             dagName + "." + task1Name,
+            dagName + "." + task1Name + "." + sparkTaskName,
             Optional.empty(),
             NAMESPACE_NAME);
 
@@ -609,8 +757,8 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
       ZonedDateTime startOfHour,
       ZonedDateTime endOfHour,
       String airflowParentRunId,
-      String taskName,
       String dagName,
+      String taskName,
       String namespace) {
     RunFacet airflowVersionFacet = ol.newRunFacet();
     airflowVersionFacet
@@ -622,8 +770,8 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
         startOfHour,
         endOfHour,
         airflowParentRunId,
-        taskName,
         dagName,
+        taskName,
         Optional.of(airflowVersionFacet),
         namespace);
   }
@@ -634,8 +782,8 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
       ZonedDateTime startOfHour,
       ZonedDateTime endOfHour,
       String airflowParentRunId,
-      String taskName,
       String dagName,
+      String taskName,
       Optional<RunFacet> airflowVersionFacet,
       String namespace) {
     // The Java SDK requires parent run ids to be a UUID, but the python SDK doesn't. In order to
@@ -650,7 +798,7 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
                 "run",
                 ImmutableMap.of("runId", airflowParentRunId),
                 "job",
-                ImmutableMap.of("namespace", namespace, "name", dagName + "." + taskName)));
+                ImmutableMap.of("namespace", namespace, "name", dagName)));
     RunFacetsBuilder runFacetBuilder =
         ol.newRunFacetsBuilder()
             .nominalTime(ol.newNominalTimeRunFacet(startOfHour, endOfHour))
@@ -663,7 +811,7 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
         .job(
             ol.newJob(
                 namespace,
-                dagName + "." + taskName,
+                taskName,
                 ol.newJobFacetsBuilder()
                     .documentation(ol.newDocumentationJobFacet("the job docs"))
                     .sql(ol.newSQLJobFacet("SELECT * FROM the_table"))


### PR DESCRIPTION
### Problem

A recent change broke how marquez handles DAGs with dots and tasks within task groups. This change corrects that and adds a few test cases to validate

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)