### PR TITLE
Use `clean` when running `shadowJar` in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 *.md
 .*
 Dockerfile
-build
+api/build
 docs
 web/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY build.gradle build.gradle
 COPY api ./api
 COPY api/build.gradle ./api/build.gradle
 COPY clients/java ./clients/java
-RUN ./gradlew --no-daemon :api:shadowJar
+RUN ./gradlew --no-daemon clean :api:shadowJar
 
 FROM eclipse-temurin:17
 RUN apt-get update && apt-get install -y postgresql-client bash coreutils

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -12,14 +12,8 @@ if [[ -z "${MARQUEZ_CONFIG}" ]]; then
   echo "WARNING 'MARQUEZ_CONFIG' not set, using development configuration."
 fi
 
-if [[ -z "${MARQUEZ_VERSION}" ]]; then
-  MARQUEZ_VERSION='*'
-  echo "WARNING 'MARQUEZ_VERSION' not set. Running could fail if directory contains multiple jar versions."
-fi
-
-
 # Adjust java options for the http server
 JAVA_OPTS="${JAVA_OPTS} -Duser.timezone=UTC -Dlog4j2.formatMsgNoLookups=true"
 
 # Start http server with java options and configuration
-java ${JAVA_OPTS} -jar marquez-${MARQUEZ_VERSION}.jar server ${MARQUEZ_CONFIG}
+java ${JAVA_OPTS} -jar marquez-*.jar server ${MARQUEZ_CONFIG}


### PR DESCRIPTION
### Problem

PR #2032 introduced `MARQUEZ_VERSION` in [`entrypoint.sh`](https://github.com/MarquezProject/marquez/blob/main/docker/entrypoint.sh) to avoid the case when multiple JARs are located under the directory `api/build/libs/`. When building the docker image for the API, we copy over the directory `api/` in its entirety. This  results in (possibly) multiple JARs with  the following error:

```
marquez-ap   | invalid choice: 'marquez-api-0.27.1-SNAPSHOT.jar' (choose from 'server', 'check', 'metadata', 'seed')
marquez-api  | usage: java -jar marquez-api-0.27.0-SNAPSHOT.jar
```

### Solution

When building the API docker image, use `clean` when building the shadow JAR:

```
 $ ./gradlew clean :api:shadowJar
```

This will ensure the directory `api/build/libs/` is cleaned before building the JAR again. This PR also updates `.dockerignore` to ignore `api/build/*`.


### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)