### PR TITLE
cli: add commend to generate graph-based runs

### DIFF
--- a/api/src/main/java/marquez/MarquezApp.java
+++ b/api/src/main/java/marquez/MarquezApp.java
@@ -27,6 +27,7 @@ import javax.sql.DataSource;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import marquez.api.filter.JobRedirectFilter;
+import marquez.cli.GraphCommand;
 import marquez.cli.MetadataCommand;
 import marquez.cli.SeedCommand;
 import marquez.common.Utils;
@@ -79,6 +80,7 @@ public final class MarquezApp extends Application<MarquezConfig> {
 
     // Add CLI commands
     bootstrap.addCommand(new MetadataCommand());
+    bootstrap.addCommand(new GraphCommand());
     bootstrap.addCommand(new SeedCommand());
 
     bootstrap.getObjectMapper().disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);

--- a/api/src/main/java/marquez/cli/GraphCommand.java
+++ b/api/src/main/java/marquez/cli/GraphCommand.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.cli;
+
+import io.dropwizard.cli.Command;
+import io.dropwizard.setup.Bootstrap;
+import java.util.List;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+
+/** A command to generate graph that can be used as an event template for load testing tool - k6. */
+@Slf4j
+public final class GraphCommand extends Command {
+
+  /* Default output. */
+  private static final String DEFAULT_OUTPUT = "metadata.json";
+
+  /* Args for graph command. */
+  private static final String CMD_ARG_GRAPH_DATASETS = "datasets";
+  private static final String CMD_ARG_GRAPH_LEVELS = "levels";
+  private static final String CMD_ARG_GRAPH_FIRST_LEVEL = "first-level";
+  private static final String CMD_ARG_GRAPH_MAX_INPUTS = "max-inputs";
+  private static final String CMD_ARG_GRAPH_OUTPUT = "output";
+
+  /* Define metadata command. */
+  public GraphCommand() {
+    super("graph", "generate random metadata graph using the OpenLineage standard");
+  }
+
+  /* Configure metadata command. */
+  @Override
+  public void configure(@NonNull Subparser subparser) {
+    subparser
+        .addArgument("--datasets")
+        .dest("datasets")
+        .type(Integer.class)
+        .required(false)
+        .setDefault(10)
+        .help("how many datasets should graph contain");
+    subparser
+        .addArgument("--levels")
+        .dest("levels")
+        .type(Integer.class)
+        .required(false)
+        .setDefault(5)
+        .help("how many levels should graph contain");
+    subparser
+        .addArgument("--first-level")
+        .dest("first-level")
+        .type(Integer.class)
+        .required(false)
+        .setDefault(0)
+        .help("Set size of first level. If 0, it will be random.");
+    subparser
+        .addArgument("--max-inputs")
+        .dest("max-inputs")
+        .type(Integer.class)
+        .required(false)
+        .setDefault(7)
+        .help("set maximum amount of input datasets any job should contain");
+    subparser
+        .addArgument("-o", "--output")
+        .dest("output")
+        .type(String.class)
+        .required(false)
+        .help("the output metadata file")
+        .setDefault(DEFAULT_OUTPUT);
+  }
+
+  @Override
+  public void run(@NonNull Bootstrap<?> bootstrap, @NonNull Namespace namespace) {
+    List<JobTemplate> graph;
+
+    final int datasets = namespace.getInt(CMD_ARG_GRAPH_DATASETS);
+    final int levels = namespace.getInt(CMD_ARG_GRAPH_LEVELS);
+    final int firstLevel = namespace.getInt(CMD_ARG_GRAPH_FIRST_LEVEL);
+    final int maxInputCount = namespace.getInt(CMD_ARG_GRAPH_MAX_INPUTS);
+
+    if (levels <= 2) {
+      System.out.format("Level count needs to be higher than 2, got '%d'\n", levels);
+    }
+
+    LayeredDAGGenerator graphGenerator =
+        new LayeredDAGGenerator(datasets, levels, firstLevel, maxInputCount);
+    graph = graphGenerator.generateGraph();
+
+    final String output = namespace.getString(CMD_ARG_GRAPH_OUTPUT);
+    MetadataUtils.writeOlEvents(graph, output);
+  }
+}

