### PR TITLE
Appreciate column prefix when given for ended_at

### DIFF
--- a/api/src/main/java/marquez/db/mappers/RunMapper.java
+++ b/api/src/main/java/marquez/db/mappers/RunMapper.java
@@ -68,7 +68,7 @@ public final class RunMapper implements RowMapper<Run> {
         columnNames.contains(columnPrefix + Columns.STARTED_AT)
             ? timestampOrNull(results, columnPrefix + Columns.STARTED_AT)
             : null,
-        columnNames.contains(Columns.ENDED_AT)
+        columnNames.contains(columnPrefix + Columns.ENDED_AT)
             ? timestampOrNull(results, columnPrefix + Columns.ENDED_AT)
             : null,
         durationMs.orElse(null),


### PR DESCRIPTION
Signed-off-by: Minkyu Park <minkyu.park.200@gmail.com>

### Problem
`ended_at` column is always null when querying if the `columnPrefix` is given for the mapper.

### Solution
Include `columnPrefix` when checking column existence.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)