### PR TITLE
Show facets even when dataset has no fields.

### DIFF
--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -21,12 +21,10 @@ interface DatasetInfoProps {
 const DatasetInfo: FunctionComponent<DatasetInfoProps> = props => {
   const { datasetFields, facets, run } = props
 
-  if (datasetFields.length === 0) {
-    return <MqEmpty title={'No Fields'} body={'Try adding dataset fields.'} />
-  }
-
   return (
     <Box>
+      {datasetFields.length === 0 && <MqEmpty title={'No Fields'} body={'Try adding dataset fields.'} />}
+      {datasetFields.length > 0 && (
       <Table size='small'>
         <TableHead>
           <TableRow>
@@ -53,6 +51,7 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = props => {
           })}
         </TableBody>
       </Table>
+      )}
       {facets && (
         <Box mt={2}>
           <Box mb={1}>


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

### Problem

Facets are not shown in UI when dataset has no fields set. 

Closes:  #2213 
### Solution

Change logic in DatasetInfo component to always show facets.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)