### PR TITLE
add code quality doc to project

### DIFF
--- a/CODE_QUALITY_AND_SECURITY.md
+++ b/CODE_QUALITY_AND_SECURITY.md
@@ -1,0 +1,30 @@
+# Code Quality and Security Assurance Statement
+
+The authors of Marquez are committed to providing secure software of the highest quality possible. To this end, we employ a number of tools and methodologies to ensure that our design, build, maintenance and testing practices maximize efficiency and minimize risk.
+
+The specific security and analysis methodologies that we employ include but are not limited to: 
+
+## Security
+
+- Participation in the [OpenSSF Best Practices Badge Program](https://bestpractices.coreinfrastructure.org/en/projects/5106) for Free/Libre and FLOSS projects to ensure that we follow current best practices for quality and security
+- Use of [HTTPS](https://en.wikipedia.org/wiki/HTTPS) for network communication 
+- Support for multiple cryptographic algorithms (through the use of HTTPS)
+- Separate storage of authentication credentials according to best practices
+- Use of secure protocols for network communication (through the use of HTTPS)
+- Up-to-date support for TLS/SSL (through the use of [OpenSSL](https://www.openssl.org/))
+- Performance of TLS certificate verification by default before sending HTTP headers with private information (through the use of OpenSSL and HTTPS)
+- Distribution of the software via cryptographically signed releases (on the [PyPI](https://pypi.org/) and [Maven](https://mvnrepository.com/) package repositories)
+- Use of [GitHub](https://github.com/) Issues for vulnerability reporting and tracking
+
+## Analysis
+
+- Use of [PMD](https://pmd.github.io/) and [Spotless](https://github.com/diffplug/spotless) for Java code linting on pull requests and builds
+- Use of [Flake8](https://flake8.pycqa.org/en/latest/) and [Pytest](https://docs.pytest.org/en/7.2.x/) for Python code linting on pull requests and builds
+- Use of GitHub Issues for bug reporting and tracking
+
+## Contact
+
+For more information about our approach to quality and security, feel free to reach out to the Marquez development team:
+
+- Slack: [Marquezproject.slack.com](http://bit.ly/MarquezSlack)
+- Twitter: [@MarquezProject](https://twitter.com/MarquezProject)


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

That the project has a code quality assurance document is a requirement of the LFAI.

### Solution

This will add such a document to the project.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)