### PR TITLE
Column lineage java client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Lineage graph endpoint for column lineage [`#2124`](https://github.com/MarquezProject/marquez/pull/2124) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
 * Enrich returned dataset resource with column lineage information [`#2113`](https://github.com/MarquezProject/marquez/pull/2113) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
 * Downstream column lineage [`#2159`](https://github.com/MarquezProject/marquez/pull/2159) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+* column lineage within Marquez Java client  [`#2163`](https://github.com/MarquezProject/marquez/pull/2163) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
 
 ### Fixed
 * Add support for `parentRun` facet as reported by older Airflow OpenLineage versions [@collado-mike](https://github.com/collado-mike)

--- a/api/src/main/java/marquez/db/ColumnLineageDao.java
+++ b/api/src/main/java/marquez/db/ColumnLineageDao.java
@@ -138,7 +138,7 @@ public interface ColumnLineageDao extends BaseDao {
                 (node.input_dataset_field_uuid = adjacent_node.output_dataset_field_uuid) --upstream lineage
                 OR (:withDownstream AND adjacent_node.input_dataset_field_uuid = node.output_dataset_field_uuid) --optional downstream lineage
               )
-              AND node.depth < :depth
+              AND node.depth < :depth - 1 -- fetching single row means fetching single edge which is size 1
               AND NOT is_cycle
             )
             SELECT

--- a/api/src/test/java/marquez/ColumnLineageIntegrationTest.java
+++ b/api/src/test/java/marquez/ColumnLineageIntegrationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez;
+
+import static marquez.db.ColumnLineageTestUtils.getDatasetA;
+import static marquez.db.ColumnLineageTestUtils.getDatasetB;
+import static marquez.db.ColumnLineageTestUtils.getDatasetC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Optional;
+import marquez.api.JdbiUtils;
+import marquez.client.MarquezClient;
+import marquez.client.models.Node;
+import marquez.db.LineageTestUtils;
+import marquez.db.OpenLineageDao;
+import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
+import marquez.service.models.LineageEvent;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@org.junit.jupiter.api.Tag("IntegrationTests")
+@ExtendWith(MarquezJdbiExternalPostgresExtension.class)
+public class ColumnLineageIntegrationTest extends BaseIntegrationTest {
+
+  @BeforeEach
+  public void setup(Jdbi jdbi) {
+    OpenLineageDao openLineageDao = jdbi.onDemand(OpenLineageDao.class);
+
+    LineageEvent.JobFacet jobFacet =
+        new LineageEvent.JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+
+    LineageEvent.Dataset dataset_A = getDatasetA();
+    LineageEvent.Dataset dataset_B = getDatasetB();
+    LineageEvent.Dataset dataset_C = getDatasetC();
+
+    LineageTestUtils.createLineageRow(
+        openLineageDao,
+        "job1",
+        "COMPLETE",
+        jobFacet,
+        Arrays.asList(dataset_A),
+        Arrays.asList(dataset_B));
+
+    LineageTestUtils.createLineageRow(
+        openLineageDao,
+        "job2",
+        "COMPLETE",
+        jobFacet,
+        Arrays.asList(dataset_B),
+        Arrays.asList(dataset_C));
+  }
+
+  @AfterEach
+  public void tearDown(Jdbi jdbi) {
+    JdbiUtils.cleanDatabase(jdbi);
+  }
+
+  @Test
+  public void testColumnLineageEndpointByDataset() {
+    MarquezClient.Lineage lineage = client.getColumnLineage("namespace", "dataset_b");
+
+    assertThat(lineage.getGraph()).hasSize(3);
+    assertThat(getNodeByFieldName(lineage, "col_a")).isPresent();
+    assertThat(getNodeByFieldName(lineage, "col_b")).isPresent();
+    assertThat(getNodeByFieldName(lineage, "col_c")).isPresent();
+  }
+
+  @Test
+  public void testColumnLineageEndpointByDatasetField() {
+    MarquezClient.Lineage lineage = client.getColumnLineage("namespace", "dataset_b", "col_c");
+
+    assertThat(lineage.getGraph()).hasSize(3);
+    assertThat(getNodeByFieldName(lineage, "col_a")).isPresent();
+    assertThat(getNodeByFieldName(lineage, "col_b")).isPresent();
+    assertThat(getNodeByFieldName(lineage, "col_c")).isPresent();
+  }
+
+  @Test
+  public void testColumnLineageEndpointWithDepthLimit() {
+    MarquezClient.Lineage lineage =
+        client.getColumnLineage("namespace", "dataset_c", "col_d", 1, false);
+
+    assertThat(lineage.getGraph()).hasSize(2);
+    assertThat(getNodeByFieldName(lineage, "col_c")).isPresent();
+    assertThat(getNodeByFieldName(lineage, "col_d")).isPresent();
+  }
+
+  @Test
+  public void testColumnLineageEndpointWithDownstream() {
+    MarquezClient.Lineage lineage =
+        client.getColumnLineage("namespace", "dataset_b", "col_c", 10, true);
+
+    assertThat(lineage.getGraph()).hasSize(4);
+    assertThat(getNodeByFieldName(lineage, "col_d")).isPresent();
+  }
+
+  private Optional<Node> getNodeByFieldName(MarquezClient.Lineage lineage, String field) {
+    return lineage.getGraph().stream()
+        .filter(n -> n.getId().asDatasetFieldId().getField().equals(field))
+        .findAny();
+  }
+}

--- a/api/src/test/java/marquez/db/ColumnLineageDaoTest.java
+++ b/api/src/test/java/marquez/db/ColumnLineageDaoTest.java
@@ -396,9 +396,9 @@ public class ColumnLineageDaoTest {
     assertThat(dao.getLineage(20, Collections.singletonList(field_col_e), false, Instant.now()))
         .hasSize(3);
 
-    // verify graph size is 2 when max depth is 1
+    // depth 1 corresponds to single ColumnLineageData with other nodes as node inputFields
     assertThat(dao.getLineage(1, Collections.singletonList(field_col_e), false, Instant.now()))
-        .hasSize(2);
+        .hasSize(1);
   }
 
   @Test

--- a/clients/java/src/main/java/marquez/client/MarquezPathV1.java
+++ b/clients/java/src/main/java/marquez/client/MarquezPathV1.java
@@ -177,4 +177,8 @@ class MarquezPathV1 {
   static String searchPath() {
     return path("/search");
   }
+
+  static String columnLineagePath() {
+    return path("/column-lineage/");
+  }
 }

--- a/clients/java/src/main/java/marquez/client/MarquezUrl.java
+++ b/clients/java/src/main/java/marquez/client/MarquezUrl.java
@@ -7,6 +7,7 @@ package marquez.client;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static marquez.client.MarquezPathV1.columnLineagePath;
 import static marquez.client.MarquezPathV1.createRunPath;
 import static marquez.client.MarquezPathV1.createTagPath;
 import static marquez.client.MarquezPathV1.datasetPath;
@@ -41,6 +42,9 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 import lombok.NonNull;
+import marquez.client.models.DatasetFieldId;
+import marquez.client.models.DatasetId;
+import marquez.client.models.NodeId;
 import marquez.client.models.RunState;
 import marquez.client.models.SearchFilter;
 import marquez.client.models.SearchSort;
@@ -204,5 +208,22 @@ class MarquezUrl {
     }
     queryParams.put("limit", limit);
     return from(searchPath(), queryParams.build());
+  }
+
+  URL toColumnLineageUrl(
+      String namespace, String dataset, String field, int depth, boolean withDownstream) {
+    final ImmutableMap.Builder queryParams = new ImmutableMap.Builder();
+    queryParams.put("nodeId", NodeId.of(new DatasetFieldId(namespace, dataset, field)).getValue());
+    queryParams.put("depth", String.valueOf(depth));
+    queryParams.put("withDownstream", String.valueOf(withDownstream));
+    return from(columnLineagePath(), queryParams.build());
+  }
+
+  URL toColumnLineageUrl(String namespace, String dataset, int depth, boolean withDownstream) {
+    final ImmutableMap.Builder queryParams = new ImmutableMap.Builder();
+    queryParams.put("nodeId", NodeId.of(new DatasetId(namespace, dataset)).getValue());
+    queryParams.put("depth", String.valueOf(depth));
+    queryParams.put("withDownstream", String.valueOf(withDownstream));
+    return from(columnLineagePath(), queryParams.build());
   }
 }

--- a/clients/java/src/main/java/marquez/client/Utils.java
+++ b/clients/java/src/main/java/marquez/client/Utils.java
@@ -70,4 +70,15 @@ public final class Utils {
       @NonNull final HttpRequestBase request, @NonNull final String apiKey) {
     request.addHeader(AUTHORIZATION, "Bearer " + apiKey);
   }
+
+  public static String checkNotBlank(@NonNull final String arg) {
+    if (emptyOrBlank(arg)) {
+      throw new IllegalArgumentException();
+    }
+    return arg;
+  }
+
+  private static boolean emptyOrBlank(final String arg) {
+    return arg.trim().isEmpty();
+  }
 }

