### PR TITLE
Fix bug that caused a single run event to create multiple jobs

### DIFF
--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -58,6 +58,7 @@ import marquez.service.models.LineageEvent.JobFacet;
 import marquez.service.models.LineageEvent.LifecycleStateChangeFacet;
 import marquez.service.models.LineageEvent.NominalTimeRunFacet;
 import marquez.service.models.LineageEvent.ParentRunFacet;
+import marquez.service.models.LineageEvent.Run;
 import marquez.service.models.LineageEvent.RunFacet;
 import marquez.service.models.LineageEvent.SchemaDatasetFacet;
 import marquez.service.models.LineageEvent.SchemaField;
@@ -150,23 +151,11 @@ public interface OpenLineageDao extends BaseDao {
             DEFAULT_NAMESPACE_OWNER);
     bag.setNamespace(namespace);
 
-    String description =
-        Optional.ofNullable(event.getJob().getFacets())
-            .map(JobFacet::getDocumentation)
-            .map(DocumentationJobFacet::getDescription)
-            .orElse(null);
-
     Map<String, String> context = buildJobContext(event);
     JobContextRow jobContext =
         jobContextDao.upsert(
             UUID.randomUUID(), now, Utils.toJson(context), Utils.checksumFor(context));
     bag.setJobContext(jobContext);
-
-    String location =
-        Optional.ofNullable(event.getJob().getFacets())
-            .flatMap(f -> Optional.ofNullable(f.getSourceCodeLocation()))
-            .flatMap(s -> Optional.ofNullable(s.getUrl()))
-            .orElse(null);
 
     Instant nominalStartTime =
         Optional.ofNullable(event.getRun().getFacets())
@@ -181,75 +170,26 @@ public interface OpenLineageDao extends BaseDao {
             .map(t -> t.withZoneSameInstant(ZoneId.of("UTC")).toInstant())
             .orElse(null);
 
-    Logger log = LoggerFactory.getLogger(OpenLineageDao.class);
     Optional<ParentRunFacet> parentRun =
-        Optional.ofNullable(event.getRun())
-            .map(LineageEvent.Run::getFacets)
-            .map(RunFacet::getParent);
-
+        Optional.ofNullable(event.getRun()).map(Run::getFacets).map(RunFacet::getParent);
     Optional<UUID> parentUuid = parentRun.map(Utils::findParentRunUuid);
-    Optional<JobRow> parentJob =
-        parentUuid.map(
-            uuid ->
-                findParentJobRow(
-                    event,
-                    namespace,
-                    jobContext,
-                    location,
-                    nominalStartTime,
-                    nominalEndTime,
-                    log,
-                    parentRun.get(),
-                    uuid));
 
-    // construct the simple name of the job by removing the parent prefix plus the dot '.' separator
-    String jobName =
-        parentJob
-            .map(
-                p -> {
-                  if (event.getJob().getName().startsWith(p.getName() + '.')) {
-                    return event.getJob().getName().substring(p.getName().length() + 1);
-                  } else {
-                    return event.getJob().getName();
-                  }
-                })
-            .orElse(event.getJob().getName());
-    log.debug(
-        "Calculated job name {} from job {} with parent {}",
-        jobName,
-        event.getJob().getName(),
-        parentJob.map(JobRow::getName));
     JobRow job =
-        parentJob
-            .map(
-                parent ->
-                    jobDao.upsertJob(
-                        UUID.randomUUID(),
-                        parent.getUuid(),
-                        getJobType(event.getJob()),
-                        now,
-                        namespace.getUuid(),
-                        namespace.getName(),
-                        jobName,
-                        description,
-                        jobContext.getUuid(),
-                        location,
-                        null,
-                        jobDao.toJson(toDatasetId(event.getInputs()), mapper)))
+        runDao
+            .findJobRowByRunUuid(runToUuid(event.getRun().getRunId()))
             .orElseGet(
                 () ->
-                    jobDao.upsertJob(
-                        UUID.randomUUID(),
-                        getJobType(event.getJob()),
+                    buildJobFromEvent(
+                        event,
+                        mapper,
+                        jobDao,
                         now,
-                        namespace.getUuid(),
-                        namespace.getName(),
-                        jobName,
-                        description,
-                        jobContext.getUuid(),
-                        location,
-                        null,
-                        jobDao.toJson(toDatasetId(event.getInputs()), mapper)));
+                        namespace,
+                        jobContext,
+                        nominalStartTime,
+                        nominalEndTime,
+                        parentRun));
+
     bag.setJob(job);
 
     Map<String, String> runArgsMap = createRunArgs(event);
