### PR TITLE
drop and create datasets_view

### DIFF
--- a/api/src/main/resources/marquez/db/migration/R__3_Datasets_view.sql
+++ b/api/src/main/resources/marquez/db/migration/R__3_Datasets_view.sql
@@ -1,4 +1,5 @@
-CREATE OR REPLACE VIEW datasets_view
+DROP VIEW IF EXISTS datasets_view;
+CREATE VIEW datasets_view
 AS
 SELECT d.uuid,
        d.type,


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Change within `datasets_view` definition breaks upgrades.

Closes: #2183

### Solution

Drop view each time migration is run

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)