--- a/clients/java/src/main/java/marquez/client/models/ColumnLineage.java
+++ b/clients/java/src/main/java/marquez/client/models/ColumnLineage.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @Getter
 public class ColumnLineage {
   @NonNull private String name;
-  @NonNull private List<ColumnLineageInputField> inputFields;
+  @NonNull private List<DatasetFieldId> inputFields;
   @NonNull private String transformationDescription;
   @NonNull private String transformationType;
 }

--- a/clients/java/src/main/java/marquez/client/models/ColumnLineageNodeData.java
+++ b/clients/java/src/main/java/marquez/client/models/ColumnLineageNodeData.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.client.models;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import marquez.client.Utils;
+
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ColumnLineageNodeData implements NodeData {
+  @NonNull String namespace;
+  @NonNull String dataset;
+  @NonNull String field;
+  @NonNull String fieldType;
+  @NonNull String transformationDescription;
+  @NonNull String transformationType;
+  @NonNull List<DatasetFieldId> inputFields;
+
+  public static ColumnLineageNodeData fromJson(@NonNull final String json) {
+    return Utils.fromJson(json, new TypeReference<ColumnLineageNodeData>() {});
+  }
+}

--- a/clients/java/src/main/java/marquez/client/models/DatasetFieldId.java
+++ b/clients/java/src/main/java/marquez/client/models/DatasetFieldId.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.client.models;
+
+import lombok.NonNull;
+import lombok.Value;
+
+@Value
+public class DatasetFieldId {
+  @NonNull String namespace;
+  @NonNull String dataset;
+  @NonNull String field;
+}