--- a/api/src/main/java/marquez/cli/JobTemplate.java
+++ b/api/src/main/java/marquez/cli/JobTemplate.java
@@ -1,0 +1,26 @@
+package marquez.cli;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public record JobTemplate(
+    List<Integer> inputs, List<Integer> outputs, String jobName, Optional<ParentRun> parentJob) {
+
+  List<String> getInputDatasetNames() {
+    return inputs.stream().map(input -> String.format("dataset%d", input)).toList();
+  }
+
+  List<String> getOutputDatasetNames() {
+    Optional<String> x = Optional.of("x");
+
+    x.orElse(x.get());
+    return outputs.stream().map(output -> String.format("dataset%d", output)).toList();
+  }
+
+  String getJobName() {
+    return String.format("job%s", jobName);
+  }
+
+  public record ParentRun(UUID runId, String jobName, String jobNamespace) {}
+}

--- a/api/src/main/java/marquez/cli/LayeredDAGGenerator.java
+++ b/api/src/main/java/marquez/cli/LayeredDAGGenerator.java
@@ -1,0 +1,89 @@
+package marquez.cli;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.AllArgsConstructor;
+
+/**
+ * This class generates DAGs in a "layered" structure. First, it splits graph nodes into randomly
+ * sized layers of monotonically growing node numbers. That means that node N will always be in
+ * lower layer or the same as every node with number greater than N. Next, it creates jobs for each
+ * node element that are in layers higher than 1. Job consists of one output node and up to
+ * maxJobInputCount input nodes. The input nodes are chosen by randomly selecting numbers in layers
+ * lower than current layer.
+ */
+@AllArgsConstructor
+public class LayeredDAGGenerator {
+  private final int nodeCount;
+  private final int levelCount;
+  private final int firstLevelSize;
+  private final int maxJobInputCount;
+  private final Random random = new Random();
+
+  public List<JobTemplate> generateGraph() {
+    List<JobTemplate> jobs = new ArrayList<>();
+
+    List<List<Integer>> tiers = new ArrayList<>();
+    if (firstLevelSize > 0) {
+      tiers.add(IntStream.rangeClosed(1, firstLevelSize).boxed().toList());
+      tiers.addAll(
+          splitListIntoRandomChunks(
+              IntStream.rangeClosed(firstLevelSize + 1, nodeCount)
+                  .boxed()
+                  .collect(Collectors.toList()),
+              levelCount - 1));
+    } else {
+      tiers =
+          splitListIntoRandomChunks(
+              IntStream.rangeClosed(1, nodeCount).boxed().collect(Collectors.toList()), levelCount);
+    }
+
+    int jobCount = 0;
+    int previousLevelsSize = tiers.get(0).size();
+    for (int i = 1; i < levelCount; i++) {
+      System.out.format("\nLevel %d: ", i);
+      List<Integer> levelDatasets = tiers.get(i);
+      for (Integer levelDataset : levelDatasets) {
+        System.out.printf("%s ", levelDataset);
+        Set<Integer> inputDatasets = new TreeSet<>();
+
+        int inputCount = Math.max(2, (int) (random.nextGaussian() * maxJobInputCount));
+        for (int k = 0; k < inputCount; k++) {
+          inputDatasets.add(random.nextInt(1, previousLevelsSize + 1));
+        }
+        jobs.add(
+            new JobTemplate(
+                inputDatasets.stream().toList(),
+                Collections.singletonList(levelDataset),
+                String.format("job%d", jobCount),
+                Optional.empty()));
+        jobCount++;
+      }
+      previousLevelsSize += tiers.get(i).size();
+    }
+    return jobs;
+  }
+
+  private List<List<Integer>> splitListIntoRandomChunks(List<Integer> nodes, int chunks) {
+    if (chunks == 0) {
+      return Collections.emptyList();
+    } else if (chunks == 1) {
+      return List.of(nodes);
+    }
+
+    List<List<Integer>> splits = new ArrayList<>();
+    double avg = (double) nodes.size() / (double) chunks;
+    double rand = (1.0 + random.nextGaussian() / 3) * avg;
+    int index = Math.min(Math.max((int) rand, 1), nodes.size() - chunks);
+    splits.add(nodes.subList(0, index));
+    splits.addAll(splitListIntoRandomChunks(nodes.subList(index, nodes.size()), chunks - 1));
+    return splits;
+  }
+}

