### PR TITLE
include column lineage in dataset resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Implemented dataset symlink feature which allows providing multiple names for a dataset and adds edges to lineage graph based on symlinks [`#2066`](https://github.com/MarquezProject/marquez/pull/2066) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
 * Store column lineage facets in separate table [`#2096`](https://github.com/MarquezProject/marquez/pull/2096) [@mzareba382](https://github.com/mzareba382) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
 * Lineage graph endpoint for column lineage [`#2124`](https://github.com/MarquezProject/marquez/pull/2124) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+* Enrich returned dataset resource with column lineage information [`#2113`](https://github.com/MarquezProject/marquez/pull/2113) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
 
 ### Fixed
 * Add support for `parentRun` facet as reported by older Airflow OpenLineage versions [@collado-mike](https://github.com/collado-mike)

--- a/api/src/main/java/marquez/api/DatasetResource.java
+++ b/api/src/main/java/marquez/api/DatasetResource.java
@@ -12,6 +12,7 @@ import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.ResponseMetered;
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import javax.validation.Valid;
@@ -85,10 +86,11 @@ public class DatasetResource extends BaseResource {
       @PathParam("dataset") DatasetName datasetName) {
     throwIfNotExists(namespaceName);
 
-    final Dataset dataset =
+    Dataset dataset =
         datasetService
             .findWithTags(namespaceName.getValue(), datasetName.getValue())
             .orElseThrow(() -> new DatasetNotFoundException(datasetName));
+    columnLineageService.enrichWithColumnLineage(Arrays.asList(dataset));
     return Response.ok(dataset).build();
   }
 
@@ -147,6 +149,7 @@ public class DatasetResource extends BaseResource {
 
     final List<Dataset> datasets =
         datasetService.findAllWithTags(namespaceName.getValue(), limit, offset);
+    columnLineageService.enrichWithColumnLineage(datasets);
     final int totalCount = datasetService.countFor(namespaceName.getValue());
     return Response.ok(new ResultsPage<>("datasets", datasets, totalCount)).build();
   }

--- a/api/src/main/java/marquez/db/DatasetFieldDao.java
+++ b/api/src/main/java/marquez/db/DatasetFieldDao.java
@@ -34,11 +34,14 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 @RegisterRowMapper(FieldDataMapper.class)
 public interface DatasetFieldDao extends BaseDao {
   @SqlQuery(
-      "SELECT EXISTS ("
-          + "SELECT 1 FROM dataset_fields AS df "
-          + "INNER JOIN datasets_view AS d "
-          + "  ON d.uuid = df.dataset_uuid AND d.name = :datasetName AND d.namespace_name = :namespaceName "
-          + "WHERE df.name = :name)")
+      """
+          SELECT EXISTS (
+            SELECT 1 FROM dataset_fields AS df
+            INNER JOIN datasets_view AS d ON d.uuid = df.dataset_uuid
+            WHERE CAST((:namespaceName, :datasetName) AS DATASET_NAME) = ANY(d.dataset_symlinks)
+            AND df.name = :name
+          )
+      """)
   boolean exists(String namespaceName, String datasetName, String name);
 
   default Dataset updateTags(
@@ -97,20 +100,20 @@ public interface DatasetFieldDao extends BaseDao {
       """
           SELECT df.uuid
           FROM dataset_fields  df
-          INNER JOIN datasets_view AS d
-          ON d.uuid = df.dataset_uuid AND d.name = :datasetName AND d.namespace_name = :namespace
+          JOIN datasets_view AS d ON d.uuid = df.dataset_uuid
+          WHERE CAST((:namespaceName, :datasetName) AS DATASET_NAME) = ANY(d.dataset_symlinks)
       """)
-  List<UUID> findDatasetFieldsUuids(String namespace, String datasetName);
+  List<UUID> findDatasetFieldsUuids(String namespaceName, String datasetName);
 
   @SqlQuery(
       """
           SELECT df.uuid
           FROM dataset_fields  df
-          INNER JOIN datasets_view AS d
-          ON d.uuid = df.dataset_uuid AND d.name = :datasetName AND d.namespace_name = :namespace
-          WHERE df.name = :name
+          JOIN datasets_view AS d ON d.uuid = df.dataset_uuid
+          WHERE CAST((:namespaceName, :datasetName) AS DATASET_NAME) = ANY(d.dataset_symlinks)
+          AND df.name = :name
       """)
-  Optional<UUID> findUuid(String namespace, String datasetName, String name);
+  Optional<UUID> findUuid(String namespaceName, String datasetName, String name);
 
   @SqlQuery(
       "SELECT f.*, "

--- a/api/src/main/java/marquez/service/models/ColumnLineage.java
+++ b/api/src/main/java/marquez/service/models/ColumnLineage.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.service.models;
+
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@ToString
+@Builder
+@Getter
+public class ColumnLineage {
+  @NotNull private String name;
+  @NotNull private List<ColumnLineageInputField> inputFields;
+  @NotNull private String transformationDescription;
+  @NotNull private String transformationType;
+}

--- a/api/src/main/java/marquez/service/models/ColumnLineageInputField.java
+++ b/api/src/main/java/marquez/service/models/ColumnLineageInputField.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.service.models;
+
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@ToString
+@Getter
+@AllArgsConstructor
+public class ColumnLineageInputField {
+  @NotNull private String namespace;
+  @NotNull private String dataset;
+  @NotNull private String field;
+}

--- a/api/src/main/java/marquez/service/models/Dataset.java
+++ b/api/src/main/java/marquez/service/models/Dataset.java
@@ -53,6 +53,7 @@ public abstract class Dataset {
   @Nullable private final String lastLifecycleState;
   @Nullable private final String description;
   @Nullable private final UUID currentVersion;
+  @Getter @Setter @Nullable private List<ColumnLineage> columnLineage;
   @Getter ImmutableMap<String, Object> facets;
   @Getter private final boolean isDeleted;
 
@@ -70,6 +71,7 @@ public abstract class Dataset {
       @Nullable final String lastLifecycleState,
       @Nullable final String description,
       @Nullable final UUID currentVersion,
+      @Nullable final ImmutableList<ColumnLineage> columnLineage,
       @Nullable final ImmutableMap<String, Object> facets,
       boolean isDeleted) {
     this.id = id;
@@ -86,6 +88,7 @@ public abstract class Dataset {
     this.lastLifecycleState = lastLifecycleState;
     this.description = description;
     this.currentVersion = currentVersion;
+    this.columnLineage = columnLineage;
     this.facets = (facets == null) ? ImmutableMap.of() : facets;
     this.isDeleted = isDeleted;
   }

--- a/api/src/main/java/marquez/service/models/DbTable.java
+++ b/api/src/main/java/marquez/service/models/DbTable.java
@@ -53,6 +53,7 @@ public final class DbTable extends Dataset {
         lastLifecycleState,
         description,
         currentVersion,
+        null,
         facets,
         isDeleted);
   }

--- a/api/src/main/java/marquez/service/models/Stream.java
+++ b/api/src/main/java/marquez/service/models/Stream.java
@@ -59,6 +59,7 @@ public final class Stream extends Dataset {
         lastLifecycleState,
         description,
         currentVersion,
+        null,
         facets,
         isDeleted);
     this.schemaLocation = schemaLocation;

--- a/api/src/test/java/marquez/OpenLineageIntegrationTest.java
+++ b/api/src/test/java/marquez/OpenLineageIntegrationTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import marquez.api.JdbiUtils;
 import marquez.client.MarquezClient;
 import marquez.client.models.Dataset;
 import marquez.client.models.DatasetVersion;
@@ -84,23 +85,8 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
 
   @AfterEach
   public void tearDown() {
-    Jdbi.create(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())
-        .withHandle(
-            handle -> {
-              handle.execute("DELETE FROM lineage_events");
-              handle.execute("DELETE FROM runs_input_mapping");
-              handle.execute("DELETE FROM dataset_versions_field_mapping");
-              handle.execute("DELETE FROM stream_versions");
-              handle.execute("DELETE FROM dataset_versions");
-              handle.execute("UPDATE runs SET start_run_state_uuid=NULL, end_run_state_uuid=NULL");
-              handle.execute("DELETE FROM run_states");
-              handle.execute("DELETE FROM runs");
-              handle.execute("DELETE FROM run_args");
-              handle.execute("DELETE FROM job_versions_io_mapping");
-              handle.execute("DELETE FROM job_versions");
-              handle.execute("DELETE FROM jobs");
-              return null;
-            });
+    JdbiUtils.cleanDatabase(
+        Jdbi.create(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword()));
   }
 
   @Test

--- a/api/src/test/java/marquez/api/JdbiUtils.java
+++ b/api/src/test/java/marquez/api/JdbiUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.api;
+
+import org.jdbi.v3.core.Jdbi;
+
+public class JdbiUtils {
+
+  public static void cleanDatabase(Jdbi jdbi) {
+    jdbi.inTransaction(
+        handle -> {
+          handle.execute("DELETE FROM lineage_events");
+          handle.execute("DELETE FROM runs_input_mapping");
+          handle.execute("DELETE FROM dataset_versions_field_mapping");
+          handle.execute("DELETE FROM stream_versions");
+          handle.execute("DELETE FROM column_lineage");
+          handle.execute("DELETE FROM dataset_versions");
+          handle.execute("DELETE FROM dataset_symlinks");
+          handle.execute("UPDATE runs SET start_run_state_uuid=NULL, end_run_state_uuid=NULL");
+          handle.execute("DELETE FROM datasets_tag_mapping");
+          handle.execute("DELETE FROM run_states");
+          handle.execute("DELETE FROM runs");
+          handle.execute("DELETE FROM run_args");
+          handle.execute("DELETE FROM job_versions_io_mapping");
+          handle.execute("DELETE FROM job_versions");
+          handle.execute("DELETE FROM jobs");
+          handle.execute("DELETE FROM dataset_fields_tag_mapping");
+          handle.execute("DELETE FROM dataset_fields");
+          handle.execute("DELETE FROM datasets");
+          handle.execute("DELETE FROM sources");
+          handle.execute("DELETE FROM namespace_ownerships");
+          handle.execute("DELETE FROM namespaces");
+          return null;
+        });
+  }
+}

--- a/api/src/test/java/marquez/common/api/JobResourceIntegrationTest.java
+++ b/api/src/test/java/marquez/common/api/JobResourceIntegrationTest.java
@@ -12,6 +12,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.UUID;
 import marquez.BaseIntegrationTest;
+import marquez.api.JdbiUtils;
 import marquez.client.MarquezHttpException;
 import marquez.client.models.DbTableMeta;
 import marquez.client.models.Job;
@@ -43,22 +44,7 @@ public class JobResourceIntegrationTest extends BaseIntegrationTest {
 
   @AfterEach
   public void tearDown(Jdbi jdbi) {
-    jdbi.inTransaction(
-        handle -> {
-          handle.execute("DELETE FROM lineage_events");
-          handle.execute("DELETE FROM runs_input_mapping");
-          handle.execute("DELETE FROM dataset_versions_field_mapping");
-          handle.execute("DELETE FROM stream_versions");
-          handle.execute("DELETE FROM dataset_versions");
-          handle.execute("UPDATE runs SET start_run_state_uuid=NULL, end_run_state_uuid=NULL");
-          handle.execute("DELETE FROM run_states");
-          handle.execute("DELETE FROM runs");
-          handle.execute("DELETE FROM run_args");
-          handle.execute("DELETE FROM job_versions_io_mapping");
-          handle.execute("DELETE FROM job_versions");
-          handle.execute("DELETE FROM jobs");
-          return null;
-        });
+    JdbiUtils.cleanDatabase(jdbi);
   }
 
   @Test

--- a/api/src/test/java/marquez/db/ColumnLineageTestUtils.java
+++ b/api/src/test/java/marquez/db/ColumnLineageTestUtils.java
@@ -10,35 +10,14 @@ import static marquez.db.LineageTestUtils.SCHEMA_URL;
 
 import java.util.Arrays;
 import java.util.Collections;
+import marquez.api.JdbiUtils;
 import marquez.service.models.LineageEvent;
 import org.jdbi.v3.core.Jdbi;
 
 public class ColumnLineageTestUtils {
 
   public static void tearDown(Jdbi jdbi) {
-    jdbi.inTransaction(
-        handle -> {
-          handle.execute("DELETE FROM column_lineage");
-          handle.execute("DELETE FROM lineage_events");
-          handle.execute("DELETE FROM runs_input_mapping");
-          handle.execute("DELETE FROM datasets_tag_mapping");
-          handle.execute("DELETE FROM dataset_versions_field_mapping");
-          handle.execute("DELETE FROM dataset_versions");
-          handle.execute("UPDATE runs SET start_run_state_uuid=NULL, end_run_state_uuid=NULL");
-          handle.execute("DELETE FROM run_states");
-          handle.execute("DELETE FROM runs");
-          handle.execute("DELETE FROM run_args");
-          handle.execute("DELETE FROM job_versions_io_mapping");
-          handle.execute("DELETE FROM job_versions");
-          handle.execute("DELETE FROM jobs");
-          handle.execute("DELETE FROM dataset_fields_tag_mapping");
-          handle.execute("DELETE FROM dataset_fields");
-          handle.execute("DELETE FROM datasets");
-          handle.execute("DELETE FROM sources");
-          handle.execute("DELETE FROM dataset_symlinks");
-          handle.execute("DELETE FROM namespaces");
-          return null;
-        });
+    JdbiUtils.cleanDatabase(jdbi);
   }
 
   // dataset_A (col_a, col_b)
@@ -100,6 +79,9 @@ public class ColumnLineageTestUtils {
         "namespace",
         "dataset_c",
         LineageEvent.DatasetFacets.builder()
+            .dataSource(
+                new LineageEvent.DatasourceDatasetFacet(
+                    PRODUCER_URL, SCHEMA_URL, "the source", "http://thesource.com"))
             .schema(
                 new LineageEvent.SchemaDatasetFacet(
                     PRODUCER_URL,

--- a/api/src/test/java/marquez/db/DatasetDaoTest.java
+++ b/api/src/test/java/marquez/db/DatasetDaoTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.Getter;
+import marquez.api.JdbiUtils;
 import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
 import marquez.service.models.LineageEvent;
 import marquez.service.models.LineageEvent.Dataset;
@@ -63,29 +64,7 @@ class DatasetDaoTest {
 
   @AfterEach
   public void tearDown(Jdbi jdbi) {
-    jdbi.inTransaction(
-        handle -> {
-          handle.execute("DELETE FROM lineage_events");
-          handle.execute("DELETE FROM runs_input_mapping");
-          handle.execute("DELETE FROM dataset_versions_field_mapping");
-          handle.execute("DELETE FROM stream_versions");
-          handle.execute("DELETE FROM dataset_versions");
-          handle.execute("DELETE FROM dataset_symlinks");
-          handle.execute("UPDATE runs SET start_run_state_uuid=NULL, end_run_state_uuid=NULL");
-          handle.execute("DELETE FROM run_states");
-          handle.execute("DELETE FROM runs");
-          handle.execute("DELETE FROM run_args");
-          handle.execute("DELETE FROM job_versions_io_mapping");
-          handle.execute("DELETE FROM job_versions");
-          handle.execute("DELETE FROM jobs");
-          handle.execute("DELETE FROM dataset_fields_tag_mapping");
-          handle.execute("DELETE FROM dataset_fields");
-          handle.execute("DELETE FROM datasets_tag_mapping");
-          handle.execute("DELETE FROM datasets");
-          handle.execute("DELETE FROM sources");
-          handle.execute("DELETE FROM namespaces");
-          return null;
-        });
+    JdbiUtils.cleanDatabase(jdbi);
   }
 
   @Test

--- a/api/src/test/java/marquez/db/LineageDaoTest.java
+++ b/api/src/test/java/marquez/db/LineageDaoTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import marquez.api.JdbiUtils;
 import marquez.common.models.JobType;
 import marquez.db.LineageTestUtils.DatasetConsumerJob;
 import marquez.db.LineageTestUtils.JobLineage;
@@ -79,27 +80,7 @@ public class LineageDaoTest {
 
   @AfterEach
   public void tearDown(Jdbi jdbi) {
-    jdbi.inTransaction(
-        handle -> {
-          handle.execute("DELETE FROM lineage_events");
-          handle.execute("DELETE FROM runs_input_mapping");
-          handle.execute("DELETE FROM dataset_versions_field_mapping");
-          handle.execute("DELETE FROM dataset_versions");
-          handle.execute("DELETE FROM dataset_symlinks");
-          handle.execute("UPDATE runs SET start_run_state_uuid=NULL, end_run_state_uuid=NULL");
-          handle.execute("DELETE FROM run_states");
-          handle.execute("DELETE FROM runs");
-          handle.execute("DELETE FROM run_args");
-          handle.execute("DELETE FROM job_versions_io_mapping");
-          handle.execute("DELETE FROM job_versions");
-          handle.execute("DELETE FROM jobs");
-          handle.execute("DELETE FROM dataset_fields_tag_mapping");
-          handle.execute("DELETE FROM dataset_fields");
-          handle.execute("DELETE FROM datasets");
-          handle.execute("DELETE FROM sources");
-          handle.execute("DELETE FROM namespaces");
-          return null;
-        });
+    JdbiUtils.cleanDatabase(jdbi);
   }
 
   @Test

--- a/api/src/test/java/marquez/db/RunDaoTest.java
+++ b/api/src/test/java/marquez/db/RunDaoTest.java
@@ -22,6 +22,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import marquez.api.JdbiUtils;
 import marquez.common.models.DatasetId;
 import marquez.common.models.DatasetVersionId;
 import marquez.common.models.NamespaceName;
@@ -62,28 +63,7 @@ class RunDaoTest {
 
   @AfterEach
   public void tearDown(Jdbi jdbi) {
-    jdbi.inTransaction(
-        handle -> {
-          handle.execute("DELETE FROM lineage_events");
-          handle.execute("DELETE FROM runs_input_mapping");
-          handle.execute("DELETE FROM datasets_tag_mapping");
-          handle.execute("DELETE FROM dataset_versions_field_mapping");
-          handle.execute("DELETE FROM dataset_versions");
-          handle.execute("DELETE FROM dataset_symlinks");
-          handle.execute("UPDATE runs SET start_run_state_uuid=NULL, end_run_state_uuid=NULL");
-          handle.execute("DELETE FROM run_states");
-          handle.execute("DELETE FROM runs");
-          handle.execute("DELETE FROM run_args");
-          handle.execute("DELETE FROM job_versions_io_mapping");
-          handle.execute("DELETE FROM job_versions");
-          handle.execute("DELETE FROM jobs");
-          handle.execute("DELETE FROM dataset_fields_tag_mapping");
-          handle.execute("DELETE FROM dataset_fields");
-          handle.execute("DELETE FROM datasets");
-          handle.execute("DELETE FROM sources");
-          handle.execute("DELETE FROM namespaces");
-          return null;
-        });
+    JdbiUtils.cleanDatabase(jdbi);
   }
 
   @Test

--- a/api/src/test/java/marquez/service/LineageServiceTest.java
+++ b/api/src/test/java/marquez/service/LineageServiceTest.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import marquez.api.JdbiUtils;
 import marquez.common.models.DatasetName;
 import marquez.common.models.DatasetVersionId;
 import marquez.common.models.JobName;
@@ -81,28 +82,7 @@ public class LineageServiceTest {
 
   @AfterEach
   public void tearDown(Jdbi jdbi) {
-    jdbi.inTransaction(
-        handle -> {
-          handle.execute("DELETE FROM lineage_events");
-          handle.execute("DELETE FROM runs_input_mapping");
-          handle.execute("DELETE FROM dataset_versions_field_mapping");
-          handle.execute("DELETE FROM stream_versions");
-          handle.execute("DELETE FROM dataset_versions");
-          handle.execute("DELETE FROM dataset_symlinks");
-          handle.execute("UPDATE runs SET start_run_state_uuid=NULL, end_run_state_uuid=NULL");
-          handle.execute("DELETE FROM run_states");
-          handle.execute("DELETE FROM runs");
-          handle.execute("DELETE FROM run_args");
-          handle.execute("DELETE FROM job_versions_io_mapping");
-          handle.execute("DELETE FROM job_versions");
-          handle.execute("DELETE FROM jobs");
-          handle.execute("DELETE FROM dataset_fields_tag_mapping");
-          handle.execute("DELETE FROM dataset_fields");
-          handle.execute("DELETE FROM datasets");
-          handle.execute("DELETE FROM sources");
-          handle.execute("DELETE FROM namespaces");
-          return null;
-        });
+    JdbiUtils.cleanDatabase(jdbi);
   }
 
   @Test

--- a/clients/java/src/main/java/marquez/client/models/ColumnLineage.java
+++ b/clients/java/src/main/java/marquez/client/models/ColumnLineage.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.client.models;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@ToString
+@Builder
+@Getter
+public class ColumnLineage {
+  @NonNull private String name;
+  @NonNull private List<ColumnLineageInputField> inputFields;
+  @NonNull private String transformationDescription;
+  @NonNull private String transformationType;
+}

--- a/clients/java/src/main/java/marquez/client/models/ColumnLineageInputField.java
+++ b/clients/java/src/main/java/marquez/client/models/ColumnLineageInputField.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.client.models;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@ToString
+@Getter
+@AllArgsConstructor
+public class ColumnLineageInputField {
+  @NonNull private String namespace;
+  @NonNull private String dataset;
+  @NonNull private String field;
+}

--- a/clients/java/src/main/java/marquez/client/models/Dataset.java
+++ b/clients/java/src/main/java/marquez/client/models/Dataset.java
@@ -47,6 +47,7 @@ public abstract class Dataset {
   @Getter @NonNull private final Set<String> tags;
   @Nullable private final Instant lastModifiedAt;
   @Nullable private final String description;
+  @Getter @Nullable private List<ColumnLineage> columnLineage;
   @Getter private final Map<String, Object> facets;
   @Nullable private final UUID currentVersion;
 
@@ -63,6 +64,7 @@ public abstract class Dataset {
       @Nullable final Set<String> tags,
       @Nullable final Instant lastModifiedAt,
       @Nullable final String description,
+      @Nullable final List<ColumnLineage> columnLineage,
       @Nullable final Map<String, Object> facets,
       @Nullable final UUID currentVersion) {
     this.id = id;
@@ -77,6 +79,7 @@ public abstract class Dataset {
     this.tags = (tags == null) ? ImmutableSet.of() : ImmutableSet.copyOf(tags);
     this.lastModifiedAt = lastModifiedAt;
     this.description = description;
+    this.columnLineage = columnLineage;
     this.facets = (facets == null) ? ImmutableMap.of() : ImmutableMap.copyOf(facets);
     this.currentVersion = currentVersion;
   }

--- a/clients/java/src/main/java/marquez/client/models/DbTable.java
+++ b/clients/java/src/main/java/marquez/client/models/DbTable.java
@@ -31,6 +31,7 @@ public final class DbTable extends Dataset {
       @Nullable final Set<String> tags,
       @Nullable final Instant lastModifiedAt,
       @Nullable final String description,
+      @Nullable final List<ColumnLineage> columnLineage,
       @Nullable final Map<String, Object> facets,
       @Nullable final UUID currentVersion) {
     super(
@@ -46,6 +47,7 @@ public final class DbTable extends Dataset {
         tags,
         lastModifiedAt,
         description,
+        columnLineage,
         facets,
         currentVersion);
   }

--- a/clients/java/src/main/java/marquez/client/models/Stream.java
+++ b/clients/java/src/main/java/marquez/client/models/Stream.java
@@ -36,6 +36,7 @@ public final class Stream extends Dataset {
       @Nullable final Instant lastModifiedAt,
       @Nullable final URL schemaLocation,
       @Nullable final String description,
+      @Nullable final List<ColumnLineage> columnLineage,
       @Nullable final Map<String, Object> facets,
       @Nullable final UUID currentVersion) {
     super(
@@ -51,6 +52,7 @@ public final class Stream extends Dataset {
         tags,
         lastModifiedAt,
         description,
+        columnLineage,
         facets,
         currentVersion);
     this.schemaLocation = schemaLocation;

--- a/clients/java/src/test/java/marquez/client/MarquezClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezClientTest.java
@@ -146,6 +146,7 @@ public class MarquezClientTest {
           TAGS,
           null,
           DB_TABLE_DESCRIPTION,
+          null,
           DB_FACETS,
           CURRENT_VERSION);
   private static final DbTable DB_TABLE_MODIFIED =
@@ -161,6 +162,7 @@ public class MarquezClientTest {
           TAGS,
           LAST_MODIFIED_AT,
           DB_TABLE_DESCRIPTION,
+          null,
           DB_FACETS,
           CURRENT_VERSION);
 
@@ -197,6 +199,7 @@ public class MarquezClientTest {
           null,
           STREAM_SCHEMA_LOCATION,
           STREAM_DESCRIPTION,
+          null,
           DB_FACETS,
           CURRENT_VERSION);
   private static final Stream STREAM_MODIFIED =
@@ -213,6 +216,7 @@ public class MarquezClientTest {
           LAST_MODIFIED_AT,
           STREAM_SCHEMA_LOCATION,
           STREAM_DESCRIPTION,
+          null,
           DB_FACETS,
           CURRENT_VERSION);
 

--- a/clients/java/src/test/java/marquez/client/models/ModelGenerator.java
+++ b/clients/java/src/test/java/marquez/client/models/ModelGenerator.java
@@ -86,6 +86,7 @@ public final class ModelGenerator {
         newTagNames(2),
         null,
         newDescription(),
+        null,
         newDatasetFacets(2),
         currentVersion);
   }
@@ -134,6 +135,7 @@ public final class ModelGenerator {
         null,
         newSchemaLocation(),
         newDescription(),
+        null,
         newDatasetFacets(2),
         currentVersion);
   }


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Column lineage should be returned within `dataset` resource.

Closes: #2113

### Solution

 * create method in `ColumnLineageService` which enriches `Dataset` with column lineage information, 
 * use the method in `DatasetResource`.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)