### PR TITLE
add governance and dco docs

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,146 @@
+# Marquez Governance
+
+Marquez is an open source **metadata service** for the **collection**, **aggregation**, and **visualization** of a data ecosystem's metadata. It maintains the provenance of how datasets are consumed and produced, provides global visibility into job runtime and frequency of dataset access, centralization of dataset lifecycle management, and much more.
+
+A project of this scope requires input from a wide range of subject matter experts with different backgrounds and allegiances.
+As such we need a set of principles, roles and operating practices to ensure the results of our contributions are useful,
+have high quality and are widely consumable.
+
+## General principles
+
+The principles set the tone of the operation of Marquez:
+
+* The activities of the project ensure open collaboration.
+Through this open collaboration we aim to build a community of people who are interested in the success of the project.
+* The scope of the content is determined by the individuals who are actively contributing.
+* The resulting content is licensed under the Apache 2.0 license.
+* An individual's privileges and position is awarded through their contribution and engagement.
+
+These principles should be respected as the procedures used to manage the Marquez project are evolved and matured.
+
+## Marquez community members
+
+Anyone can become a member of the Marquez community by signing up to the
+the Marquez mailing list, joining the Slack community, attending the virtual community meetings
+or contributing content to one or more of the GitHub repositories.
+
+The [Contribution Guide](CONTRIBUTING.md) describes how to connect to these channels.
+
+All participants in the Marquez community are bound by the project's
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+As a member you are able to attend our meetings, just to listen, or to play an active part in the discussion.
+The online meetings are recorded to allow community members to catch up if they are not able to attend the live meeting.
+When you attend the community meetings specifically, your name will be recorded in the meeting minutes along with any remarks or suggestions you make.
+The agenda and minutes of our community meetings are publicly available on the [wiki](https://wiki.lfaidata.foundation/display/MAR/Marquez+Home).
+
+A member may make contributions to the Marquez content by submitting a
+GitHub pull request on the appropriate Git repository.
+This will be reviewed and processed by the **Marquez committers**.
+
+Each contribution is signed by the contributor to confirm they
+agree to our [Developer Certificate of Origin (DCO)](why-the-dco.md).
+
+Community members can progress to be **Marquez Contributors** and then **Marquez Committers**.
+
+### Marquez contributors
+
+Marquez contributors are members who have actively taken additional steps to promote and foster the success of Marquez and its acceptance/adoption across the IT community. The activities that contributors engage in might include:
+
+* Provide best practices for information governance, lineage, metadata management and other related disciplines during active discussions and/or development of material
+* Actively participate in meetings and discussions
+* Promote the goals of Marquez and the benefits of open metadata to the IT community (deliver presentations, informal talks, assist at trade shows, independent blogs, etc.)
+* Assist in the recruitment of new members
+* Contribute where appropriate to documentation and code reviews, specification development, demonstration assets and other artifacts that help move Marquez forward
+
+### Marquez project committers
+
+Committers are members of the Marquez community who have permission to change the Marquez content.
+This may be content that they have created themselves, or has been provided by another member.
+Committers also have responsibility for helping other project members with their contributions.
+This includes:
+* Monitoring email aliases.
+* Monitoring Slack (delayed response is perfectly acceptable).
+* Triaging GitHub issues and performing pull request reviews for other maintainers and the community.
+* Making sure that ongoing Git pull requests are moving forward at the right pace or closing them.
+
+#### How to become a committer
+
+New committers are voted onto the committers list by the existing committers. For the current list, see:
+[COMMITTERS.md](COMMITTERS.md).
+
+The committers vote, and if a majority agree then the requester
+is added to the committers list and given write access to the Git repositories.
+
+Once confirmed, you can publicly refer to yourself as a Marquez committer.
+
+#### When does a committer lose maintainer status
+
+If a committer is no longer interested or cannot perform the committer duties listed above, they
+should volunteer to be moved to emeritus status. In extreme cases this can also occur by a vote of
+the committers per the voting process below.
+Emeritus committers can rejoin the committer list through a vote of the
+existing committers.
+
+### Marquez leadership
+
+The leadership of Marquez is granted through a vote of the Marquez committers.
+Marquez is currently led by Willy Lulciuc.
+
+## Marquez project meetings
+
+Some meetings are face-to-face, but most are conference calls.  
+Attendance at meetings is open to all.  Conference calls can be joined without an explicit invitation.
+However, due to physical security requirements at some of the venues we use,
+it is necessary to ensure you are added to the invitee list of any face-to-face meetings
+that you wish to attend and complete the necessary formalities for the venue.
+
+For example, the face-to-face meeting may be at a conference that requires you to register for the conference to attend.
+Or a meeting may be at an organization's offices that are required to maintain a list of everyone on site.
+
+## Marquez on Slack
+
+Marquez uses [a Slack community](http://bit.ly/MarquezSlack) to provide an ongoing dialogue between members.
+This creates a recorded discussion of design decisions and discussions that complement the project meetings.
+
+Follow the link above and register with the Slack service using your email address.
+Once signed in you can see all of the active Slack channels.
+
+Additional channels are added from time to time as new workgroups and discussion topics are established. 
+
+## Marquez email
+
+Marquez uses a [discussion list](https://lists.lfaidata.foundation/g/marquez-announce)
+for more general discussion.
+
+## Marquez content management tools
+
+The Marquez content is managed in GitHub under [https://github.com/MarquezProject/marquez](https://github.com/MarquezProject/marquez).
+It may be developed using patches, branches from main, or forks/git pull requests.
+Each change should have a [GitHub issue](https://github.com/MarquezProject/marquez/issues) explaining why the change is being made.
+See: [CONTRIBUTING.md](CONTRIBUTING.md)
+
+When new content proposed to the project, the person contributing is required to sign the contribution
+to confirm it conforms to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+
+## Marquez project releases
+
+The Marquez team aim to create regular official release of Marquez.
+
+In between official releases, the latest build is also available to developers on GitHub.
+
+### Release cadence and process
+
+For details about the timing and authorization of releases, see: [RELEASING.md](RELEASING.md).
+
+## Conflict resolution and voting
+
+In general, we prefer that technical issues and committer membership are amicably worked out
+between the persons involved. If a dispute cannot be decided independently, the committers can be
+called in to decide an issue. If the committers themselves cannot decide an issue, the issue will
+be resolved by voting. The voting process is a simple majority in which each committer receives one vote.
+
+
+----
+License: Apache-2.0, 
+Copyright 2018-2022 contributors to the Marquez project.

--- a/README.md
+++ b/README.md
@@ -152,3 +152,7 @@ Marquez listens on port `8080` for all API calls and port `8081` for the admin i
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md) for more details about how to contribute.
+
+## Reporting a Vulnerability
+
+If you discover a vulnerability in the project, please open an issue and attach the "security" label.

--- a/why-the-dco.md
+++ b/why-the-dco.md
@@ -1,0 +1,32 @@
+# Why the DCO?
+
+We have tried to make it as easy as possible to make contributions. 
+This applies to how we handle the legal aspects of contribution.
+
+We simply ask that when submitting a patch for review,
+the developer must include a sign-off statement in the commit message.
+This is the same approach that the
+[Linux® Kernel community](http://elinux.org/Developer_Certificate_Of_Origin)
+uses to manage code contributions.
+
+Here is an example Signed-off-by line, which indicates that the submitter accepts the DCO:
+
+```
+Signed-off-by: John Doe <john.doe@hisdomain.com>
+```
+
+You can include this automatically when you commit a change
+to your local git repository using
+
+```bash
+$ git commit -s
+```
+
+By signing your work, you are confirming that the origin of the content
+makes it suitable to add to this project.  See
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+
+
+----
+License: Apache-2.0, 
+Copyright 2018-2022 contributors to the Marquez project.


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

To graduate from the LFAI & Data program, the project needs to feature a governance doc outlining policies concerning electing committers, communicating with members, and so on. 

### Solution

This change adds a `GOVERNANCE.md` and a supporting `why-the-dco.md` doc to the project to meet this requirement. Also included: a vulnerability reporting section in the main readme to meet additional LFAI requirements.

Closes: #2220 

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)