### PR TITLE
Cloud Logo 

### DIFF
--- a/web/src/components/header/Header.tsx
+++ b/web/src/components/header/Header.tsx
@@ -46,7 +46,7 @@ const Header = (props: HeaderProps): ReactElement => {
       <Toolbar>
         <Box className={classes.innerToolbar}>
           <Link to='/'>
-            <img src={'/img/marquez_logo.svg'} height={48} alt='Marquez Logo' />
+            <img src={'https://raw.githubusercontent.com/MarquezProject/marquez/main/web/src/img/marquez_logo.svg'} height={48} alt='Marquez Logo' />
           </Link>
           <Box display={'flex'} alignItems={'center'}>
             <Search />


### PR DESCRIPTION
### Problem
We migrated the project to support Node 18 which included several webpack changes. Unfortunately, this broke the display of our main logo. 

### Solution

I referenced the cloud based url in GitHub to fetch the logo. This is a short term solution while we take a longer look at webpack and the asset loaders.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)