### PR TITLE
[DOCS] Add deployment security expectations

### DIFF
--- a/CODE_QUALITY_AND_SECURITY.md
+++ b/CODE_QUALITY_AND_SECURITY.md
@@ -1,0 +1,30 @@
+# Code Quality and Security Assurance Statement
+
+The authors of Marquez are committed to providing secure software of the highest quality possible. To this end, we employ a number of tools and methodologies to ensure that our design, build, maintenance and testing practices maximize efficiency and minimize risk.
+
+The specific security and analysis methodologies that we employ include but are not limited to: 
+
+## Security
+
+- Participation in the [OpenSSF Best Practices Badge Program](https://bestpractices.coreinfrastructure.org/en/projects/5106) for Free/Libre and FLOSS projects to ensure that we follow current best practices for quality and security
+- Use of [HTTPS](https://en.wikipedia.org/wiki/HTTPS) for network communication 
+- Support for multiple cryptographic algorithms (through the use of HTTPS)
+- Separate storage of authentication credentials according to best practices
+- Use of secure protocols for network communication (through the use of HTTPS)
+- Up-to-date support for TLS/SSL (through the use of [OpenSSL](https://www.openssl.org/))
+- Performance of TLS certificate verification by default before sending HTTP headers with private information (through the use of OpenSSL and HTTPS)
+- Distribution of the software via cryptographically signed releases (on the [PyPI](https://pypi.org/) and [Maven](https://mvnrepository.com/) package repositories)
+- Use of [GitHub](https://github.com/) Issues for vulnerability reporting and tracking
+
+## Analysis
+
+- Use of [PMD](https://pmd.github.io/) and [Spotless](https://github.com/diffplug/spotless) for Java code linting on pull requests and builds
+- Use of [Flake8](https://flake8.pycqa.org/en/latest/) and [Pytest](https://docs.pytest.org/en/7.2.x/) for Python code linting on pull requests and builds
+- Use of GitHub Issues for bug reporting and tracking
+
+## Contact
+
+For more information about our approach to quality and security, feel free to reach out to the Marquez development team:
+
+- Slack: [Marquezproject.slack.com](http://bit.ly/MarquezSlack)
+- Twitter: [@MarquezProject](https://twitter.com/MarquezProject)

--- a/docs/deployment-overview.md
+++ b/docs/deployment-overview.md
@@ -8,15 +8,17 @@ layout: deployment-overview
 
 Marquez uses [Helm](https://helm.sh) to manage deployments onto [Kubernetes](https://kubernetes.io) in a cloud environment. The chart and templates for the [HTTP API](https://github.com/MarquezProject/marquez/tree/main/api) server and [Web UI](https://github.com/MarquezProject/marquez/tree/main/web) are maintained in the Marquez [repository](https://github.com/MarquezProject/marquez) and can be found in the [chart](https://github.com/MarquezProject/marquez/tree/main/chart) directory. The chart's base [`values.yaml`](https://github.com/MarquezProject/marquez/blob/main/chart/values.yaml#L183) file includes an option to easily override deployment [settings](https://github.com/MarquezProject/marquez/tree/main/chart#configuration).
 
-> **Note:** The Marquez HTTP API server and Web UI images are publshed to [DockerHub](https://hub.docker.com/r/marquezproject/marquez).
+> **Note:** The Marquez HTTP API server and Web UI images are published to [DockerHub](https://hub.docker.com/r/marquezproject/marquez).
 
 ### `TLS/HTTPS`
 
-To enable HTTPS traffic when deploying Marquez onto Kubernetes, use the flag [`ingress.enabled`](https://github.com/MarquezProject/marquez/tree/main/chart#ingress-parameters) to confgure the ingress controller. Then, to secure ingress traffic, use the [`ingress.tls`](https://github.com/MarquezProject/marquez/tree/main/chart#ingress-parameters) section by defining your TLS `secret` and `hosts` (see the `ingress` section the chart's base [`values.yaml`](https://github.com/MarquezProject/marquez/blob/main/chart/values.yaml#L183) for more details).
+To enable HTTPS traffic when deploying Marquez onto Kubernetes, use the flag [`ingress.enabled`](https://github.com/MarquezProject/marquez/tree/main/chart#ingress-parameters) to configure the ingress controller. To secure ingress traffic, use the [`ingress.tls`](https://github.com/MarquezProject/marquez/tree/main/chart#ingress-parameters) section to define your TLS `secret` and `hosts` (see `ingress` in the chart's base [`values.yaml`](https://github.com/MarquezProject/marquez/blob/main/chart/values.yaml#L183) for more details).
 
 ## Database
 
 The Marquez [HTTP API](https://marquezproject.github.io/marquez/openapi.html) server relies only on PostgreSQL to store dataset, job, and run metadata allowing for minimal operational overhead. We recommend a cloud provided databases, such as AWS [RDS](https://aws.amazon.com/rds/postgresql), when deploying Marquez onto Kubernetes.
+
+> **Note:** We encourage enabling encryption at rest when provisioning your cloud provided database.
 
 ## Architecture
 
@@ -48,7 +50,9 @@ The Marquez [HTTP API](https://marquezproject.github.io/marquez/openapi.html) se
 
 ## Authentication
 
-Our [clients](https://github.com/MarquezProject/marquez/tree/main/clients) support authentication by automatically sending an API key on each request via [_Bearer Auth_](https://datatracker.ietf.org/doc/html/rfc6750) when configured on client instantiation. By default, the Marquez HTTP API does not require any form of authentication or authorization.
+Our [clients](https://github.com/MarquezProject/marquez/tree/main/clients) support authentication by automatically sending an API key on each request via [_Bearer Auth_](https://datatracker.ietf.org/doc/html/rfc6750) when configured on client instantiation.
+
+> **Note:**  By default, the Marquez HTTP API server does not require any form of authentication or authorization.
 
 ## Next Steps
 

--- a/docs/deployment-overview.md
+++ b/docs/deployment-overview.md
@@ -6,9 +6,13 @@ layout: deployment-overview
 
 ## Helm Chart
 
-Marquez uses [Helm](https://helm.sh) to manage deployments onto [Kubernetes](https://kubernetes.io) in a cloud environment. The chart and templates for the [HTTP API](https://github.com/MarquezProject/marquez/tree/main/api) server and [Web UI](https://github.com/MarquezProject/marquez/tree/main/web) are maintained in the Marquez [repository](https://github.com/MarquezProject/marquez) and can be found in the [chart](https://github.com/MarquezProject/marquez/tree/main/chart) directory. The chart's base `values.yaml` file includes an option to easily override deployment [settings](https://github.com/MarquezProject/marquez/tree/main/chart#configuration).
+Marquez uses [Helm](https://helm.sh) to manage deployments onto [Kubernetes](https://kubernetes.io) in a cloud environment. The chart and templates for the [HTTP API](https://github.com/MarquezProject/marquez/tree/main/api) server and [Web UI](https://github.com/MarquezProject/marquez/tree/main/web) are maintained in the Marquez [repository](https://github.com/MarquezProject/marquez) and can be found in the [chart](https://github.com/MarquezProject/marquez/tree/main/chart) directory. The chart's base [`values.yaml`](https://github.com/MarquezProject/marquez/blob/main/chart/values.yaml#L183) file includes an option to easily override deployment [settings](https://github.com/MarquezProject/marquez/tree/main/chart#configuration).
 
 > **Note:** The Marquez HTTP API server and Web UI images are publshed to [DockerHub](https://hub.docker.com/r/marquezproject/marquez).
+
+### `TLS/HTTPS`
+
+To enable HTTPS traffic when deploying Marquez onto Kubernetes, use the flag [`ingress.enabled`](https://github.com/MarquezProject/marquez/tree/main/chart#ingress-parameters) to confgure the ingress controller. Then, to secure ingress traffic, use the [`ingress.tls`](https://github.com/MarquezProject/marquez/tree/main/chart#ingress-parameters) section by defining your TLS `secret` and `hosts` (see the `ingress` section the chart's base [`values.yaml`](https://github.com/MarquezProject/marquez/blob/main/chart/values.yaml#L183) for more details).
 
 ## Database
 

--- a/docs/deployment-overview.md
+++ b/docs/deployment-overview.md
@@ -18,7 +18,7 @@ To enable HTTPS traffic when deploying Marquez onto Kubernetes, use the flag [`i
 
 The Marquez [HTTP API](https://marquezproject.github.io/marquez/openapi.html) server relies only on PostgreSQL to store dataset, job, and run metadata allowing for minimal operational overhead. We recommend a cloud provided databases, such as AWS [RDS](https://aws.amazon.com/rds/postgresql), when deploying Marquez onto Kubernetes.
 
-> **Note:** We encourage enabling encryption at rest when provisioning your cloud provided database.
+> **Note:** We encourage enabling encryption at rest when provisioning your database.
 
 ## Architecture
 


### PR DESCRIPTION
### Problem

Our [Deployment Overview](https://marquezproject.github.io/marquez/deployment-overview.html) page is missing deployment security expectations.

### Solution

Add missing deployment security expectations to our [Deployment Overview](https://marquezproject.github.io/marquez/deployment-overview.html) page.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)