### PR TITLE
Downstream column lineage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Store column lineage facets in separate table [`#2096`](https://github.com/MarquezProject/marquez/pull/2096) [@mzareba382](https://github.com/mzareba382) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
 * Lineage graph endpoint for column lineage [`#2124`](https://github.com/MarquezProject/marquez/pull/2124) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
 * Enrich returned dataset resource with column lineage information [`#2113`](https://github.com/MarquezProject/marquez/pull/2113) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+* Downstream column lineage [`#2159`](https://github.com/MarquezProject/marquez/pull/2159) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
 
 ### Fixed
 * Add support for `parentRun` facet as reported by older Airflow OpenLineage versions [@collado-mike](https://github.com/collado-mike)

--- a/api/src/main/java/marquez/api/ColumnLineageResource.java
+++ b/api/src/main/java/marquez/api/ColumnLineageResource.java
@@ -41,8 +41,10 @@ public class ColumnLineageResource extends BaseResource {
   @Produces(APPLICATION_JSON)
   public Response getLineage(
       @QueryParam("nodeId") @NotNull NodeId nodeId,
-      @QueryParam("depth") @DefaultValue(DEFAULT_DEPTH) int depth)
+      @QueryParam("depth") @DefaultValue(DEFAULT_DEPTH) int depth,
+      @QueryParam("withDownstream") @DefaultValue("false") boolean withDownstream)
       throws ExecutionException, InterruptedException {
-    return Response.ok(columnLineageService.lineage(nodeId, depth, Instant.now())).build();
+    return Response.ok(columnLineageService.lineage(nodeId, depth, withDownstream, Instant.now()))
+        .build();
   }
 }

--- a/api/src/main/java/marquez/service/ColumnLineageService.java
+++ b/api/src/main/java/marquez/service/ColumnLineageService.java
@@ -40,13 +40,12 @@ public class ColumnLineageService extends DelegatingDaos.DelegatingColumnLineage
     this.datasetFieldDao = datasetFieldDao;
   }
 
-  public Lineage lineage(NodeId nodeId, int depth, Instant createdAtUntil) {
+  public Lineage lineage(NodeId nodeId, int depth, boolean withDownstream, Instant createdAtUntil) {
     List<UUID> columnNodeUuids = getColumnNodeUuids(nodeId);
     if (columnNodeUuids.isEmpty()) {
       throw new NodeIdNotFoundException("Could not find node");
     }
-
-    return toLineage(getLineage(depth, columnNodeUuids, createdAtUntil));
+    return toLineage(getLineage(depth, columnNodeUuids, withDownstream, createdAtUntil));
   }
 
   private Lineage toLineage(Set<ColumnLineageNodeData> lineageNodeData) {

--- a/api/src/test/java/marquez/api/ColumnLineageResourceTest.java
+++ b/api/src/test/java/marquez/api/ColumnLineageResourceTest.java
@@ -7,7 +7,7 @@ package marquez.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,7 +40,7 @@ public class ColumnLineageResourceTest {
             ColumnLineageResourceTest.class.getResourceAsStream("/column_lineage/node.json"),
             new TypeReference<>() {});
     LINEAGE = new Lineage(ImmutableSortedSet.of(testNode));
-    when(lineageService.lineage(any(NodeId.class), anyInt(), any(Instant.class)))
+    when(lineageService.lineage(any(NodeId.class), eq(20), eq(false), any(Instant.class)))
         .thenReturn(LINEAGE);
 
     ServiceFactory serviceFactory =

--- a/api/src/test/java/marquez/db/ColumnLineageDaoTest.java
+++ b/api/src/test/java/marquez/db/ColumnLineageDaoTest.java
@@ -257,7 +257,7 @@ public class ColumnLineageDaoTest {
     UpdateLineageRow.DatasetRecord datasetRecord_c = lineageRow.getOutputs().get().get(0);
     UUID field_col_d = fieldDao.findUuid(datasetRecord_c.getDatasetRow().getUuid(), "col_d").get();
     Set<ColumnLineageNodeData> lineage =
-        dao.getLineage(20, Collections.singletonList(field_col_d), Instant.now());
+        dao.getLineage(20, Collections.singletonList(field_col_d), false, Instant.now());
 
     assertEquals(2, lineage.size());
 
@@ -326,7 +326,8 @@ public class ColumnLineageDaoTest {
     UUID field_col_a = fieldDao.findUuid(datasetRecord_a.getDatasetRow().getUuid(), "col_a").get();
 
     // assert lineage is empty
-    assertThat(dao.getLineage(20, Collections.singletonList(field_col_a), Instant.now())).isEmpty();
+    assertThat(dao.getLineage(20, Collections.singletonList(field_col_a), false, Instant.now()))
+        .isEmpty();
   }
 
   /**
@@ -392,11 +393,12 @@ public class ColumnLineageDaoTest {
     UUID field_col_e = fieldDao.findUuid(datasetRecord_d.getDatasetRow().getUuid(), "col_e").get();
 
     // make sure dataset are constructed properly
-    assertThat(dao.getLineage(20, Collections.singletonList(field_col_e), Instant.now()))
+    assertThat(dao.getLineage(20, Collections.singletonList(field_col_e), false, Instant.now()))
         .hasSize(3);
 
     // verify graph size is 2 when max depth is 1
-    assertThat(dao.getLineage(1, Collections.singletonList(field_col_e), Instant.now())).hasSize(2);
+    assertThat(dao.getLineage(1, Collections.singletonList(field_col_e), false, Instant.now()))
+        .hasSize(2);
   }
 
   @Test
@@ -462,9 +464,9 @@ public class ColumnLineageDaoTest {
     UUID field_col_d = fieldDao.findUuid(datasetRecord_c.getDatasetRow().getUuid(), "col_d").get();
 
     // column lineages for col_a and col_e should be of size 3
-    assertThat(dao.getLineage(20, Collections.singletonList(field_col_a), Instant.now()))
+    assertThat(dao.getLineage(20, Collections.singletonList(field_col_a), false, Instant.now()))
         .hasSize(3);
-    assertThat(dao.getLineage(20, Collections.singletonList(field_col_d), Instant.now()))
+    assertThat(dao.getLineage(20, Collections.singletonList(field_col_d), false, Instant.now()))
         .hasSize(3);
   }
 
@@ -524,7 +526,7 @@ public class ColumnLineageDaoTest {
 
     // assert input fields for col_d contain col_a and col_c
     List<String> inputFields =
-        dao.getLineage(20, Collections.singletonList(field_col_c), Instant.now()).stream()
+        dao.getLineage(20, Collections.singletonList(field_col_c), false, Instant.now()).stream()
             .filter(node -> node.getDataset().equals("dataset_b"))
             .flatMap(node -> node.getInputFields().stream())
             .map(input -> input.getField())
@@ -558,11 +560,17 @@ public class ColumnLineageDaoTest {
     // assert lineage is empty before and present after
     assertThat(
             dao.getLineage(
-                20, Collections.singletonList(field_col_b), columnLineageCreatedAt.minusSeconds(1)))
+                20,
+                Collections.singletonList(field_col_b),
+                false,
+                columnLineageCreatedAt.minusSeconds(1)))
         .isEmpty();
     assertThat(
             dao.getLineage(
-                20, Collections.singletonList(field_col_b), columnLineageCreatedAt.plusSeconds(1)))
+                20,
+                Collections.singletonList(field_col_b),
+                false,
+                columnLineageCreatedAt.plusSeconds(1)))
         .hasSize(1);
   }
 
@@ -590,7 +598,7 @@ public class ColumnLineageDaoTest {
     UpdateLineageRow.DatasetRecord datasetRecord_b = lineageRow.getOutputs().get().get(0);
     UUID field_col_b = fieldDao.findUuid(datasetRecord_b.getDatasetRow().getUuid(), "col_c").get();
 
-    assertThat(dao.getLineage(20, Collections.singletonList(field_col_b), Instant.now()))
+    assertThat(dao.getLineage(20, Collections.singletonList(field_col_b), false, Instant.now()))
         .hasSize(1);
   }
 }


### PR DESCRIPTION
### Problem

Column lineage should be able to detect downstream edges when requested. 

Closes: #2116

### Solution

Extend recursive query, that returns column lineage nodes, to traverse the graph for downstream nodes. 


> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)