--- a/api/src/main/java/marquez/cli/MetadataUtils.java
+++ b/api/src/main/java/marquez/cli/MetadataUtils.java
@@ -1,0 +1,188 @@
+package marquez.cli;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
+import io.openlineage.client.OpenLineage;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URI;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import lombok.NonNull;
+import marquez.common.Utils;
+import marquez.common.models.FieldName;
+import marquez.common.models.NamespaceName;
+import marquez.common.models.RunId;
+
+public class MetadataUtils {
+  /* Used for event randomization. */
+  private static final Random RANDOM = new Random();
+  private static final ZoneId AMERICA_LOS_ANGELES = ZoneId.of("America/Los_Angeles");
+  private static final List<String> FIELD_TYPES = ImmutableList.of("VARCHAR", "TEXT", "INTEGER");
+
+  private static final String OL_NAMESPACE = newNamespaceName().getValue();
+  private static final OpenLineage OL =
+      new OpenLineage(
+          URI.create(
+              "https://github.com/MarquezProject/marquez/blob/main/api/src/main/java/marquez/cli/JobTemplateConverter.java"));
+
+  /**
+   * Returns a new {@link OpenLineage.Run} object. A {@code parent} run will be associated with
+   * {@code child} run if {@code hasParentRun} is {@code true}; otherwise, the {@code child} run
+   * will not have a {@code parent} run.
+   */
+  public static OpenLineage.Run newRun(final JobTemplate job) {
+    return OL.newRun(
+        newRunId().getValue(),
+        OL.newRunFacetsBuilder()
+            .parent(
+                job.parentJob().isPresent()
+                    ? OL.newParentRunFacetBuilder()
+                        .run(OL.newParentRunFacetRun(job.parentJob().get().runId()))
+                        .job(newParentJob(job.parentJob().get()))
+                        .build()
+                    : null)
+            .nominalTime(
+                OL.newNominalTimeRunFacetBuilder()
+                    .nominalStartTime(newNominalTime())
+                    .nominalEndTime(newNominalTime().plusHours(1))
+                    .build())
+            .build());
+  }
+
+  /** Returns a new {@link OpenLineage.ParentRunFacetRun} object. */
+  public static OpenLineage.ParentRunFacetRun newParentRun() {
+    return OL.newParentRunFacetRunBuilder().runId(newRunId().getValue()).build();
+  }
+
+  /** Returns a new {@link OpenLineage.ParentRunFacetJob} object. */
+  public static OpenLineage.ParentRunFacetJob newParentJob(JobTemplate.ParentRun parentRun) {
+    return OL.newParentRunFacetJobBuilder()
+        .namespace(parentRun.jobNamespace())
+        .name(parentRun.jobName())
+        .build();
+  }
+
+  /** Returns a new {@link OpenLineage.Job} object. */
+  public static OpenLineage.Job newJob(JobTemplate jobTemplate) {
+    return OL.newJobBuilder().namespace(OL_NAMESPACE).name(jobTemplate.getJobName()).build();
+  }
+
+  /** Returns new {@link OpenLineage.InputDataset} objects. */
+  public static List<OpenLineage.InputDataset> newInputs(
+      final List<String> inputDatasetNames,
+      List<OpenLineage.SchemaDatasetFacet> schemaDatasetFacets) {
+    return IntStream.range(0, inputDatasetNames.size())
+        .boxed()
+        .map(
+            i ->
+                OL.newInputDatasetBuilder()
+                    .namespace(OL_NAMESPACE)
+                    .name(inputDatasetNames.get(i))
+                    .facets(OL.newDatasetFacetsBuilder().schema(schemaDatasetFacets.get(i)).build())
+                    .build())
+        .collect(toImmutableList());
+  }
+
+  /** Returns new {@link OpenLineage.OutputDataset} objects. */
+  public static List<OpenLineage.OutputDataset> newOutputs(
+      final List<String> outputDatasetNames,
+      List<OpenLineage.SchemaDatasetFacet> schemaDatasetFacets) {
+    return IntStream.range(0, outputDatasetNames.size())
+        .boxed()
+        .map(
+            i ->
+                OL.newOutputDatasetBuilder()
+                    .namespace(OL_NAMESPACE)
+                    .name(outputDatasetNames.get(i))
+                    .facets(OL.newDatasetFacetsBuilder().schema(schemaDatasetFacets.get(i)).build())
+                    .build())
+        .collect(toImmutableList());
+  }
+
+  /** Returns a new {@link OpenLineage.SchemaDatasetFacet} object. */
+  public static OpenLineage.SchemaDatasetFacet newDatasetSchema(final int numOfFields) {
+    return OL.newSchemaDatasetFacetBuilder().fields(newFields(numOfFields)).build();
+  }
+
+  /** Returns new {@link OpenLineage.SchemaDatasetFacetFields} objects. */
+  public static List<OpenLineage.SchemaDatasetFacetFields> newFields(final int numOfFields) {
+    return Stream.generate(
+            () ->
+                OL.newSchemaDatasetFacetFieldsBuilder()
+                    .name(newFieldName().getValue())
+                    .type(newFieldType())
+                    .description(newDescription())
+                    .build())
+        .limit(numOfFields)
+        .collect(toImmutableList());
+  }
+
+  /** Returns a new {@link NamespaceName} object. */
+  public static NamespaceName newNamespaceName() {
+    return NamespaceName.of("namespace" + newId());
+  }
+
+  /** Returns a new {@link RunId} object. */
+  public static RunId newRunId() {
+    return RunId.of(UUID.randomUUID());
+  }
+
+  /** Returns a new {@link FieldName} object. */
+  public static FieldName newFieldName() {
+    return FieldName.of("field" + newId());
+  }
+
+  /** Returns a new field {@code type}. */
+  public static String newFieldType() {
+    return FIELD_TYPES.get(RANDOM.nextInt(FIELD_TYPES.size()));
+  }
+
+  /** Returns a new {@code description}. */
+  public static String newDescription() {
+    return "description" + newId();
+  }
+
+  /** Returns a new {@code nominal} time. */
+  public static ZonedDateTime newNominalTime() {
+    return Instant.now().atZone(AMERICA_LOS_ANGELES);
+  }
+
+  /** Returns a new {@code event} time. */
+  public static ZonedDateTime newEventTime() {
+    return Instant.now().atZone(AMERICA_LOS_ANGELES);
+  }
+
+  public static int newId() {
+    return RANDOM.nextInt(Integer.MAX_VALUE - 1);
+  }
+
+  /** Write {@link OpenLineage.RunEvent}s to the specified {@code output}. */
+  public static void writeOlEvents(@NonNull final List<?> olEvents, @NonNull final String output) {
+    System.out.format("Writing '%d' events to: '%s'\n", olEvents.size(), output);
+    FileWriter fileWriter;
+    PrintWriter printWriter = null;
+    try {
+      fileWriter = new FileWriter(output);
+      printWriter = new PrintWriter(fileWriter);
+      printWriter.write(Utils.toJson(olEvents));
+    } catch (IOException e) {
+      e.printStackTrace();
+    } finally {
+      if (printWriter != null) {
+        printWriter.close();
+      }
+    }
+  }
+
+  /** A container class for run info. */
+  record RunEvents(@NonNull OpenLineage.RunEvent start, @NonNull OpenLineage.RunEvent complete) {}
+}

