### PR TITLE
fix column lineage returning multiple entries for job run multiple times

### DIFF
--- a/api/src/main/java/marquez/db/ColumnLineageDao.java
+++ b/api/src/main/java/marquez/db/ColumnLineageDao.java
@@ -105,9 +105,12 @@ public interface ColumnLineageDao extends BaseDao {
               INNER JOIN datasets_view d ON d.uuid = df.dataset_uuid
             ),
             column_lineage_recursive AS (
-              SELECT *, 0 as depth
-              FROM column_lineage
-              WHERE output_dataset_field_uuid IN (<datasetFieldUuids>) AND created_at <= :createdAtUntil
+              (
+                SELECT DISTINCT ON (output_dataset_field_uuid, input_dataset_field_uuid) *, 0 as depth
+                FROM column_lineage
+                WHERE output_dataset_field_uuid IN (<datasetFieldUuids>) AND created_at <= :createdAtUntil
+                ORDER BY output_dataset_field_uuid, input_dataset_field_uuid, updated_at DESC, updated_at
+              )
               UNION
               SELECT
                 upstream_node.output_dataset_version_uuid,

--- a/api/src/test/java/marquez/db/ColumnLineageDaoTest.java
+++ b/api/src/test/java/marquez/db/ColumnLineageDaoTest.java
@@ -565,4 +565,32 @@ public class ColumnLineageDaoTest {
                 20, Collections.singletonList(field_col_b), columnLineageCreatedAt.plusSeconds(1)))
         .hasSize(1);
   }
+
+  @Test
+  void testGetLineageWhenJobRunMultipleTimes() {
+    Dataset dataset_A = getDatasetA();
+    Dataset dataset_B = getDatasetB();
+
+    LineageTestUtils.createLineageRow(
+        openLineageDao,
+        "job1",
+        "COMPLETE",
+        jobFacet,
+        Arrays.asList(dataset_A),
+        Arrays.asList(dataset_B));
+    UpdateLineageRow lineageRow =
+        LineageTestUtils.createLineageRow(
+            openLineageDao,
+            "job1",
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(dataset_A),
+            Arrays.asList(dataset_B));
+
+    UpdateLineageRow.DatasetRecord datasetRecord_b = lineageRow.getOutputs().get().get(0);
+    UUID field_col_b = fieldDao.findUuid(datasetRecord_b.getDatasetRow().getUuid(), "col_c").get();
+
+    assertThat(dao.getLineage(20, Collections.singletonList(field_col_b), Instant.now()))
+        .hasSize(1);
+  }
 }


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Each column lineage row contains columns: `output_dataset_version_uuid`, `output_dataset_field_uuid`, `input_dataset_version_uuid`, `input_dataset_field_uuid`. This means that in case of a single job reading one column and writing to another, if a job is run twice this will result in two rows in `column-lineage` table. This is fine as we want to track this information. But we shouldn't retrieve this twice through the endpoint. 

### Solution

Return column dependency only once if a job has been run several times. 

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)