### PR TITLE
Set `--allow-releaseinfo-change`

### DIFF
--- a/.circleci/get-jdk17.sh
+++ b/.circleci/get-jdk17.sh
@@ -14,7 +14,7 @@
 #
 # Usage: $ ./get-jdk17.sh
 
-set -e
+set -ex
 
 wget -qO - https://adoptium.jfrog.io/adoptium/api/gpg/key/public | sudo apt-key add -
 sudo add-apt-repository --yes https://adoptium.jfrog.io/adoptium/deb

--- a/.circleci/get-jdk17.sh
+++ b/.circleci/get-jdk17.sh
@@ -14,7 +14,7 @@
 #
 # Usage: $ ./get-jdk17.sh
 
-set -ex
+set -x
 
 wget -qO - https://adoptium.jfrog.io/adoptium/api/gpg/key/public | sudo apt-key add -
 sudo add-apt-repository --yes https://adoptium.jfrog.io/adoptium/deb

--- a/.circleci/get-jdk17.sh
+++ b/.circleci/get-jdk17.sh
@@ -14,8 +14,6 @@
 #
 # Usage: $ ./get-jdk17.sh
 
-set -x
-
 wget -qO - https://adoptium.jfrog.io/adoptium/api/gpg/key/public | sudo apt-key add -
 sudo add-apt-repository --yes https://adoptium.jfrog.io/adoptium/deb
 sudo apt-get update --allow-releaseinfo-change && sudo apt-get install --yes temurin-17-jdk

--- a/.circleci/get-jdk17.sh
+++ b/.circleci/get-jdk17.sh
@@ -17,8 +17,8 @@
 set -e
 
 wget -qO - https://adoptium.jfrog.io/adoptium/api/gpg/key/public | sudo apt-key add -
-sudo add-apt-repository --yes https://adoptium.jfrog.io/adoptium/deb
-sudo apt-get update --allow-releaseinfo-change && sudo apt-get install temurin-17-jdk
+sudo add-apt-repository --yes --allow-releaseinfo-change https://adoptium.jfrog.io/adoptium/deb
+sudo apt-get update && sudo apt-get install temurin-17-jdk
 sudo update-alternatives --set java /usr/lib/jvm/temurin-17-jdk-amd64/bin/java
 sudo update-alternatives --set javac /usr/lib/jvm/temurin-17-jdk-amd64/bin/javac
 java -version

--- a/.circleci/get-jdk17.sh
+++ b/.circleci/get-jdk17.sh
@@ -18,7 +18,7 @@ set -e
 
 wget -qO - https://adoptium.jfrog.io/adoptium/api/gpg/key/public | sudo apt-key add -
 sudo add-apt-repository --yes https://adoptium.jfrog.io/adoptium/deb
-sudo apt-get update && sudo apt-get install temurin-17-jdk
+sudo apt-get update --allow-releaseinfo-change && sudo apt-get install temurin-17-jdk
 sudo update-alternatives --set java /usr/lib/jvm/temurin-17-jdk-amd64/bin/java
 sudo update-alternatives --set javac /usr/lib/jvm/temurin-17-jdk-amd64/bin/javac
 java -version

--- a/.circleci/get-jdk17.sh
+++ b/.circleci/get-jdk17.sh
@@ -17,8 +17,8 @@
 set -e
 
 wget -qO - https://adoptium.jfrog.io/adoptium/api/gpg/key/public | sudo apt-key add -
-sudo add-apt-repository --yes --allow-releaseinfo-change https://adoptium.jfrog.io/adoptium/deb
-sudo apt-get update && sudo apt-get install temurin-17-jdk
+sudo add-apt-repository --yes https://adoptium.jfrog.io/adoptium/deb
+sudo apt-get update --allow-releaseinfo-change && sudo apt-get install --yes temurin-17-jdk
 sudo update-alternatives --set java /usr/lib/jvm/temurin-17-jdk-amd64/bin/java
 sudo update-alternatives --set javac /usr/lib/jvm/temurin-17-jdk-amd64/bin/javac
 java -version


### PR DESCRIPTION
### Problem

CI fails with error:

```
...
reading package lists... Done                   
E: Repository 'https://cli-assets.heroku.com/apt ./ InRelease' changed its 'Origin' value from 'Heroku' to 'Jeff Dickey @jdxcode'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
```

### Solution

Use [`--allow-releaseinfo-change`](https://www.linuxtutorials.org/This-must-be-accepted-explicitly-before-updates-for-this-repository-can-be-applied-See-apt-secure-8-manpage-for-details/) to accept the repository changed some information.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)