### PR TITLE
get column lineage by job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 * Lineage graph endpoint for column lineage [`#2124`](https://github.com/MarquezProject/marquez/pull/2124) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
 * Enrich returned dataset resource with column lineage information [`#2113`](https://github.com/MarquezProject/marquez/pull/2113) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
 * Downstream column lineage [`#2159`](https://github.com/MarquezProject/marquez/pull/2159) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
-* column lineage within Marquez Java client  [`#2163`](https://github.com/MarquezProject/marquez/pull/2163) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+* Column lineage within Marquez Java client  [`#2163`](https://github.com/MarquezProject/marquez/pull/2163) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+* Endpoint to get column lineage by a job [`#2204`](https://github.com/MarquezProject/marquez/pull/2204) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+
 
 ### Fixed
 * Add support for `parentRun` facet as reported by older Airflow OpenLineage versions [@collado-mike](https://github.com/collado-mike)

--- a/api/src/main/java/marquez/db/DatasetFieldDao.java
+++ b/api/src/main/java/marquez/db/DatasetFieldDao.java
@@ -107,6 +107,22 @@ public interface DatasetFieldDao extends BaseDao {
 
   @SqlQuery(
       """
+          WITH latest_run AS (
+            SELECT DISTINCT r.uuid as uuid, r.created_at
+            FROM runs_view r
+            WHERE r.namespace_name = :namespaceName AND r.job_name = :jobName
+            ORDER BY r.created_at DESC
+            LIMIT 1
+          )
+          SELECT dataset_fields.uuid
+          FROM dataset_fields
+          JOIN dataset_versions ON dataset_versions.dataset_uuid = dataset_fields.dataset_uuid
+          JOIN latest_run ON dataset_versions.run_uuid = latest_run.uuid
+      """)
+  List<UUID> findFieldsUuidsByJob(String namespaceName, String jobName);
+
+  @SqlQuery(
+      """
           SELECT df.uuid
           FROM dataset_fields  df
           JOIN datasets_view AS d ON d.uuid = df.dataset_uuid

--- a/api/src/main/java/marquez/service/ColumnLineageService.java
+++ b/api/src/main/java/marquez/service/ColumnLineageService.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import marquez.common.models.DatasetFieldId;
 import marquez.common.models.DatasetId;
+import marquez.common.models.JobId;
 import marquez.db.ColumnLineageDao;
 import marquez.db.DatasetFieldDao;
 import marquez.db.models.ColumnLineageNodeData;
@@ -124,6 +125,11 @@ public class ColumnLineageService extends DelegatingDaos.DelegatingColumnLineage
               datasetFieldId.getDatasetId().getName().getValue(),
               datasetFieldId.getFieldName().getValue())
           .ifPresent(uuid -> columnNodeUuids.add(uuid));
+    } else if (nodeId.isJobType()) {
+      JobId jobId = nodeId.asJobId();
+      columnNodeUuids.addAll(
+          datasetFieldDao.findFieldsUuidsByJob(
+              jobId.getNamespace().getValue(), jobId.getName().getValue()));
     }
     return columnNodeUuids;
   }

--- a/api/src/test/java/marquez/ColumnLineageIntegrationTest.java
+++ b/api/src/test/java/marquez/ColumnLineageIntegrationTest.java
@@ -64,7 +64,7 @@ public class ColumnLineageIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void testColumnLineageEndpointByDataset() {
-    MarquezClient.Lineage lineage = client.getColumnLineage("namespace", "dataset_b");
+    MarquezClient.Lineage lineage = client.getColumnLineageByDataset("namespace", "dataset_b");
 
     assertThat(lineage.getGraph()).hasSize(3);
     assertThat(getNodeByFieldName(lineage, "col_a")).isPresent();
@@ -74,7 +74,8 @@ public class ColumnLineageIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void testColumnLineageEndpointByDatasetField() {
-    MarquezClient.Lineage lineage = client.getColumnLineage("namespace", "dataset_b", "col_c");
+    MarquezClient.Lineage lineage =
+        client.getColumnLineageByDataset("namespace", "dataset_b", "col_c");
 
     assertThat(lineage.getGraph()).hasSize(3);
     assertThat(getNodeByFieldName(lineage, "col_a")).isPresent();
@@ -85,7 +86,7 @@ public class ColumnLineageIntegrationTest extends BaseIntegrationTest {
   @Test
   public void testColumnLineageEndpointWithDepthLimit() {
     MarquezClient.Lineage lineage =
-        client.getColumnLineage("namespace", "dataset_c", "col_d", 1, false);
+        client.getColumnLineageByDatasetField("namespace", "dataset_c", "col_d", 1, false);
 
     assertThat(lineage.getGraph()).hasSize(2);
     assertThat(getNodeByFieldName(lineage, "col_c")).isPresent();
@@ -95,10 +96,20 @@ public class ColumnLineageIntegrationTest extends BaseIntegrationTest {
   @Test
   public void testColumnLineageEndpointWithDownstream() {
     MarquezClient.Lineage lineage =
-        client.getColumnLineage("namespace", "dataset_b", "col_c", 10, true);
+        client.getColumnLineageByDatasetField("namespace", "dataset_b", "col_c", 10, true);
 
     assertThat(lineage.getGraph()).hasSize(4);
     assertThat(getNodeByFieldName(lineage, "col_d")).isPresent();
+  }
+
+  @Test
+  public void testColumnLineageEndpointByJob() {
+    MarquezClient.Lineage lineage = client.getColumnLineageByJob("namespace", "job1");
+
+    assertThat(lineage.getGraph()).hasSize(3);
+    assertThat(getNodeByFieldName(lineage, "col_a")).isPresent();
+    assertThat(getNodeByFieldName(lineage, "col_b")).isPresent();
+    assertThat(getNodeByFieldName(lineage, "col_c")).isPresent();
   }
 
   private Optional<Node> getNodeByFieldName(MarquezClient.Lineage lineage, String field) {

--- a/clients/java/src/main/java/marquez/client/MarquezClient.java
+++ b/clients/java/src/main/java/marquez/client/MarquezClient.java
@@ -115,33 +115,50 @@ public class MarquezClient {
     @Getter public final String value;
   }
 
-  public Lineage getColumnLineage(@NonNull String namespaceName, @NonNull String datasetName) {
-    return getColumnLineage(namespaceName, datasetName, DEFAULT_LINEAGE_GRAPH_DEPTH, false);
+  public Lineage getColumnLineageByDataset(
+      @NonNull String namespaceName, @NonNull String datasetName) {
+    return getColumnLineageByDataset(
+        namespaceName, datasetName, DEFAULT_LINEAGE_GRAPH_DEPTH, false);
   }
 
-  public Lineage getColumnLineage(
+  public Lineage getColumnLineageByDataset(
       @NonNull String namespaceName, @NonNull String datasetName, @NonNull String field) {
-    return getColumnLineage(namespaceName, datasetName, field, DEFAULT_LINEAGE_GRAPH_DEPTH, false);
+    return getColumnLineageByDatasetField(
+        namespaceName, datasetName, field, DEFAULT_LINEAGE_GRAPH_DEPTH, false);
   }
 
-  public Lineage getColumnLineage(
+  public Lineage getColumnLineageByDataset(
       @NonNull String namespaceName,
       @NonNull String datasetName,
       int depth,
       boolean withDownstream) {
     final String bodyAsJson =
-        http.get(url.toColumnLineageUrl(namespaceName, datasetName, depth, withDownstream));
+        http.get(
+            url.toColumnLineageUrlByDataset(namespaceName, datasetName, depth, withDownstream));
     return Lineage.fromJson(bodyAsJson);
   }
 
-  public Lineage getColumnLineage(
+  public Lineage getColumnLineageByDatasetField(
       @NonNull String namespaceName,
       @NonNull String datasetName,
       @NonNull String field,
       int depth,
       boolean withDownstream) {
     final String bodyAsJson =
-        http.get(url.toColumnLineageUrl(namespaceName, datasetName, field, depth, withDownstream));
+        http.get(
+            url.toColumnLineageUrlByDatasetField(
+                namespaceName, datasetName, field, depth, withDownstream));
+    return Lineage.fromJson(bodyAsJson);
+  }
+
+  public Lineage getColumnLineageByJob(@NonNull String namespaceName, @NonNull String jobName) {
+    return getColumnLineageByJob(namespaceName, jobName, DEFAULT_LINEAGE_GRAPH_DEPTH, false);
+  }
+
+  public Lineage getColumnLineageByJob(
+      @NonNull String namespaceName, @NonNull String jobName, int depth, boolean withDownstream) {
+    final String bodyAsJson =
+        http.get(url.toColumnLineageUrlByJob(namespaceName, jobName, depth, withDownstream));
     return Lineage.fromJson(bodyAsJson);
   }
 

--- a/clients/java/src/main/java/marquez/client/MarquezUrl.java
+++ b/clients/java/src/main/java/marquez/client/MarquezUrl.java
@@ -44,6 +44,7 @@ import javax.annotation.Nullable;
 import lombok.NonNull;
 import marquez.client.models.DatasetFieldId;
 import marquez.client.models.DatasetId;
+import marquez.client.models.JobId;
 import marquez.client.models.NodeId;
 import marquez.client.models.RunState;
 import marquez.client.models.SearchFilter;
@@ -210,7 +211,7 @@ class MarquezUrl {
     return from(searchPath(), queryParams.build());
   }
 
-  URL toColumnLineageUrl(
+  URL toColumnLineageUrlByDatasetField(
       String namespace, String dataset, String field, int depth, boolean withDownstream) {
     final ImmutableMap.Builder queryParams = new ImmutableMap.Builder();
     queryParams.put("nodeId", NodeId.of(new DatasetFieldId(namespace, dataset, field)).getValue());
@@ -219,9 +220,18 @@ class MarquezUrl {
     return from(columnLineagePath(), queryParams.build());
   }
 
-  URL toColumnLineageUrl(String namespace, String dataset, int depth, boolean withDownstream) {
+  URL toColumnLineageUrlByDataset(
+      String namespace, String dataset, int depth, boolean withDownstream) {
     final ImmutableMap.Builder queryParams = new ImmutableMap.Builder();
     queryParams.put("nodeId", NodeId.of(new DatasetId(namespace, dataset)).getValue());
+    queryParams.put("depth", String.valueOf(depth));
+    queryParams.put("withDownstream", String.valueOf(withDownstream));
+    return from(columnLineagePath(), queryParams.build());
+  }
+
+  URL toColumnLineageUrlByJob(String namespace, String job, int depth, boolean withDownstream) {
+    final ImmutableMap.Builder queryParams = new ImmutableMap.Builder();
+    queryParams.put("nodeId", NodeId.of(new JobId(namespace, job)).getValue());
     queryParams.put("depth", String.valueOf(depth));
     queryParams.put("withDownstream", String.valueOf(withDownstream));
     return from(columnLineagePath(), queryParams.build());

--- a/clients/java/src/main/java/marquez/client/models/NodeId.java
+++ b/clients/java/src/main/java/marquez/client/models/NodeId.java
@@ -70,6 +70,10 @@ public final class NodeId implements Comparable<NodeId> {
             datasetFieldId.getField()));
   }
 
+  public static NodeId of(@NonNull JobId jobId) {
+    return of(ID_JOINER.join(ID_PREFX_JOB, jobId.getNamespace(), jobId.getName()));
+  }
+
   @JsonIgnore
   public boolean isDatasetFieldType() {
     return value.startsWith(ID_PREFX_DATASET_FIELD);
@@ -78,6 +82,11 @@ public final class NodeId implements Comparable<NodeId> {
   @JsonIgnore
   public boolean isDatasetType() {
     return value.startsWith(ID_PREFX_DATASET + ID_DELIM);
+  }
+
+  @JsonIgnore
+  public boolean isJobType() {
+    return value.startsWith(ID_PREFX_JOB);
   }
 
   @JsonIgnore
@@ -122,6 +131,12 @@ public final class NodeId implements Comparable<NodeId> {
   public DatasetFieldId asDatasetFieldId() {
     String[] parts = parts(4, ID_PREFX_DATASET);
     return new DatasetFieldId(parts[1], parts[2], parts[3]);
+  }
+
+  @JsonIgnore
+  public JobId asJobId() {
+    String[] parts = parts(3, ID_PREFX_JOB);
+    return new JobId(parts[1], parts[2]);
   }
 
   public static class FromValue extends StdConverter<String, NodeId> {

--- a/clients/java/src/test/java/marquez/client/MarquezUrlTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezUrlTest.java
@@ -38,10 +38,12 @@ public class MarquezUrlTest {
   void testToColumnLineageUrl() {
     Assertions.assertEquals(
         "http://marquez:5000/api/v1/column-lineage?nodeId=dataset%3Anamespace%3Adataset&depth=20&withDownstream=true",
-        marquezUrl.toColumnLineageUrl("namespace", "dataset", 20, true).toString());
+        marquezUrl.toColumnLineageUrlByDataset("namespace", "dataset", 20, true).toString());
 
     Assertions.assertEquals(
         "http://marquez:5000/api/v1/column-lineage?nodeId=datasetField%3Anamespace%3Adataset%3Afield&depth=20&withDownstream=true",
-        marquezUrl.toColumnLineageUrl("namespace", "dataset", "field", 20, true).toString());
+        marquezUrl
+            .toColumnLineageUrlByDatasetField("namespace", "dataset", "field", 20, true)
+            .toString());
   }
 }

--- a/clients/java/src/test/java/marquez/client/models/NodeIdTest.java
+++ b/clients/java/src/test/java/marquez/client/models/NodeIdTest.java
@@ -47,4 +47,19 @@ public class NodeIdTest {
     assertEquals(dataset, nodeId.asDatasetFieldId().getDataset());
     assertEquals(field, nodeId.asDatasetFieldId().getField());
   }
+
+  @ParameterizedTest(name = "testJob-{index} {argumentsWithNames}")
+  @CsvSource(
+      value = {"my-namespace$my-job", "org://team$my-job"},
+      delimiter = '$')
+  public void testJob(String namespace, String job) {
+    JobId jobId = new JobId(namespace, job);
+    NodeId nodeId = NodeId.of(jobId);
+    assertTrue(nodeId.isJobType());
+    assertFalse(nodeId.isDatasetType());
+    assertEquals(jobId, nodeId.asJobId());
+    assertEquals(nodeId, NodeId.of(nodeId.getValue()));
+    assertEquals(namespace, nodeId.asJobId().getNamespace());
+    assertEquals(job, nodeId.asJobId().getName());
+  }
 }


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

No endpoint to retrieve column lineage by job. 

Closes: #2185

### Solution

Implement the endpoint. 

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)