### PR TITLE
Allow null column type in column-lineage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
 ## [Unreleased](https://github.com/MarquezProject/marquez/compare/0.28.0...HEAD)
+
+### Added
+
 * Column-lineage endpoints supports point-in-time requests [`#2265`](https://github.com/MarquezProject/marquez/pull/2265) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
     *Enable requesting `column-lineage` endpoint by a dataset version, job version or dataset field of a specific dataset version.*
 
+### Fixed
+
+* Allow null column type in column-lineage [`#2272`](https://github.com/MarquezProject/marquez/pull/2272) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
 * Include error message for JSON processing exception [`#2271`](https://github.com/MarquezProject/marquez/pull/2271) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
     *In case of JSON processing exceptions Marquez API should return exception message to a client.*
 

--- a/api/src/main/java/marquez/db/mappers/ColumnLineageNodeDataMapper.java
+++ b/api/src/main/java/marquez/db/mappers/ColumnLineageNodeDataMapper.java
@@ -39,7 +39,7 @@ public class ColumnLineageNodeDataMapper implements RowMapper<ColumnLineageNodeD
         stringOrThrow(results, Columns.DATASET_NAME),
         uuidOrThrow(results, Columns.DATASET_VERSION_UUID),
         stringOrThrow(results, Columns.FIELD_NAME),
-        stringOrThrow(results, Columns.TYPE),
+        stringOrNull(results, Columns.TYPE),
         stringOrNull(results, TRANSFORMATION_DESCRIPTION),
         stringOrNull(results, TRANSFORMATION_TYPE),
         toInputFields(results, "inputFields"));

--- a/api/src/main/java/marquez/db/models/ColumnLineageNodeData.java
+++ b/api/src/main/java/marquez/db/models/ColumnLineageNodeData.java
@@ -19,7 +19,7 @@ public class ColumnLineageNodeData implements NodeData {
   @NonNull String dataset;
   @Nullable UUID datasetVersion;
   @NonNull String field;
-  @NonNull String fieldType;
+  @Nullable String fieldType;
   String transformationDescription;
   String transformationType;
   @NonNull List<InputFieldNodeData> inputFields;

--- a/api/src/test/java/marquez/db/ColumnLineageDaoTest.java
+++ b/api/src/test/java/marquez/db/ColumnLineageDaoTest.java
@@ -474,6 +474,15 @@ public class ColumnLineageDaoTest {
         .isEqualTo(lineageRow.getInputs().get().get(0).getDatasetVersionRow().getUuid());
   }
 
+  @Test
+  void testGetLineageWhenDataTypeIsEmpty() {
+    Dataset datasetWithNullDataType = getDatasetB();
+    datasetWithNullDataType.getFacets().getSchema().getFields().get(0).setType(null);
+
+    UpdateLineageRow lineageRow = createLineage(openLineageDao, dataset_A, datasetWithNullDataType);
+    getColumnLineage(lineageRow, "col_c");
+  }
+
   private Set<ColumnLineageNodeData> getColumnLineage(UpdateLineageRow lineageRow, String field) {
     UpdateLineageRow.DatasetRecord datasetRecord = lineageRow.getOutputs().get().get(0);
     UUID field_UUID = fieldDao.findUuid(datasetRecord.getDatasetRow().getUuid(), field).get();


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Column lineage endpoint throw an exception when no data type of the field provided.

Closes: #2261

### Solution

Write a test for this scenario, allow null. 

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)