--- a/clients/java/src/main/java/marquez/client/models/Edge.java
+++ b/clients/java/src/main/java/marquez/client/models/Edge.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.client.models;
+
+import java.util.Comparator;
+import lombok.NonNull;
+import lombok.Value;
+
+@Value
+public class Edge implements Comparable<Edge> {
+  @NonNull NodeId origin;
+  @NonNull NodeId destination;
+
+  public static Edge of(@NonNull final NodeId origin, @NonNull final NodeId destination) {
+    return new Edge(origin, destination);
+  }
+
+  @Override
+  public int compareTo(Edge o) {
+    return Comparator.comparing(Edge::getOrigin)
+        .thenComparing(Edge::getDestination)
+        .compare(this, o);
+  }
+}

--- a/clients/java/src/main/java/marquez/client/models/Node.java
+++ b/clients/java/src/main/java/marquez/client/models/Node.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.client.models;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.Set;
+import javax.annotation.Nullable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@ToString
+@JsonPropertyOrder({"id", "type", "data", "inEdges", "outEdges"})
+public final class Node {
+  @Getter private final NodeId id;
+  @Getter private final NodeType type;
+  @Getter @Setter @Nullable private NodeData data;
+  @Getter private final Set<Edge> inEdges;
+  @Getter private final Set<Edge> outEdges;
+
+  public Node(
+      @NonNull final NodeId id,
+      @NonNull final NodeType type,
+      @Nullable final NodeData data,
+      @Nullable final Set<Edge> inEdges,
+      @Nullable final Set<Edge> outEdges) {
+    this.id = id;
+    this.type = type;
+    this.data = data;
+    this.inEdges = (inEdges == null) ? ImmutableSet.of() : ImmutableSortedSet.copyOf(inEdges);
+    this.outEdges = (outEdges == null) ? ImmutableSet.of() : ImmutableSortedSet.copyOf(outEdges);
+  }
+}

