### PR TITLE
Update jobs_current_version_uuid_index and jobs_symlink_target_uuid_index to ignore NULL values

### DIFF
--- a/api/src/main/resources/marquez/db/migration/V51__job_indices_for_lineage.sql
+++ b/api/src/main/resources/marquez/db/migration/V51__job_indices_for_lineage.sql
@@ -1,10 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 create index jobs_current_version_uuid_index
-    on jobs (current_version_uuid);
+    on jobs (current_version_uuid) WHERE current_version_uuid IS NOT NULL;
 
 create index jobs_symlink_target_uuid_index
-    on jobs (symlink_target_uuid);
+    on jobs (symlink_target_uuid) WHERE symlink_target_uuid IS NOT NULL;
 
 create index jobs_current_job_context_uuid_index
     on jobs (current_job_context_uuid);


### PR DESCRIPTION
### Problem

Most jobs don't have a symlink target and jobs don't have a current version until they've had at least one successful run. The indices recently added will always write to the index, even when the indexed values are null.

### Solution

Avoid writing to the indices when indexed values are null

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)