### PR TITLE
Fix `codecov` in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ only-on-release: &only-on-release
       ignore: /.*/
 
 orbs:
+  # https://circleci.com/orbs/registry/orb/codecov/codecov
   codecov: codecov/codecov@3.2.3
 
 jobs:
@@ -35,7 +36,7 @@ jobs:
       - run: ./gradlew --no-daemon --stacktrace api:javadoc
       - run: ./gradlew --no-daemon --stacktrace api:build
       - run: ./gradlew --no-daemon api:jacocoTestReport
-      - run: codecov/upload
+      - codecov/upload
       - store_test_results:
           path: api/build/test-results/test
       - store_artifacts:
@@ -102,7 +103,7 @@ jobs:
       - run: ./gradlew --no-daemon --stacktrace clients:java:javadoc
       - run: ./gradlew --no-daemon --stacktrace clients:java:build
       - run: ./gradlew --no-daemon clients:java:jacocoTestReport
-      - run: codecov/upload
+      - codecov/upload
       - store_test_results:
           path: clients/java/build/test-results/test
       - store_artifacts:
@@ -122,7 +123,7 @@ jobs:
       - run: pip install -e .[dev]
       - run: flake8
       - run: pytest --cov=marquez_python tests/
-      - run: codecov/upload
+      - codecov/upload
 
   build-client-python:
     working_directory: ~/marquez/clients/python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ only-on-release: &only-on-release
     branches:
       ignore: /.*/
 
+orbs:
+  codecov: codecov/codecov@3.2.3
+
 jobs:
   build-api:
     working_directory: ~/marquez
@@ -32,7 +35,7 @@ jobs:
       - run: ./gradlew --no-daemon --stacktrace api:javadoc
       - run: ./gradlew --no-daemon --stacktrace api:build
       - run: ./gradlew --no-daemon api:jacocoTestReport
-      - run: bash <(curl -s https://codecov.io/bash)
+      - run: codecov/upload
       - store_test_results:
           path: api/build/test-results/test
       - store_artifacts:
@@ -99,7 +102,7 @@ jobs:
       - run: ./gradlew --no-daemon --stacktrace clients:java:javadoc
       - run: ./gradlew --no-daemon --stacktrace clients:java:build
       - run: ./gradlew --no-daemon clients:java:jacocoTestReport
-      - run: bash <(curl -s https://codecov.io/bash)
+      - run: codecov/upload
       - store_test_results:
           path: clients/java/build/test-results/test
       - store_artifacts:
@@ -119,7 +122,7 @@ jobs:
       - run: pip install -e .[dev]
       - run: flake8
       - run: pytest --cov=marquez_python tests/
-      - run: bash <(curl -s https://codecov.io/bash)
+      - run: codecov/upload
 
   build-client-python:
     working_directory: ~/marquez/clients/python


### PR DESCRIPTION
### Problem

CI is failing to upload `codecov` reports.

### Solution

Use recommended [uploader](https://about.codecov.io/blog/introducing-codecovs-new-uploader/) for `codecov` via [codecov](https://circleci.com/developer/orbs/orb/codecov/codecov) orb.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)