### PR TITLE
[Docs] fix typos in root docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,11 @@
 
 * Add support for `parentRun` facet as reported by older Airflow OpenLineage versions [`#2130`](https://github.com/MarquezProject/marquez/pull/2130) [@collado-mike](https://github.com/collado-mike)  
     *Adds a `parentRun` alias to the `LineageEvent` `RunFacet`.*
-* Add fix and tests for handling Airflow DAGs with dots and task groups [`2126`](https://github.com/MarquezProject/marquez/pull/2126) [@collado-mike](https://github.com/collado-mike) [@wslulciuc](https://github.com/wslulciuc)  
+* Add fix and tests for handling Airflow DAGs with dots and task groups [`#2126`](https://github.com/MarquezProject/marquez/pull/2126) [@collado-mike](https://github.com/collado-mike) [@wslulciuc](https://github.com/wslulciuc)  
     *Fixes a recent change that broke how Marquez handles DAGs with dots and tasks within task groups and adds test cases to validate.*
-* Fix version bump in `docker/up.sh` [`2129`](https://github.com/MarquezProject/marquez/pull/2129) [@wslulciuc](https://github.com/wslulciuc)  
+* Fix version bump in `docker/up.sh` [`#2129`](https://github.com/MarquezProject/marquez/pull/2129) [@wslulciuc](https://github.com/wslulciuc)  
     *Defines a `VERSION` variable to bump on a release.*
-* Use `clean` when running `shadowJar` in Dockerfile [`2145`](https://github.com/MarquezProject/marquez/pull/2145) [@wslulciuc](https://github.com/wslulciuc)  
+* Use `clean` when running `shadowJar` in Dockerfile [`#2145`](https://github.com/MarquezProject/marquez/pull/2145) [@wslulciuc](https://github.com/wslulciuc)  
     *Ensures the directory `api/build/libs/` is cleaned before building the JAR again and updates `.dockerignore` to ignore `api/build/*`.*
 * Fix bug that caused a single run event to create multiple jobs [`#2162`](https://github.com/MarquezProject/marquez/pull/2162) [@collado-mike](https://github.com/collado-mike)  
     *Checks to see if a run with the given ID already exists and uses the pre-associated job if so.*

--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -1,5 +1,5 @@
 # Marquez Committers
-The Marquez Committers are the group of people who can accept Pull Request to Marquez.
+The Marquez Committers are the group of people who can accept Pull Requests to Marquez.
 They take responsibility for guiding new pull requests into the main branch.
 
 
@@ -26,7 +26,7 @@ They take responsibility for guiding new pull requests into the main branch.
 ## Emeritus
 
 The following people are no longer working on the Marquez project.
-However they have been a committer in the past and through their
+However, they have been committers in the past and, through their
 contributions, we have a strong foundation to build on.
 
 | Name             | Handle                      |
@@ -34,5 +34,5 @@ contributions, we have a strong foundation to build on.
 
 # Becoming a Committer
 
-A Contributor may become a Committer by a majority approval of the
-existing Committers. (per the project [charter](https://wiki.lfaidata.foundation/download/attachments/18481434/Marquez%20Project%20Technical%20Charter%20Final_Adopted%2005.21.20.pdf?version=1&modificationDate=1591718661000&api=v2))
+A Contributor may become a Committer by the approval of a majority of the
+existing Committers (as per the project [charter](https://wiki.lfaidata.foundation/download/attachments/18481434/Marquez%20Project%20Technical%20Charter%20Final_Adopted%2005.21.20.pdf?version=1&modificationDate=1591718661000&api=v2)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ We use [spotless](https://github.com/diffplug/spotless) to format our code. This
 $ ./gradlew spotlessApply
 ```
 
-> **Note:** To make formatting code simple, we recommend installing a [plugin](https://github.com/google/google-java-format#intellij-android-studio-and-other-jetbrains-ides) for your favorite IDE. We also us [Lombok](https://projectlombok.org). Though not required, you might want to install the [plugin](https://projectlombok.org/setup/overview) as well.
+> **Note:** To make formatting code simple, we recommend installing a [plugin](https://github.com/google/google-java-format#intellij-android-studio-and-other-jetbrains-ides) for your favorite IDE. We also use [Lombok](https://projectlombok.org). Though not required, you might want to install the [plugin](https://projectlombok.org/setup/overview), as well.
 
 # `.git/hooks`
 
@@ -94,7 +94,7 @@ act pull_request --reuse --verbose
 
 # Troubleshooting
 
-There is an issue within the _act_ tool that prevents the _kind_ cluster from being deleted after execution the action.
+There is an issue within the _act_ tool that prevents the _kind_ cluster from being deleted after execution of the action.
 When this condition exists, you will experience the error below.
 
 ```bash
@@ -122,12 +122,12 @@ $ ./gradlew publishToMavenLocal
 1. [Fork](https://github.com/MarquezProject/marquez/fork) and clone the repository
 2. Make sure all tests pass locally: `./gradlew :api:test`
 3. Create a new [branch](#branching): `git checkout -b feature/my-cool-new-feature`
-4. Make change on your cool new branch
+4. Make a change on your cool new branch
 5. Write a test for your change
 6. Make sure `.java` files are formatted: `./gradlew spotlessJavaCheck`
 7. Make sure `.java` files contain a [copyright and license header](#copyright--license)
 8. Make sure to [sign you work](#sign-your-work)
-9. Push change to your fork and [submit a pull request](https://github.com/MarquezProject/marquez/compare)
+9. Push the change to your fork and [submit a pull request](https://github.com/MarquezProject/marquez/compare)
 10. Work with project maintainers to get your change reviewed and merged into the `main` branch
 11. Delete your branch
 
@@ -137,13 +137,13 @@ To ensure your pull request is accepted, follow these guidelines:
 * Do your best to have a [well-formed commit message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) for your change
 * [Keep diffs small](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and self-contained
 * If your change fixes a bug, please [link the issue](https://help.github.com/articles/closing-issues-using-keywords) in your pull request description
-* Any changes to the API reference requires [regenerating](#api-docs) the static `openapi.html` file.
+* Any changes to the API reference require [regenerating](#api-docs) the static `openapi.html` file.
 
 > **Note:** A pull request should generally contain only one commit (use `git commit --amend` and `git push --force` or [squash](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html) existing commits into one).
 
 # Branching
 
-* Use a _group_ at the beginning of your branch names
+* Use a _group_ at the beginning of your branch names:
 
   ```
   feature  Add or expand a feature
@@ -167,10 +167,10 @@ To ensure your pull request is accepted, follow these guidelines:
 # Dependencies
 
 We use [renovate](https://github.com/renovatebot/renovate) to manage dependencies for most of our project modules,
-with a couple of exceptions. Renovate automatically detects new dependency versions, and opens pull
-requests to upgrade dependencies in accordance to the [configured rules](https://github.com/MarquezProject/marquez/blob/main/renovate.json).
+with a couple of exceptions. Renovate automatically detects new dependency versions and opens pull
+requests to upgrade dependencies in accordance with the [configured rules](https://github.com/MarquezProject/marquez/blob/main/renovate.json).
 
-The following dependencies are managed manually
+The following dependencies are managed manually:
 
 * _Web code_ - it is challenging to programmatically validate web content
 * _Spark versions_ - the internal query plans parsed by the Spark OpenLineage integration are not stable across Spark versions
@@ -178,7 +178,7 @@ The following dependencies are managed manually
 
 # Sign Your Work
 
-The _sign-off_ is a simple line at the end of the message for a commit. All commits needs to be signed. Your signature certifies that you wrote the patch or otherwise have the right to contribute the material (see [Developer Certificate of Origin](https://developercertificate.org)):
+The _sign-off_ is a simple line at the end of the message for a commit. All commits need to be signed. Your signature certifies that you wrote the patch or otherwise have the right to contribute the material (see [Developer Certificate of Origin](https://developercertificate.org)):
 
 ```
 This is my commit message
@@ -244,6 +244,6 @@ We use [SPDX](https://spdx.dev) for copyright and license information. The follo
 * [How to Contribute to Open Source](https://opensource.guide/how-to-contribute)
 * [Using the Fork-and-Branch Git Workflow](https://blog.scottlowe.org/2015/01/27/using-fork-branch-git-workflow)
 * [Understanding the GitHub flow](https://guides.github.com/introduction/flow/)
-* [Keep a Changelog](https://keepachangelog.com)
+* [Keeping a Changelog](https://keepachangelog.com)
 * [Code Review Developer Guide](https://google.github.io/eng-practices/review)
 * [Signing Commits](https://docs.github.com/en/github/authenticating-to-github/signing-commits)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Marquez is an open source **metadata service** for the **collection**, **aggrega
 
 ## Status
 
-Marquez is an [LF AI & Data Foundation](https://lfaidata.foundation/projects/marquez) incubation project under active development and we'd love your help!
+Marquez is an [LF AI & Data Foundation](https://lfaidata.foundation/projects/marquez) incubation project under active development, and we'd love your help!
 
 ## Adopters
 
@@ -38,7 +38,7 @@ Want to be added? Send a pull request our way!
 
 ## Quickstart
 
-Marquez provides a simple way to collect and view _dataset_, _job_, and _run_ metadata using [OpenLineage](https://openlineage.io). The easiest way to get up and running is with Docker. From the base of the Marquez repository run:
+Marquez provides a simple way to collect and view _dataset_, _job_, and _run_ metadata using [OpenLineage](https://openlineage.io). The easiest way to get up and running is with Docker. From the base of the Marquez repository, run:
 
 ```
 $ ./docker/up.sh
@@ -58,7 +58,7 @@ You can open [http://localhost:3000](http://localhost:3000) to begin exploring t
 
 **`HTTP API`**
 
-The Marquez [HTTP API](https://marquezproject.github.io/marquez/openapi.html) listens on port `5000` for all calls and port `5001` for the admin interface. The admin interface exposes helpful endpoints like `/healthcheck` and `/metrics`. To verify the HTTP API server is running and listening on `localhost` browse to [http://localhost:5001](http://localhost:5001). To begin collecting lineage metadata as OpenLineage events, use the [LineageAPI](https://marquezproject.github.io/marquez/openapi.html#tag/Lineage/paths/~1lineage/post), or an OpenLineage [integration](https://openlineage.io/integration).
+The Marquez [HTTP API](https://marquezproject.github.io/marquez/openapi.html) listens on port `5000` for all calls and port `5001` for the admin interface. The admin interface exposes helpful endpoints like `/healthcheck` and `/metrics`. To verify the HTTP API server is running and listening on `localhost`, browse to [http://localhost:5001](http://localhost:5001). To begin collecting lineage metadata as OpenLineage events, use the [LineageAPI](https://marquezproject.github.io/marquez/openapi.html#tag/Lineage/paths/~1lineage/post) or an OpenLineage [integration](https://openlineage.io/integration).
 
 > **Note:** By default, the HTTP API does not require any form of authentication or authorization.
 
@@ -81,7 +81,7 @@ Marquez uses a _multi_-project structure and contains the following modules:
 * [`clients`](https://github.com/MarquezProject/marquez/tree/main/clients): clients that implement the HTTP [API](https://marquezproject.github.io/marquez/openapi.html)
 * [`chart`](https://github.com/MarquezProject/marquez/tree/main/chart): helm chart
 
-> **Note:** The `integrations` module was removed in [`0.21.0`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#removed), please use an OpenLineage [integration](https://openlineage.io/integration) to easily collect lineage events.
+> **Note:** The `integrations` module was removed in [`0.21.0`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#removed), so please use an OpenLineage [integration](https://openlineage.io/integration) to collect lineage events easily.
 
 ## Requirements
 
@@ -134,13 +134,13 @@ By default, Marquez uses the following ports:
 ```bash
 $ ./gradlew :api:runShadow
 ```
-Marquez listens on port `8080` for all API calls and port `8081` for the admin interface. To verify the HTTP API server is running and listening on `localhost` browse to [http://localhost:8081](http://localhost:8081). We encourage you to familiarize yourself with the [data model](https://marquezproject.github.io/marquez/#data-model) and [APIs](https://marquezproject.github.io/marquez/openapi.html) of Marquez. To run the web UI, please follow the steps outlined [here](https://github.com/MarquezProject/marquez/tree/main/web#development).
+Marquez listens on port `8080` for all API calls and port `8081` for the admin interface. To verify the HTTP API server is running and listening on `localhost`, browse to [http://localhost:8081](http://localhost:8081). We encourage you to familiarize yourself with the [data model](https://marquezproject.github.io/marquez/#data-model) and [APIs](https://marquezproject.github.io/marquez/openapi.html) of Marquez. To run the web UI, please follow the steps outlined [here](https://github.com/MarquezProject/marquez/tree/main/web#development).
 
 > **Note:** By default, the HTTP API does not require any form of authentication or authorization.
 
 ## Related Projects
 
-* [`OpenLineage`](https://github.com/OpenLineage/OpenLineage): open standard for metadata and lineage collection
+* [`OpenLineage`](https://github.com/OpenLineage/OpenLineage): an open standard for metadata and lineage collection
 
 ## Getting Involved
 


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

A number of minor typos were found in the docs in the root directory (the changelog, COMMITTERS.md, CONTRIBUTING.md, and README.md) -- mostly punctuation issues.

### Solution

This change fixes the minor typos found in these docs.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)