### PR TITLE
Update insert job function to avoid joining on symlinks for jobs that have no symlinks

### DIFF
--- a/api/src/test/java/marquez/db/LineageDaoTest.java
+++ b/api/src/test/java/marquez/db/LineageDaoTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Functions;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -220,7 +221,7 @@ public class LineageDaoTest {
             .upsertJob(
                 UUID.randomUUID(),
                 JobType.valueOf(writeJob.getJob().getType()),
-                writeJob.getJob().getCreatedAt(),
+                Instant.now(),
                 namespaceRow.getUuid(),
                 writeJob.getJob().getNamespaceName(),
                 symlinkTargetJobName,
@@ -233,7 +234,7 @@ public class LineageDaoTest {
         .upsertJob(
             writeJob.getJob().getUuid(),
             JobType.valueOf(writeJob.getJob().getType()),
-            writeJob.getJob().getCreatedAt(),
+            Instant.now(),
             namespaceRow.getUuid(),
             writeJob.getJob().getNamespaceName(),
             writeJob.getJob().getName(),


### PR DESCRIPTION
### Problem

Typical marquez installations don't have a large number of new jobs being created on a regular basis. However, in some small number of installations, there can be a large number of new jobs being created, which executes the `rewrite_jobs_fqn_table` function each time, putting stress on the backing database. Most of the compute cost of this function is in computing the symlinks and aliases for jobs - even when the inserted job has no symlink.

Closes: #ISSUE-NUMBER

### Solution

Adding a check for the symlink field and offering a lower cost query in cases when no symlink is present (the norm) radically reduces the database compute load in Marquez installations that frequently create a large number of new jobs.
The following graph shows query count and latency and database CPU utilization under a test load of many new jobs being created. The test load was several days of real production OpenLineage events being replayed on a dev instance. To verify results, I ran the same test twice for both the old query and the new. Under heavy load, the job creation query causes database CPU utilization to climb to 100% and query latency climbs to as high as 2 seconds. Under the same load (I renamed all of the jobs in the database, so the same load shows up as new jobs that invoke the job creation query), the new query drives CPU utilization to around 30% and query latency is around 300 microseconds.

Note that the query latency in this graph is shown at log scale (right axis). Otherwise, the latency for the new query would be indistinguishable from 0.
<img width="953" alt="Screen Shot 2022-09-26 at 8 41 11 AM" src="https://user-images.githubusercontent.com/40346148/192327238-79d36b0f-84ec-4188-bc02-dca7a216ec4a.png">

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)