### PR TITLE
Display current run state for job node in lineage graph

### DIFF
--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -10,7 +10,7 @@ import MqText from '../core/text/MqText'
 import React, { FunctionComponent } from 'react'
 import RunStatus from '../jobs/RunStatus'
 
-const DATASET_COLUMNS = ['Field', 'Type', 'Description']
+const DATASET_COLUMNS = ['NAME', 'TYPE', 'DESCRIPTION']
 
 interface DatasetInfoProps {
   datasetFields: Field[]
@@ -56,7 +56,7 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = props => {
       {facets && (
         <Box mt={2}>
           <Box mb={1}>
-            <MqText subheading>Facets</MqText>
+            <MqText subheading>FACETS</MqText>
           </Box>
           <MqJson code={facets} />
         </Box>

--- a/web/src/components/datasets/DatasetVersions.tsx
+++ b/web/src/components/datasets/DatasetVersions.tsx
@@ -26,7 +26,13 @@ const styles = (theme: ITheme) => {
   })
 }
 
-const DATASET_VERSIONS_COLUMNS = ['VERSION', 'CREATED AT', 'FIELDS', 'CREATED BY RUN', 'LIFECYCLE STATE']
+const DATASET_VERSIONS_COLUMNS = [
+  'VERSION',
+  'CREATED AT',
+  'FIELDS',
+  'CREATED BY RUN',
+  'LIFECYCLE STATE'
+]
 
 interface DatasetVersionsProps {
   versions: DatasetVersion[]

--- a/web/src/components/datasets/DatasetVersions.tsx
+++ b/web/src/components/datasets/DatasetVersions.tsx
@@ -26,7 +26,7 @@ const styles = (theme: ITheme) => {
   })
 }
 
-const DATASET_VERSIONS_COLUMNS = ['Version', 'Created At', 'Field Count', 'Dataset Creator (Run)', 'Lifecycle State']
+const DATASET_VERSIONS_COLUMNS = ['VERSION', 'CREATED AT', 'FIELDS', 'CREATED BY RUN', 'LIFECYCLE STATE']
 
 interface DatasetVersionsProps {
   versions: DatasetVersion[]

--- a/web/src/components/jobs/RunInfo.tsx
+++ b/web/src/components/jobs/RunInfo.tsx
@@ -26,7 +26,7 @@ const RunInfo: FunctionComponent<RunInfoProps> = props => {
       {run.facets && (
         <Box mt={2}>
           <Box mb={1}>
-            <MqText subheading>Facets</MqText>
+            <MqText subheading>FACETS</MqText>
           </Box>
           <MqJson code={run.facets} />
         </Box>

--- a/web/src/components/jobs/Runs.tsx
+++ b/web/src/components/jobs/Runs.tsx
@@ -27,7 +27,7 @@ import RunInfo from './RunInfo'
 import RunStatus from './RunStatus'
 import transitions from '@material-ui/core/styles/transitions'
 
-const RUN_COLUMNS = ['ID', 'State', 'Created At', 'Started At', 'Ended At', 'Duration']
+const RUN_COLUMNS = ['ID', 'STATE', 'CREATED AT', 'STARTED AT', 'ENDED AT', 'DURATION']
 
 const styles = (theme: Theme) => {
   return createStyles({
@@ -116,7 +116,7 @@ const Runs: FunctionComponent<RunsProps & WithStyles<typeof styles>> = props => 
       {facets && (
         <Box mt={2}>
           <Box mb={1}>
-            <MqText subheading>Facets</MqText>
+            <MqText subheading>FACETS</MqText>
           </Box>
           <MqCode code={JSON.stringify(facets, null, '\t')} />
         </Box>

--- a/web/src/components/lineage/components/node/Node.tsx
+++ b/web/src/components/lineage/components/node/Node.tsx
@@ -43,10 +43,11 @@ type NodeProps = DispatchProps & OwnProps
 
 function runStateToNodeColor(run: Nullable<Run>) {
   switch (run?.state) {
-    case 'RUNNING': return theme.palette.primary.main;
+    case 'NEW': return theme.palette.secondary.main;
+    case 'RUNNING': return theme.palette.info.main;
     case 'COMPLETED': return theme.palette.primary.main;
     case 'FAILED': return theme.palette.error.main;
-    case 'ABORTED': return theme.palette.primary.main;
+    case 'ABORTED': return theme.palette.warning.main;
     default:
       break;
   }

--- a/web/src/components/lineage/components/node/Node.tsx
+++ b/web/src/components/lineage/components/node/Node.tsx
@@ -42,12 +42,17 @@ interface OwnProps {
 type NodeProps = DispatchProps & OwnProps
 
 function runStateToNodeColor(run: Nullable<Run>) {
-  switch (run?.state) {
-    case 'NEW': return theme.palette.secondary.main
-    case 'RUNNING': return theme.palette.info.main
-    case 'COMPLETED': return theme.palette.secondary.main
-    case 'FAILED': return theme.palette.error.main
-    case 'ABORTED': return theme.palette.warning.main
+  switch (run && run.state) {
+    case 'NEW':
+      return theme.palette.secondary.main
+    case 'RUNNING':
+      return theme.palette.info.main
+    case 'COMPLETED':
+      return theme.palette.secondary.main
+    case 'FAILED':
+      return theme.palette.error.main
+    case 'ABORTED':
+      return theme.palette.warning.main
     default:
       return theme.palette.secondary.main
   }
@@ -109,11 +114,7 @@ class Node extends React.Component<NodeProps> {
               x={node.x - RADIUS}
               y={node.y - RADIUS}
               fill={theme.palette.common.white}
-              stroke={
-                isSelected
-                  ? theme.palette.primary.main
-                  : theme.palette.secondary.main
-              }
+              stroke={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
               strokeWidth={BORDER}
               width={RADIUS * 2}
               height={RADIUS * 2}

--- a/web/src/components/lineage/components/node/Node.tsx
+++ b/web/src/components/lineage/components/node/Node.tsx
@@ -8,6 +8,8 @@ import { Node as GraphNode } from 'dagre'
 import { Link } from 'react-router-dom'
 import { MqNode } from '../../types'
 import { NodeText } from './NodeText'
+import { Nullable } from '../../../../types/util/Nullable'
+import { Run } from '../../../../types/api'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { encodeNode, isDataset, isJob } from '../../../../helpers/nodes'
@@ -16,8 +18,6 @@ import { faCog } from '@fortawesome/free-solid-svg-icons/faCog'
 import { faDatabase } from '@fortawesome/free-solid-svg-icons/faDatabase'
 import { setSelectedNode } from '../../../../store/actionCreators'
 import { theme } from '../../../../helpers/theme'
-import { Run } from '../../../../types/api'
-import { Nullable } from '../../../../types/util/Nullable'
 
 export type Vertex = {
   x: number
@@ -43,13 +43,13 @@ type NodeProps = DispatchProps & OwnProps
 
 function runStateToNodeColor(run: Nullable<Run>) {
   switch (run?.state) {
-    case 'NEW': return theme.palette.secondary.main;
-    case 'RUNNING': return theme.palette.info.main;
-    case 'COMPLETED': return theme.palette.secondary.main;
-    case 'FAILED': return theme.palette.error.main;
-    case 'ABORTED': return theme.palette.warning.main;
+    case 'NEW': return theme.palette.secondary.main
+    case 'RUNNING': return theme.palette.info.main
+    case 'COMPLETED': return theme.palette.secondary.main
+    case 'FAILED': return theme.palette.error.main
+    case 'ABORTED': return theme.palette.warning.main
     default:
-      return theme.palette.secondary.main;
+      return theme.palette.secondary.main
   }
 }
 
@@ -66,7 +66,7 @@ class Node extends React.Component<NodeProps> {
   render() {
     const { node, edgeEnds, selectedNode } = this.props
     const job = isJob(node)
-    const isSelected = selectedNode === node.label;
+    const isSelected = selectedNode === node.label
     return (
       <Link
         to={this.determineLink(node)}

--- a/web/src/components/lineage/components/node/Node.tsx
+++ b/web/src/components/lineage/components/node/Node.tsx
@@ -27,7 +27,7 @@ export type Vertex = {
 const RADIUS = 14
 const OUTER_RADIUS = RADIUS + 8
 const ICON_SIZE = 16
-const BORDER = 2
+const BORDER = 4
 
 interface DispatchProps {
   setSelectedNode: (payload: string) => void
@@ -45,11 +45,11 @@ function runStateToNodeColor(run: Nullable<Run>) {
   switch (run?.state) {
     case 'NEW': return theme.palette.secondary.main;
     case 'RUNNING': return theme.palette.info.main;
-    case 'COMPLETED': return theme.palette.primary.main;
+    case 'COMPLETED': return theme.palette.secondary.main;
     case 'FAILED': return theme.palette.error.main;
     case 'ABORTED': return theme.palette.warning.main;
     default:
-      break;
+      return theme.palette.secondary.main;
   }
 }
 
@@ -66,6 +66,7 @@ class Node extends React.Component<NodeProps> {
   render() {
     const { node, edgeEnds, selectedNode } = this.props
     const job = isJob(node)
+    const isSelected = selectedNode === node.label;
     return (
       <Link
         to={this.determineLink(node)}
@@ -77,11 +78,7 @@ class Node extends React.Component<NodeProps> {
               style={{ cursor: 'pointer' }}
               r={RADIUS}
               fill={runStateToNodeColor(job.latestRun)}
-              stroke={
-                selectedNode === node.label
-                  ? theme.palette.common.white
-                  : runStateToNodeColor(job.latestRun)
-              }
+              stroke={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
               strokeWidth={BORDER}
               cx={node.x}
               cy={node.y}
@@ -89,8 +86,8 @@ class Node extends React.Component<NodeProps> {
             <circle
               style={{ cursor: 'pointer' }}
               r={RADIUS - 2}
-              fill={runStateToNodeColor(job.latestRun)}
-              stroke={runStateToNodeColor(job.latestRun)}
+              fill={theme.palette.common.white}
+              stroke={theme.palette.common.white}
               strokeWidth={2}
               cx={node.x}
               cy={node.y}
@@ -102,7 +99,7 @@ class Node extends React.Component<NodeProps> {
               height={ICON_SIZE}
               x={node.x - ICON_SIZE / 2}
               y={node.y - ICON_SIZE / 2}
-              color={theme.palette.common.white}
+              color={runStateToNodeColor(job.latestRun)}
             />
           </g>
         ) : (
@@ -113,7 +110,7 @@ class Node extends React.Component<NodeProps> {
               y={node.y - RADIUS}
               fill={theme.palette.common.white}
               stroke={
-                selectedNode === node.label
+                isSelected
                   ? theme.palette.primary.main
                   : theme.palette.secondary.main
               }
@@ -139,11 +136,7 @@ class Node extends React.Component<NodeProps> {
               height={ICON_SIZE}
               x={node.x - ICON_SIZE / 2}
               y={node.y - ICON_SIZE / 2}
-              color={
-                selectedNode === node.label
-                  ? theme.palette.primary.main
-                  : theme.palette.secondary.main
-              }
+              color={theme.palette.secondary.main}
             />
           </g>
         )}

--- a/web/src/components/lineage/components/node/Node.tsx
+++ b/web/src/components/lineage/components/node/Node.tsx
@@ -16,6 +16,8 @@ import { faCog } from '@fortawesome/free-solid-svg-icons/faCog'
 import { faDatabase } from '@fortawesome/free-solid-svg-icons/faDatabase'
 import { setSelectedNode } from '../../../../store/actionCreators'
 import { theme } from '../../../../helpers/theme'
+import { Run } from '../../../../types/api'
+import { Nullable } from '../../../../types/util/Nullable'
 
 export type Vertex = {
   x: number
@@ -38,6 +40,17 @@ interface OwnProps {
 }
 
 type NodeProps = DispatchProps & OwnProps
+
+function runStateToNodeColor(run: Nullable<Run>) {
+  switch (run?.state) {
+    case 'RUNNING': return theme.palette.primary.main;
+    case 'COMPLETED': return theme.palette.primary.main;
+    case 'FAILED': return theme.palette.error.main;
+    case 'ABORTED': return theme.palette.primary.main;
+    default:
+      break;
+  }
+}
 
 class Node extends React.Component<NodeProps> {
   determineLink = (node: GraphNode<MqNode>) => {
@@ -62,11 +75,11 @@ class Node extends React.Component<NodeProps> {
             <circle
               style={{ cursor: 'pointer' }}
               r={RADIUS}
-              fill={theme.palette.common.white}
+              fill={runStateToNodeColor(job.latestRun)}
               stroke={
                 selectedNode === node.label
-                  ? theme.palette.primary.main
-                  : theme.palette.secondary.main
+                  ? theme.palette.common.white
+                  : runStateToNodeColor(job.latestRun)
               }
               strokeWidth={BORDER}
               cx={node.x}
@@ -75,8 +88,8 @@ class Node extends React.Component<NodeProps> {
             <circle
               style={{ cursor: 'pointer' }}
               r={RADIUS - 2}
-              fill={theme.palette.common.white}
-              stroke={theme.palette.common.white}
+              fill={runStateToNodeColor(job.latestRun)}
+              stroke={runStateToNodeColor(job.latestRun)}
               strokeWidth={2}
               cx={node.x}
               cy={node.y}
@@ -88,11 +101,7 @@ class Node extends React.Component<NodeProps> {
               height={ICON_SIZE}
               x={node.x - ICON_SIZE / 2}
               y={node.y - ICON_SIZE / 2}
-              color={
-                selectedNode === node.label
-                  ? theme.palette.primary.main
-                  : theme.palette.secondary.main
-              }
+              color={theme.palette.common.white}
             />
           </g>
         ) : (

--- a/web/src/components/sidenav/Sidenav.tsx
+++ b/web/src/components/sidenav/Sidenav.tsx
@@ -55,7 +55,7 @@ class Sidenav extends React.Component<SidenavProps> {
             <RouterLink to={'/'} className={classes.link}>
               <MqIconButton
                 id={'homeDrawerButton'}
-                title={'Jobs'}
+                title={'JOBS'}
                 active={this.props.location.pathname === '/'}
               >
                 <FontAwesomeIcon icon={faCogs} size={'2x'} />
@@ -64,7 +64,7 @@ class Sidenav extends React.Component<SidenavProps> {
             <RouterLink to={'/datasets'} className={classes.link}>
               <MqIconButton
                 id={'datasetsDrawerButton'}
-                title={'Datasets'}
+                title={'DATASETS'}
                 active={this.props.location.pathname === '/datasets'}
               >
                 <FontAwesomeIcon icon={faDatabase} size={'2x'} />

--- a/web/src/helpers/theme.ts
+++ b/web/src/helpers/theme.ts
@@ -32,6 +32,12 @@ export const theme = createTheme({
     error: {
       main: '#ee7b7b'
     },
+    warning: {
+      main: '#7D7D7D'
+    },
+    info: {
+      main: '#FECC00'
+    },
     background: {
       default: '#191f26'
     },

--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -88,33 +88,35 @@ class Datasets extends React.Component<DatasetsProps> {
                     </TableRow>
                   </TableHead>
                   <TableBody>
-                    {datasets.filter(dataset => !dataset.deleted).map(dataset => {
-                      return (
-                        <TableRow key={dataset.name}>
-                          <TableCell align='left'>
-                            <MqText
-                              link
-                              linkTo={`/lineage/${encodeNode(
-                                'DATASET',
-                                dataset.namespace,
-                                dataset.name
-                              )}`}
-                            >
-                              {dataset.name}
-                            </MqText>
-                          </TableCell>
-                          <TableCell align='left'>
-                            <MqText>{dataset.namespace}</MqText>
-                          </TableCell>
-                          <TableCell align='left'>
-                            <MqText>{dataset.sourceName}</MqText>
-                          </TableCell>
-                          <TableCell align='left'>
-                            <MqText>{formatUpdatedAt(dataset.updatedAt)}</MqText>
-                          </TableCell>
-                        </TableRow>
-                      )
-                    })}
+                    {datasets
+                      .filter(dataset => !dataset.deleted)
+                      .map(dataset => {
+                        return (
+                          <TableRow key={dataset.name}>
+                            <TableCell align='left'>
+                              <MqText
+                                link
+                                linkTo={`/lineage/${encodeNode(
+                                  'DATASET',
+                                  dataset.namespace,
+                                  dataset.name
+                                )}`}
+                              >
+                                {dataset.name}
+                              </MqText>
+                            </TableCell>
+                            <TableCell align='left'>
+                              <MqText>{dataset.namespace}</MqText>
+                            </TableCell>
+                            <TableCell align='left'>
+                              <MqText>{dataset.sourceName}</MqText>
+                            </TableCell>
+                            <TableCell align='left'>
+                              <MqText>{formatUpdatedAt(dataset.updatedAt)}</MqText>
+                            </TableCell>
+                          </TableRow>
+                        )
+                      })}
                   </TableBody>
                 </Table>
               </>

--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -34,7 +34,7 @@ interface DispatchProps {
 
 type DatasetsProps = WithStyles<typeof styles> & StateProps & DispatchProps
 
-const DATASET_COLUMNS = ['NAME', 'NAMESPACE', 'SOURCE', 'UPDATED']
+const DATASET_COLUMNS = ['NAME', 'NAMESPACE', 'SOURCE', 'UPDATED AT']
 
 class Datasets extends React.Component<DatasetsProps> {
   componentDidMount() {

--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -34,7 +34,7 @@ interface DispatchProps {
 
 type DatasetsProps = WithStyles<typeof styles> & StateProps & DispatchProps
 
-const DATASET_COLUMNS = ['Name', 'Namespace', 'Source', 'Updated At']
+const DATASET_COLUMNS = ['NAME', 'NAMESPACE', 'SOURCE', 'UPDATED']
 
 class Datasets extends React.Component<DatasetsProps> {
   componentDidMount() {
@@ -73,7 +73,7 @@ class Datasets extends React.Component<DatasetsProps> {
             ) : (
               <>
                 <Box p={2}>
-                  <MqText heading>Datasets</MqText>
+                  <MqText heading>DATASETS</MqText>
                 </Box>
                 <Table size='small'>
                   <TableHead>

--- a/web/src/routes/jobs/Jobs.tsx
+++ b/web/src/routes/jobs/Jobs.tsx
@@ -31,7 +31,7 @@ interface DispatchProps {
 
 type JobsProps = StateProps & DispatchProps
 
-const JOB_COLUMNS = ['NAME', 'NAMESPACE', 'UPDATED', 'LATEST RUN DURATION']
+const JOB_COLUMNS = ['NAME', 'NAMESPACE', 'UPDATED AT', 'LATEST RUN DURATION']
 
 class Jobs extends React.Component<JobsProps> {
   componentDidMount() {

--- a/web/src/routes/jobs/Jobs.tsx
+++ b/web/src/routes/jobs/Jobs.tsx
@@ -31,7 +31,7 @@ interface DispatchProps {
 
 type JobsProps = StateProps & DispatchProps
 
-const JOB_COLUMNS = ['Name', 'Namespace', 'Updated At', 'Last Runtime']
+const JOB_COLUMNS = ['NAME', 'NAMESPACE', 'UPDATED', 'LATEST RUN DURATION']
 
 class Jobs extends React.Component<JobsProps> {
   componentDidMount() {
@@ -70,7 +70,7 @@ class Jobs extends React.Component<JobsProps> {
             ) : (
               <>
                 <Box p={2}>
-                  <MqText heading>Jobs</MqText>
+                  <MqText heading>JOBS</MqText>
                 </Box>
                 <Table size='small'>
                   <TableHead>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -141,7 +141,7 @@ export interface Run {
   facets: object
 }
 
-export type RunState = 'NEW' | 'COMPLETED' | 'FAILED' | 'ABORTED'
+export type RunState = 'NEW' | 'RUNNING' | 'COMPLETED' | 'FAILED' | 'ABORTED'
 
 export interface SearchResult {
   name: string


### PR DESCRIPTION
### Problem

To view the current run state of a job, you have to select the job node in the lineage graph, then navigate the run info tab.

### Solution

This PR fills job nodes in the lineage graph with the latest run state; this PR also makes some minor changes to column names used to display dataset and job metadata.

<img width="1673" alt="Screen Shot 2022-09-28 at 3 44 45 PM" src="https://user-images.githubusercontent.com/1553185/192901688-b01dcf7f-9ca2-4a0c-bfbb-9486da18d160.png">

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)