### PR TITLE
Add raw link to `iconSearchArrow.svg`

### DIFF
--- a/web/src/components/sidenav/Sidenav.tsx
+++ b/web/src/components/sidenav/Sidenav.tsx
@@ -78,7 +78,7 @@ class Sidenav extends React.Component<SidenavProps> {
                 active={this.props.location.pathname === '/events'}
               >
                 <SVG
-                  src="../../img/iconSearchArrow.svg"
+                  src="https://raw.githubusercontent.com/MarquezProject/marquez/main/web/src/img/iconSearchArrow.svg"
                   width={'30px'}
                 />
               </MqIconButton>


### PR DESCRIPTION
### Problem

The `iconSearchArrow.svg` fails to load for relative path in nav bar.

### Solution

Add direct link to `iconSearchArrow.svg` similar to https://github.com/MarquezProject/marquez/pull/2212

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)