--- a/clients/java/src/main/java/marquez/client/models/NodeData.java
+++ b/clients/java/src/main/java/marquez/client/models/NodeData.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.client.models;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+    property = "type")
+@JsonSubTypes({@JsonSubTypes.Type(value = ColumnLineageNodeData.class, name = "DATASET_FIELD")})
+public interface NodeData {}

--- a/clients/java/src/main/java/marquez/client/models/NodeId.java
+++ b/clients/java/src/main/java/marquez/client/models/NodeId.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.client.models;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.util.StdConverter;
+import com.google.common.base.Joiner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@ToString
+@JsonDeserialize(converter = NodeId.FromValue.class)
+@JsonSerialize(converter = NodeId.ToValue.class)
+public final class NodeId implements Comparable<NodeId> {
+  public static final String ID_DELIM = ":";
+  public static final Joiner ID_JOINER = Joiner.on(ID_DELIM);
+
+  private static final String ID_PREFX_DATASET = "dataset";
+  private static final String ID_PREFX_DATASET_FIELD = "datasetField";
+  private static final String ID_PREFX_JOB = "job";
+  private static final String ID_PREFX_RUN = "run";
+  private static final Pattern ID_PATTERN =
+      Pattern.compile(
+          String.format(
+              "^(%s|%s|%s|%s):.*$",
+              ID_PREFX_DATASET, ID_PREFX_DATASET_FIELD, ID_PREFX_JOB, ID_PREFX_RUN));
+
+  public static final String VERSION_DELIM = "#";
+
+  @Getter private final String value;
+
+  public NodeId(final String value) {
+    checkArgument(
+        ID_PATTERN.matcher(value).matches(),
+        "node ID (%s) must start with '%s', '%s', '%s' or '%s'",
+        value,
+        ID_PREFX_DATASET,
+        ID_PREFX_DATASET_FIELD,
+        ID_PREFX_JOB,
+        ID_PREFX_RUN);
+    this.value = value;
+  }
+
+  public static NodeId of(final String value) {
+    return new NodeId(value);
+  }
+
+  public static NodeId of(@NonNull DatasetId datasetId) {
+    return of(ID_JOINER.join(ID_PREFX_DATASET, datasetId.getNamespace(), datasetId.getName()));
+  }
+
+  public static NodeId of(@NonNull DatasetFieldId datasetFieldId) {
+    return of(
+        ID_JOINER.join(
+            ID_PREFX_DATASET_FIELD,
+            datasetFieldId.getNamespace(),
+            datasetFieldId.getDataset(),
+            datasetFieldId.getField()));
+  }
+
+  @JsonIgnore
+  public boolean isDatasetFieldType() {
+    return value.startsWith(ID_PREFX_DATASET_FIELD);
+  }
+
+  @JsonIgnore
+  public boolean isDatasetType() {
+    return value.startsWith(ID_PREFX_DATASET + ID_DELIM);
+  }
+
+  @JsonIgnore
+  private String[] parts(int expectedParts, String expectedType) {
+
+    // dead simple splitting by token- matches most ids
+    String[] parts = value.split(ID_DELIM + "|" + VERSION_DELIM);
+    if (parts.length < expectedParts) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Expected NodeId of type %s with %s parts. Got: %s",
+              expectedType, expectedParts, getValue()));
+    } else if (parts.length == expectedParts) {
+      return parts;
+    } else {
+      // try to avoid matching colons in URIs- e.g., scheme://authority and host:port patterns
+      Pattern p = Pattern.compile("(?:" + ID_DELIM + "(?!//|\\d+))");
+      Matcher matcher = p.matcher(value);
+      String[] returnParts = new String[expectedParts];
+
+      int index;
+      int prevIndex = 0;
+      for (int i = 0; i < expectedParts - 1; i++) {
+        matcher.find();
+        index = matcher.start();
+        returnParts[i] = value.substring(prevIndex, index);
+        prevIndex = matcher.end();
+      }
+      returnParts[expectedParts - 1] = value.substring(prevIndex);
+
+      return returnParts;
+    }
+  }
+
+  @JsonIgnore
+  public DatasetId asDatasetId() {
+    String[] parts = parts(3, ID_PREFX_DATASET);
+    return new DatasetId(parts[1], parts[2]);
+  }
+
+  @JsonIgnore
+  public DatasetFieldId asDatasetFieldId() {
+    String[] parts = parts(4, ID_PREFX_DATASET);
+    return new DatasetFieldId(parts[1], parts[2], parts[3]);
+  }
+
+  public static class FromValue extends StdConverter<String, NodeId> {
+    @Override
+    public NodeId convert(@NonNull String value) {
+      return NodeId.of(value);
+    }
+  }
+
+  public static class ToValue extends StdConverter<NodeId, String> {
+    @Override
+    public String convert(@NonNull NodeId id) {
+      return id.getValue();
+    }
+  }
+
+  @Override
+  public int compareTo(NodeId o) {
+    return value.compareTo(o.getValue());
+  }
+}

