### PR TITLE
fix downstream recursion

### DIFF
--- a/api/src/main/java/marquez/service/ColumnLineageService.java
+++ b/api/src/main/java/marquez/service/ColumnLineageService.java
@@ -71,7 +71,7 @@ public class ColumnLineageService extends DelegatingDaos.DelegatingColumnLineage
                               DatasetFieldId.of(i.getNamespace(), i.getDataset(), i.getField())))
                   .forEach(
                       inputNodeId -> {
-                        graphNodes.put(inputNodeId, Node.datasetField().id(inputNodeId));
+                        graphNodes.putIfAbsent(inputNodeId, Node.datasetField().id(inputNodeId));
                         Optional.ofNullable(outEdges.get(inputNodeId))
                             .ifPresentOrElse(
                                 nodeEdges -> nodeEdges.add(nodeId),

--- a/api/src/test/java/marquez/service/ColumnLineageServiceTest.java
+++ b/api/src/test/java/marquez/service/ColumnLineageServiceTest.java
@@ -318,6 +318,15 @@ public class ColumnLineageServiceTest {
                 .filter(c -> c.getId().asDatasetFieldId().getFieldName().getValue().equals("col_d"))
                 .findAny())
         .isPresent();
+
+    ColumnLineageNodeData nodeData_C =
+        (ColumnLineageNodeData)
+            lineage.getGraph().stream()
+                .filter(c -> c.getId().asDatasetFieldId().getFieldName().getValue().equals("col_c"))
+                .findAny()
+                .get()
+                .getData();
+    assertThat(nodeData_C.getInputFields()).hasSize(2);
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Traversing lineage graph with upstream and downstream edges leads to cycles and the same node being added to recursive table multiple times. 

### Solution

Apply solution described here: https://www.postgresql.org/docs/current/queries-with.html
similar to one below:
```
WITH RECURSIVE search_graph(id, link, data, depth, is_cycle, path) AS (
    SELECT g.id, g.link, g.data, 0,
      false,
      ARRAY[g.id]
    FROM graph g
  UNION ALL
    SELECT g.id, g.link, g.data, sg.depth + 1,
      g.id = ANY(path),
      path || g.id
    FROM graph g, search_graph sg
    WHERE g.id = sg.link AND NOT is_cycle
)
SELECT * FROM search_graph;
```

The same can be achieved with `CYCLE id SET is_cycle USING path` that is not available in Postgresql 12. 

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)