@@ -277,8 +217,8 @@ public interface OpenLineageDao extends BaseDao {
               runStateType,
               now,
               namespace.getName(),
-              jobName,
-              location,
+              job.getName(),
+              job.getLocation(),
               jobContext.getUuid());
     } else {
       run =
@@ -294,8 +234,8 @@ public interface OpenLineageDao extends BaseDao {
               nominalEndTime,
               namespace.getUuid(),
               namespace.getName(),
-              jobName,
-              location,
+              job.getName(),
+              job.getLocation(),
               jobContext.getUuid());
     }
     bag.setRun(run);
@@ -361,6 +301,93 @@ public interface OpenLineageDao extends BaseDao {
 
     bag.setOutputs(Optional.ofNullable(datasetOutputs));
     return bag;
+  }
+
+  private JobRow buildJobFromEvent(
+      LineageEvent event,
+      ObjectMapper mapper,
+      JobDao jobDao,
+      Instant now,
+      NamespaceRow namespace,
+      JobContextRow jobContext,
+      Instant nominalStartTime,
+      Instant nominalEndTime,
+      Optional<ParentRunFacet> parentRun) {
+    Logger log = LoggerFactory.getLogger(OpenLineageDao.class);
+    String description =
+        Optional.ofNullable(event.getJob().getFacets())
+            .map(JobFacet::getDocumentation)
+            .map(DocumentationJobFacet::getDescription)
+            .orElse(null);
+
+    String location =
+        Optional.ofNullable(event.getJob().getFacets())
+            .flatMap(f -> Optional.ofNullable(f.getSourceCodeLocation()))
+            .flatMap(s -> Optional.ofNullable(s.getUrl()))
+            .orElse(null);
+
+    Optional<UUID> parentUuid = parentRun.map(Utils::findParentRunUuid);
+    Optional<JobRow> parentJob =
+        parentUuid.map(
+            uuid ->
+                findParentJobRow(
+                    event,
+                    namespace,
+                    jobContext,
+                    location,
+                    nominalStartTime,
+                    nominalEndTime,
+                    log,
+                    parentRun.get(),
+                    uuid));
+
+    // construct the simple name of the job by removing the parent prefix plus the dot '.' separator
+    String jobName =
+        parentJob
+            .map(
+                p -> {
+                  if (event.getJob().getName().startsWith(p.getName() + '.')) {
+                    return event.getJob().getName().substring(p.getName().length() + 1);
+                  } else {
+                    return event.getJob().getName();
+                  }
+                })
+            .orElse(event.getJob().getName());
+    log.debug(
+        "Calculated job name {} from job {} with parent {}",
+        jobName,
+        event.getJob().getName(),
+        parentJob.map(JobRow::getName));
+    return parentJob
+        .map(
+            parent ->
+                jobDao.upsertJob(
+                    UUID.randomUUID(),
+                    parent.getUuid(),
+                    getJobType(event.getJob()),
+                    now,
+                    namespace.getUuid(),
+                    namespace.getName(),
+                    jobName,
+                    description,
+                    jobContext.getUuid(),
+                    location,
+                    null,
+                    jobDao.toJson(toDatasetId(event.getInputs()), mapper)))
+        .orElseGet(
+            () ->
+                jobDao.upsertJob(
+                    UUID.randomUUID(),
+                    getJobType(event.getJob()),
+                    now,
+                    namespace.getUuid(),
+                    namespace.getName(),
+                    jobName,
+                    description,
+                    jobContext.getUuid(),
+                    location,
+                    null,
+                    jobDao.toJson(toDatasetId(event.getInputs()), mapper)));
   }
 
   private JobRow findParentJobRow(


### PR DESCRIPTION
Signed-off-by: Michael Collado <collado.mike@gmail.com>

### Problem
As described in #2158 a single run may send multiple run events, where the start event contains a parent run and subsequent events do not. In that case, the subsequent jobs will create a new job without a parent, causing duplicate jobs with the same name.
Closes: #2158

### Solution

During OpenLineage event handling, check to see if a run with the given id already exists. If it does, do not create a new job (or parent), but simply use the job that is already associated with the run.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)