--- a/clients/java/src/main/java/marquez/client/models/NodeType.java
+++ b/clients/java/src/main/java/marquez/client/models/NodeType.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.client.models;
+
+public enum NodeType {
+  DATASET,
+  DATASET_FIELD,
+  JOB,
+  RUN;
+}

--- a/clients/java/src/test/java/marquez/client/MarquezPathV1Test.java
+++ b/clients/java/src/test/java/marquez/client/MarquezPathV1Test.java
@@ -81,4 +81,9 @@ public class MarquezPathV1Test {
           MarquezPathV1.path("/whatever/%s/next/%s");
         });
   }
+
+  @Test
+  void testPath_columnLineage() {
+    Assertions.assertEquals("/api/v1/column-lineage", MarquezPathV1.columnLineagePath());
+  }
 }

--- a/clients/java/src/test/java/marquez/client/MarquezUrlTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezUrlTest.java
@@ -33,4 +33,15 @@ public class MarquezUrlTest {
     Assertions.assertEquals(
         "http://marquez:5000/namespace/s3:%2F%2Fbucket/job/jname", url.toString());
   }
+
+  @Test
+  void testToColumnLineageUrl() {
+    Assertions.assertEquals(
+        "http://marquez:5000/api/v1/column-lineage?nodeId=dataset%3Anamespace%3Adataset&depth=20&withDownstream=true",
+        marquezUrl.toColumnLineageUrl("namespace", "dataset", 20, true).toString());
+
+    Assertions.assertEquals(
+        "http://marquez:5000/api/v1/column-lineage?nodeId=datasetField%3Anamespace%3Adataset%3Afield&depth=20&withDownstream=true",
+        marquezUrl.toColumnLineageUrl("namespace", "dataset", "field", 20, true).toString());
+  }
 }

