### PR TITLE
fix symlink table column length

### DIFF
--- a/api/src/main/resources/marquez/db/migration/V48__dataset_symlinks.sql
+++ b/api/src/main/resources/marquez/db/migration/V48__dataset_symlinks.sql
@@ -2,7 +2,7 @@
 
 CREATE TABLE dataset_symlinks (
   dataset_uuid      UUID,
-  name              VARCHAR(255) NOT NULL,
+  name              VARCHAR NOT NULL,
   namespace_uuid    UUID REFERENCES namespaces(uuid),
   type              VARCHAR(64),
   is_primary        BOOLEAN DEFAULT FALSE,

--- a/api/src/main/resources/marquez/db/migration/V52__alter_dataset_symlinks.sql
+++ b/api/src/main/resources/marquez/db/migration/V52__alter_dataset_symlinks.sql
@@ -1,0 +1,2 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+ALTER TABLE dataset_symlinks ALTER COLUMN name TYPE VARCHAR;


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Dataset's name column in `dataset_symlinks` table is shorter than column in `datasets` table. 

Closes: #2216

### Solution

 * Change the existing V48 migration script to allow proper migration for users who did not upgrade yet,
 * Add extra migration script to extend column length for users who did upgrade but did not experience the issues.
 
> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)