--- a/docker/load-test.sh
+++ b/docker/load-test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Copyright 2018-2022 contributors to the Marquez project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Usage: $ ./load-test.sh
+
+set -e
+
+
+usage() {
+  echo "usage: ./$(basename -- ${0}) [--vus AMOUNT] [--docker]"
+  echo "A script used to load test Marquez"
+  echo
+  title "EXAMPLES:"
+  echo "  # Run load tests with 20 processes"
+  echo "  $ ./load-test.sh --vus 20"
+  echo
+  title "ARGUMENTS:"
+  echo "  -v, --vus           amount of load testing processes (default: 10)"
+  echo
+  title "FLAGS:"
+  echo "  -d, --docker        run Marquez in docker"
+  exit 1
+}
+
+VUS=10
+LEVELS=3
+
+while [ $# -gt 0 ]; do
+  case $1 in
+    -v|'--vus')
+       shift
+       VUS="${1}"
+       ;;
+    -d|'--docker')
+       DOCKER='true'
+       ;;
+    -h|'--help')
+       usage
+       exit 0
+       ;;
+    *) usage
+       exit 1
+       ;;
+  esac
+  shift
+done
+
+DATASETS=$(expr $VUS + $LEVELS)
+
+./gradlew clean shadowJar
+
+java -jar api/build/libs/*.jar graph --levels 3 --datasets $DATASETS --first-level 3 --output graph.json
+
+if [[ "${DOCKER}" = "true" ]]; then
+  ./docker/up.sh --build --detach
+fi
+
+sleep 10
+
+k6 run --vus $VUS --duration 30s load.js
+
+if [[ "${DOCKER}" = "true" ]]; then
+  docker-compose stop
+fi

--- a/load.js
+++ b/load.js
@@ -1,0 +1,132 @@
+import { SharedArray } from 'k6/data';
+import http from 'k6/http';
+import { check } from 'k6';
+import { Rate } from 'k6/metrics';
+import { uuidv4, randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
+import exec from 'k6/execution';
+
+export const errorRate = new Rate('errors');
+
+const graph = new SharedArray('graph', function () {
+  return JSON.parse(open('./graph.json'));
+});
+
+let get_fields = function () {
+  return [{
+    "name": "field574654616",
+    "type": "VARCHAR",
+    "description": "description1901257432"
+  }, {
+    "name": "field1973758593",
+    "type": "TEXT",
+    "description": "description1919217995"
+  }, {
+    "name": "field898064800",
+    "type": "VARCHAR",
+    "description": "description1559432549"
+  }, {
+    "name": "field1206348422",
+    "type": "INTEGER",
+    "description": "description1112972360"
+  }]
+}
+
+let get_dataset = function (namespace, name) {
+  return {
+    "namespace": namespace,
+    "name": name,
+    "facets": {
+      "schema": {
+        "_producer": "https://github.com/MarquezProject/marquez/blob/main/api/src/main/java/marquez/cli/MetadataCommand.java",
+        "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/SchemaDatasetFacet.json#/$defs/SchemaDatasetFacet",
+        "fields": get_fields()
+      }
+    }
+  }
+}
+
+let get_event = function(job_template, run_id, inputs, outputs) {
+  let date = new Date();
+
+  let runFacets = {
+    "parent": {
+      "_producer": "https://github.com/MarquezProject/marquez/blob/main/api/src/main/java/marquez/cli/MetadataCommand.java",
+      "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/ParentRunFacet.json#/$defs/ParentRunFacet",
+      "run": {
+        "runId": "11cef0ea-c301-422e-90cf-cf2ba1bb45c1"
+      },
+      "job": {
+        "namespace": "namespace105136515",
+        "name": "job335691945"
+      }
+    },
+    "nominalTime": {
+      "_producer": "https://github.com/MarquezProject/marquez/blob/main/api/src/main/java/marquez/cli/MetadataCommand.java",
+      "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/NominalTimeRunFacet.json#/$defs/NominalTimeRunFacet",
+      "nominalStartTime": "2022-09-12T06:04:41.171378-07:00",
+      "nominalEndTime": "2022-09-12T07:04:41.171871-07:00"
+    }
+  }
+
+
+    return [{
+    "eventType": "START",
+    "eventTime": date.toISOString(),
+    "run": {
+      "runId": run_id,
+      "facets": runFacets
+    },
+    "job": {
+      "namespace": "namespace105136515",
+      "name": job_template.jobName
+    },
+    "inputs": inputs,
+    "outputs": outputs,
+    "producer": "https://github.com/MarquezProject/marquez/blob/main/api/src/main/java/marquez/cli/MetadataCommand.java",
+    "schemaURL": "https://openlineage.io/spec/1-0-3/OpenLineage.json#/$defs/RunEvent"
+  }, {
+    "eventType": "COMPLETE",
+    "eventTime": date.toISOString(),
+    "run": {
+      "runId": run_id,
+      "facets": runFacets
+    },
+    "job": {
+      "namespace": "namespace",
+      "name": job_template.jobName
+    },
+    "inputs": inputs,
+    "outputs": outputs,
+    "producer": "https://github.com/MarquezProject/marquez/blob/main/api/src/main/java/marquez/cli/MetadataCommand.java",
+    "schemaURL": "https://openlineage.io/spec/1-0-3/OpenLineage.json#/$defs/RunEvent"
+  }]
+}
+
+export default function () {
+  const url = 'http://localhost:5000/api/v1/lineage';
+  const params = {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  };
+
+  var job = graph[exec.vu.idInInstance-1];
+
+  let ol_events = get_event(
+      job,
+      uuidv4(),
+      [get_dataset(`namespace${exec.vu.idInInstance}`, `dataset${randomIntBetween(1, 10000000)}`)],
+      [get_dataset(`namespace${exec.vu.idInInstance}`, `dataset${randomIntBetween(1, 10000000)}`)]
+  );
+
+  // send start
+  check(http.post(url, JSON.stringify(ol_events[0]), params), {
+    'status is 201': (r) => r.status === 201,
+  }) || errorRate.add(1);
+
+  // send complete
+  check(http.post(url, JSON.stringify(ol_events[1]), params), {
+    'status is 201': (r) => r.status === 201,
+  }) || errorRate.add(1);
+
+}


### PR DESCRIPTION
This PR adds graph generation capabilities working with algorithm described below:

```
Generate DAGs in a "layered" structure. First, it split graph nodes into randomly
sized layers of monotonically growing node numbers. That means that node N will always be in
lower layer or the same as every node with number greater than N. Next, create jobs for each
node element that are in layers higher than 1. Job consists of one output node and up to
maxJobInputCount input nodes. The input nodes are chosen by randomly selecting numbers in layers
lower than current layer.
```

Load testing tool uses that structure later to generate job runs using `k6` load testing tool. 

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>