--- a/clients/java/src/test/java/marquez/client/UtilsTest.java
+++ b/clients/java/src/test/java/marquez/client/UtilsTest.java
@@ -7,6 +7,7 @@ package marquez.client;
 
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -24,6 +25,14 @@ public class UtilsTest {
   private static final Object OBJECT = new Object(VALUE);
   private static final TypeReference<Object> TYPE = new TypeReference<Object>() {};
   private static final String JSON = "{\"value\":\"" + VALUE + "\"}";
+  private static final String NULL_ERROR_MESSAGE = null;
+  private static final String NON_NULL_ERROR_MESSAGE = "test error message";
+  private static final String NON_NULL_ERROR_MESSAGE_WITH_ARGS = "test error message with %s";
+  private static final String ARG = "test arg";
+  private static final String BLANK_STRING = " ";
+  private static final String EMPTY_STRING = "";
+  private static final String NON_BLANK_STRING = "test string";
+  private static final String NULL_STRING = null;
 
   // Http Auth
   private static final String API_KEY = "PuRx8GT3huSXlheDIRUK1YUatGpLVEuL";
@@ -97,5 +106,27 @@ public class UtilsTest {
     Object(final String value) {
       this.value = value;
     }
+  }
+
+  @Test
+  public void testNotBlank() {
+    assertThat(Utils.checkNotBlank(NON_BLANK_STRING)).isEqualTo(NON_BLANK_STRING);
+  }
+
+  @Test
+  public void testCheckNotBlank_throwsOnNullString_noErrorMessage() {
+    assertThatNullPointerException().isThrownBy(() -> Utils.checkNotBlank(NULL_STRING));
+  }
+
+  @Test
+  public void testCheckNotBlank_throwsOnBlankString_noErrorMessage() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> Utils.checkNotBlank(BLANK_STRING));
+  }
+
+  @Test
+  public void testCheckNotBlank_throwsOnEmptyString_noErrorMessage() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> Utils.checkNotBlank(EMPTY_STRING));
   }
 }

--- a/clients/java/src/test/java/marquez/client/models/EdgeTest.java
+++ b/clients/java/src/test/java/marquez/client/models/EdgeTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.client.models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class EdgeTest {
+
+  /** Dummy compareTo test to avoid codeCov pitfalls. */
+  @Test
+  public void testCompareTo() {
+    Edge edge1 = new Edge(NodeId.of("dataset:a.a"), NodeId.of("dataset:b.b"));
+    Edge edge2 = new Edge(NodeId.of("dataset:a.a"), NodeId.of("dataset:a.a"));
+
+    assertThat(edge1.compareTo(edge2)).isGreaterThan(0);
+  }
+}

--- a/clients/java/src/test/java/marquez/client/models/NodeIdTest.java
+++ b/clients/java/src/test/java/marquez/client/models/NodeIdTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.client.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class NodeIdTest {
+
+  @ParameterizedTest(name = "testDataset-{index} {argumentsWithNames}")
+  @CsvSource(
+      value = {
+        "my-namespace$my-dataset",
+        "gs://bucket$/path/to/data",
+        "postgresql://hostname:5432/database$my_table",
+        "my-namespace$my_struct<a:bigint,b:bigint,c:string>"
+      },
+      delimiter = '$')
+  public void testDataset(String namespace, String dataset) {
+    NodeId nodeId = NodeId.of(new DatasetId(namespace, dataset));
+    assertTrue(nodeId.isDatasetType());
+    assertFalse(nodeId.isDatasetFieldType());
+    assertEquals(namespace, nodeId.asDatasetId().getNamespace());
+    assertEquals(dataset, nodeId.asDatasetId().getName());
+  }
+
+  @ParameterizedTest(name = "testDatasetField-{index} {argumentsWithNames}")
+  @CsvSource(
+      value = {
+        "my-namespace$my-dataset$colA",
+        "gs://bucket$/path/to/data$colA",
+        "gs://bucket$/path/to/data$col_A"
+      },
+      delimiter = '$')
+  public void testDatasetField(String namespace, String dataset, String field) {
+    NodeId nodeId = NodeId.of(new DatasetFieldId(namespace, dataset, field));
+    assertFalse(nodeId.isDatasetType());
+    assertTrue(nodeId.isDatasetFieldType());
+    assertEquals(namespace, nodeId.asDatasetFieldId().getNamespace());
+    assertEquals(dataset, nodeId.asDatasetFieldId().getDataset());
+    assertEquals(field, nodeId.asDatasetFieldId().getField());
+  }
+}


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Marquez API client methods for column lineage are missing. 

Closes: #2163

### Solution

Implement Java client. 

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)