### PR TITLE
Include external_id column to ExtendedRunRow model

### DIFF
--- a/api/src/main/java/marquez/db/Columns.java
+++ b/api/src/main/java/marquez/db/Columns.java
@@ -109,6 +109,7 @@ public final class Columns {
   public static final String CONTEXT = "context";
 
   /* RUN ROW COLUMNS */
+  public static final String EXTERNAL_ID = "external_id";
   public static final String RUN_ARGS_UUID = "run_args_uuid";
   public static final String INPUT_VERSION_UUIDS = "input_version_uuids";
   public static final String NOMINAL_START_TIME = "nominal_start_time";

--- a/api/src/main/java/marquez/db/mappers/ExtendedRunRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/ExtendedRunRowMapper.java
@@ -41,6 +41,7 @@ public final class ExtendedRunRowMapper implements RowMapper<ExtendedRunRow> {
         uuidOrNull(results, Columns.JOB_VERSION_UUID),
         uuidOrNull(results, Columns.PARENT_RUN_UUID),
         uuidOrThrow(results, Columns.RUN_ARGS_UUID),
+        stringOrNull(results, Columns.EXTERNAL_ID),
         columnNames.contains(Columns.INPUT_VERSIONS)
             ? toDatasetVersion(results, Columns.INPUT_VERSIONS)
             : ImmutableList.of(),

--- a/api/src/main/java/marquez/db/models/ExtendedRunRow.java
+++ b/api/src/main/java/marquez/db/models/ExtendedRunRow.java
@@ -23,6 +23,7 @@ public class ExtendedRunRow extends RunRow {
   @Getter private final String namespaceName;
   @Getter private final String jobName;
   @Getter private final String args;
+  @Getter private final String externalId;
 
   public ExtendedRunRow(
       final UUID uuid,
@@ -32,6 +33,7 @@ public class ExtendedRunRow extends RunRow {
       @Nullable final UUID jobVersionUuid,
       @Nullable final UUID parentRunUuid,
       final UUID runArgsUuid,
+      final String externalId,
       final List<DatasetVersionId> inputVersions,
       final List<DatasetVersionId> outputVersions,
       @Nullable final Instant nominalStartTime,
@@ -64,6 +66,7 @@ public class ExtendedRunRow extends RunRow {
     this.args = args;
     this.jobName = jobName;
     this.namespaceName = namespaceName;
+    this.externalId = externalId;
   }
 
   public boolean hasInputVersionUuids() {


### PR DESCRIPTION
### Problem
Marquez runs table has `external_id` column but the java model `ExtendedRunRow` does not have it.

### Solution
Include `external_id` to the `ExtendedRunRow` model.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)