### PR TITLE
fix column lineage when multiple jobs write to same dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * Allow null column type in column-lineage [`#2272`](https://github.com/MarquezProject/marquez/pull/2272) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
 * Include error message for JSON processing exception [`#2271`](https://github.com/MarquezProject/marquez/pull/2271) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
     *In case of JSON processing exceptions Marquez API should return exception message to a client.*
+* Fix column lineage when multiple jobs write to same dataset [`#2289`](https://github.com/MarquezProject/marquez/pull/2289) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+    *The fix deprecates the way fields `transformationDescription` and `transformationType` are returned. The depracated way of returning those fields will be removed in 0.30.0.*
 
 ## [0.28.0](https://github.com/MarquezProject/marquez/compare/0.27.0...0.28.0) - 2022-11-21
 

--- a/api/src/main/java/marquez/db/ColumnLineageDao.java
+++ b/api/src/main/java/marquez/db/ColumnLineageDao.java
@@ -146,12 +146,15 @@ public interface ColumnLineageDao extends BaseDao {
                 output_fields.dataset_name,
                 output_fields.field_name,
                 output_fields.type,
-                ARRAY_AGG(DISTINCT ARRAY[input_fields.namespace_name, input_fields.dataset_name, CAST(clr.input_dataset_version_uuid AS VARCHAR), input_fields.field_name]) AS inputFields,
-                clr.output_dataset_version_uuid as dataset_version_uuid,
-                clr.transformation_description,
-                clr.transformation_type,
-                clr.created_at,
-                clr.updated_at
+                ARRAY_AGG(DISTINCT ARRAY[
+                  input_fields.namespace_name,
+                  input_fields.dataset_name,
+                  CAST(clr.input_dataset_version_uuid AS VARCHAR),
+                  input_fields.field_name,
+                  clr.transformation_description,
+                  clr.transformation_type
+                ]) AS inputFields,
+                clr.output_dataset_version_uuid as dataset_version_uuid
             FROM column_lineage_recursive clr
             INNER JOIN dataset_fields_view output_fields ON clr.output_dataset_field_uuid = output_fields.uuid -- hidden datasets will be filtered
             LEFT JOIN dataset_fields_view input_fields ON clr.input_dataset_field_uuid = input_fields.uuid
@@ -161,11 +164,7 @@ public interface ColumnLineageDao extends BaseDao {
                 output_fields.dataset_name,
                 output_fields.field_name,
                 output_fields.type,
-                clr.output_dataset_version_uuid,
-                clr.transformation_description,
-                clr.transformation_type,
-                clr.created_at,
-                clr.updated_at
+                clr.output_dataset_version_uuid
           """)
   Set<ColumnLineageNodeData> getLineage(
       int depth,
@@ -193,12 +192,15 @@ public interface ColumnLineageDao extends BaseDao {
           output_fields.dataset_name,
           output_fields.field_name,
           output_fields.type,
-          ARRAY_AGG(DISTINCT ARRAY[input_fields.namespace_name, input_fields.dataset_name, CAST(c.input_dataset_version_uuid AS VARCHAR), input_fields.field_name]) AS inputFields,
-          c.output_dataset_version_uuid as dataset_version_uuid,
-          c.transformation_description,
-          c.transformation_type,
-          c.created_at,
-          c.updated_at
+          ARRAY_AGG(DISTINCT ARRAY[
+            input_fields.namespace_name,
+            input_fields.dataset_name,
+            CAST(c.input_dataset_version_uuid AS VARCHAR),
+            input_fields.field_name,
+            c.transformation_description,
+            c.transformation_type
+          ]) AS inputFields,
+          null as dataset_version_uuid
         FROM selected_column_lineage c
         INNER JOIN dataset_fields_view output_fields ON c.output_dataset_field_uuid = output_fields.uuid
         LEFT JOIN dataset_fields_view input_fields ON c.input_dataset_field_uuid = input_fields.uuid
@@ -206,12 +208,7 @@ public interface ColumnLineageDao extends BaseDao {
           output_fields.namespace_name,
           output_fields.dataset_name,
           output_fields.field_name,
-          output_fields.type,
-          c.output_dataset_version_uuid,
-          c.transformation_description,
-          c.transformation_type,
-          c.created_at,
-          c.updated_at
+          output_fields.type
       """)
   /**
    * Each dataset is identified by a pair of strings (namespace and name). A query returns column

--- a/api/src/main/java/marquez/db/mappers/ColumnLineageNodeDataMapper.java
+++ b/api/src/main/java/marquez/db/mappers/ColumnLineageNodeDataMapper.java
@@ -5,11 +5,9 @@
 
 package marquez.db.mappers;
 
-import static marquez.db.Columns.TRANSFORMATION_DESCRIPTION;
-import static marquez.db.Columns.TRANSFORMATION_TYPE;
 import static marquez.db.Columns.stringOrNull;
 import static marquez.db.Columns.stringOrThrow;
-import static marquez.db.Columns.uuidOrThrow;
+import static marquez.db.Columns.uuidOrNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -37,11 +35,9 @@ public class ColumnLineageNodeDataMapper implements RowMapper<ColumnLineageNodeD
     return new ColumnLineageNodeData(
         stringOrThrow(results, Columns.NAMESPACE_NAME),
         stringOrThrow(results, Columns.DATASET_NAME),
-        uuidOrThrow(results, Columns.DATASET_VERSION_UUID),
+        uuidOrNull(results, Columns.DATASET_VERSION_UUID),
         stringOrThrow(results, Columns.FIELD_NAME),
         stringOrNull(results, Columns.TYPE),
-        stringOrNull(results, TRANSFORMATION_DESCRIPTION),
-        stringOrNull(results, TRANSFORMATION_TYPE),
         toInputFields(results, "inputFields"));
   }
 
@@ -57,7 +53,10 @@ public class ColumnLineageNodeDataMapper implements RowMapper<ColumnLineageNodeD
     return ImmutableList.copyOf(
         Arrays.asList(deserializedArray).stream()
             .map(o -> (String[]) o)
-            .map(arr -> new InputFieldNodeData(arr[0], arr[1], UUID.fromString(arr[2]), arr[3]))
+            .map(
+                arr ->
+                    new InputFieldNodeData(
+                        arr[0], arr[1], UUID.fromString(arr[2]), arr[3], arr[4], arr[5]))
             .collect(Collectors.toList()));
   }
 }

--- a/api/src/main/java/marquez/db/models/ColumnLineageNodeData.java
+++ b/api/src/main/java/marquez/db/models/ColumnLineageNodeData.java
@@ -5,22 +5,63 @@
 
 package marquez.db.models;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
 import javax.annotation.Nullable;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
+import marquez.service.models.ColumnLineageInputField;
 
 @Getter
-@AllArgsConstructor
 public class ColumnLineageNodeData implements NodeData {
   @NonNull String namespace;
   @NonNull String dataset;
   @Nullable UUID datasetVersion;
   @NonNull String field;
   @Nullable String fieldType;
-  String transformationDescription;
-  String transformationType;
+  @Nullable String transformationDescription;
+  @Nullable String transformationType;
   @NonNull List<InputFieldNodeData> inputFields;
+
+  public ColumnLineageNodeData(
+      String namespace,
+      String dataset,
+      UUID datasetVersion,
+      String field,
+      String fieldType,
+      ImmutableList<InputFieldNodeData> inputFields) {
+    this.namespace = namespace;
+    this.dataset = dataset;
+    this.datasetVersion = datasetVersion;
+    this.field = field;
+    this.fieldType = fieldType;
+    this.inputFields = inputFields;
+  }
+
+  /**
+   * @deprecated Moved into {@link ColumnLineageInputField} to support multiple jobs writing to a
+   *     single dataset. This method is scheduled to be removed in release {@code 0.30.0}.
+   */
+  public String getTransformationDescription() {
+    return Optional.ofNullable(inputFields).map(List::stream).stream()
+        .flatMap(Function.identity())
+        .findAny()
+        .map(d -> d.getTransformationDescription())
+        .orElse(null);
+  }
+
+  /**
+   * @deprecated Moved into {@link ColumnLineageInputField} to support multiple jobs writing to a
+   *     single dataset. This method is scheduled to be removed in release {@code 0.30.0}.
+   */
+  public String getTransformationType() {
+    return Optional.ofNullable(inputFields).map(List::stream).stream()
+        .flatMap(Function.identity())
+        .findAny()
+        .map(d -> d.getTransformationType())
+        .orElse(null);
+  }
 }

--- a/api/src/main/java/marquez/db/models/InputFieldNodeData.java
+++ b/api/src/main/java/marquez/db/models/InputFieldNodeData.java
@@ -20,4 +20,6 @@ public class InputFieldNodeData {
   @NonNull String dataset;
   @Nullable UUID datasetVersion;
   @NonNull String field;
+  String transformationDescription;
+  String transformationType;
 }

--- a/api/src/main/java/marquez/service/ColumnLineageService.java
+++ b/api/src/main/java/marquez/service/ColumnLineageService.java
@@ -226,14 +226,16 @@ public class ColumnLineageService extends DelegatingDaos.DelegatingColumnLineage
                   .add(
                       ColumnLineage.builder()
                           .name(nodeData.getField())
-                          .transformationDescription(nodeData.getTransformationDescription())
-                          .transformationType(nodeData.getTransformationType())
                           .inputFields(
                               nodeData.getInputFields().stream()
                                   .map(
                                       f ->
                                           new ColumnLineageInputField(
-                                              f.getNamespace(), f.getDataset(), f.getField()))
+                                              f.getNamespace(),
+                                              f.getDataset(),
+                                              f.getField(),
+                                              f.getTransformationDescription(),
+                                              f.getTransformationType()))
                                   .collect(Collectors.toList()))
                           .build());
             });

--- a/api/src/main/java/marquez/service/models/ColumnLineage.java
+++ b/api/src/main/java/marquez/service/models/ColumnLineage.java
@@ -6,6 +6,9 @@
 package marquez.service.models;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -19,6 +22,31 @@ import lombok.ToString;
 public class ColumnLineage {
   @NotNull private String name;
   @NotNull private List<ColumnLineageInputField> inputFields;
-  @NotNull private String transformationDescription;
-  @NotNull private String transformationType;
+
+  @Nullable private String transformationDescription;
+  @Nullable private String transformationType;
+
+  /**
+   * @deprecated Moved into {@link ColumnLineageInputField} to support multiple jobs writing to a
+   *     single dataset. This method is scheduled to be removed in release {@code 0.30.0}.
+   */
+  public String getTransformationDescription() {
+    return Optional.ofNullable(inputFields).map(List::stream).stream()
+        .flatMap(Function.identity())
+        .findAny()
+        .map(d -> d.getTransformationDescription())
+        .orElse(null);
+  }
+
+  /**
+   * @deprecated Moved into {@link ColumnLineageInputField} to support multiple jobs writing to a
+   *     single dataset. This method is scheduled to be removed in release {@code 0.30.0}.
+   */
+  public String getTransformationType() {
+    return Optional.ofNullable(inputFields).map(List::stream).stream()
+        .flatMap(Function.identity())
+        .findAny()
+        .map(d -> d.getTransformationType())
+        .orElse(null);
+  }
 }

--- a/api/src/main/java/marquez/service/models/ColumnLineageInputField.java
+++ b/api/src/main/java/marquez/service/models/ColumnLineageInputField.java
@@ -19,4 +19,6 @@ public class ColumnLineageInputField {
   @NotNull private String namespace;
   @NotNull private String dataset;
   @NotNull private String field;
+  @NotNull private String transformationDescription;
+  @NotNull private String transformationType;
 }

--- a/api/src/test/java/marquez/db/models/ColumnLineageNodeDataTest.java
+++ b/api/src/test/java/marquez/db/models/ColumnLineageNodeDataTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.db.models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class ColumnLineageNodeDataTest {
+
+  @Test
+  public void testGetters() {
+    ColumnLineageNodeData node =
+        new ColumnLineageNodeData(
+            "namespace",
+            "dataset",
+            UUID.randomUUID(),
+            "field",
+            "varchar",
+            ImmutableList.of(
+                new InputFieldNodeData(
+                    "namespace",
+                    "dataset",
+                    UUID.randomUUID(),
+                    "other-field",
+                    "transformation description",
+                    "transformation type")));
+
+    assertThat(node.getTransformationDescription()).isEqualTo("transformation description");
+    assertThat(node.getTransformationType()).isEqualTo("transformation type");
+  }
+
+  @Test
+  public void testGettersWhenEmptyInputFields() {
+    ColumnLineageNodeData node =
+        new ColumnLineageNodeData(
+            "namespace", "dataset", UUID.randomUUID(), "field", "varchar", ImmutableList.of());
+    assertThat(node.getTransformationDescription()).isNull();
+    assertThat(node.getTransformationType()).isNull();
+  }
+
+  @Test
+  public void testGettersWhenInputFieldsAreNull() {
+    ColumnLineageNodeData node =
+        new ColumnLineageNodeData(
+            "namespace", "dataset", UUID.randomUUID(), "field", "varchar", null);
+    assertThat(node.getTransformationDescription()).isNull();
+    assertThat(node.getTransformationType()).isNull();
+  }
+}

--- a/api/src/test/java/marquez/service/ColumnLineageServiceTest.java
+++ b/api/src/test/java/marquez/service/ColumnLineageServiceTest.java
@@ -93,9 +93,8 @@ public class ColumnLineageServiceTest {
     Node col_c = getNode(lineage, "dataset_b", "col_c").get();
     List<InputFieldNodeData> inputFields =
         ((ColumnLineageNodeData) col_c.getData()).getInputFields();
-    assertEquals(
-        "description1", ((ColumnLineageNodeData) col_c.getData()).getTransformationDescription());
-    assertEquals("type1", ((ColumnLineageNodeData) col_c.getData()).getTransformationType());
+    assertEquals("description1", inputFields.get(0).getTransformationDescription());
+    assertEquals("type1", inputFields.get(0).getTransformationType());
     assertEquals("STRING", ((ColumnLineageNodeData) col_c.getData()).getFieldType());
     assertThat(inputFields).hasSize(2);
     assertEquals("dataset_a", inputFields.get(0).getDataset());
@@ -195,28 +194,27 @@ public class ColumnLineageServiceTest {
 
     assertThat(dataset_b.getColumnLineage()).hasSize(1);
     assertThat(dataset_b.getColumnLineage().get(0).getName()).isEqualTo("col_c");
-    assertThat(dataset_b.getColumnLineage().get(0).getTransformationType()).isEqualTo("type1");
-    assertThat(dataset_b.getColumnLineage().get(0).getTransformationDescription())
-        .isEqualTo("description1");
 
     List<ColumnLineageInputField> inputFields_b =
         dataset_b.getColumnLineage().get(0).getInputFields();
     assertThat(inputFields_b)
         .hasSize(2)
-        .contains(new ColumnLineageInputField("namespace", "dataset_a", "col_a"))
-        .contains(new ColumnLineageInputField("namespace", "dataset_a", "col_b"));
+        .contains(
+            new ColumnLineageInputField("namespace", "dataset_a", "col_a", "description1", "type1"))
+        .contains(
+            new ColumnLineageInputField(
+                "namespace", "dataset_a", "col_b", "description1", "type1"));
 
     assertThat(dataset_c.getColumnLineage()).hasSize(1);
     assertThat(dataset_c.getColumnLineage().get(0).getName()).isEqualTo("col_d");
-    assertThat(dataset_c.getColumnLineage().get(0).getTransformationType()).isEqualTo("type2");
-    assertThat(dataset_c.getColumnLineage().get(0).getTransformationDescription())
-        .isEqualTo("description2");
 
     List<ColumnLineageInputField> inputFields_c =
         dataset_c.getColumnLineage().get(0).getInputFields();
     assertThat(inputFields_c)
         .hasSize(1)
-        .contains(new ColumnLineageInputField("namespace", "dataset_b", "col_c"));
+        .contains(
+            new ColumnLineageInputField(
+                "namespace", "dataset_b", "col_c", "description2", "type2"));
   }
 
   @Test

--- a/api/src/test/java/marquez/service/models/ColumnLineageTest.java
+++ b/api/src/test/java/marquez/service/models/ColumnLineageTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.service.models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+public class ColumnLineageTest {
+
+  @Test
+  public void testGetters() {
+    ColumnLineage columnLineage =
+        ColumnLineage.builder()
+            .name("name")
+            .inputFields(
+                ImmutableList.of(
+                    new ColumnLineageInputField(
+                        "namespace",
+                        "dataset",
+                        "other-field",
+                        "transformation description",
+                        "transformation type")))
+            .build();
+
+    assertThat(columnLineage.getTransformationDescription())
+        .isEqualTo("transformation description");
+    assertThat(columnLineage.getTransformationType()).isEqualTo("transformation type");
+  }
+
+  @Test
+  public void testGettersWhenEmptyInputFields() {
+    ColumnLineage columnLineage =
+        ColumnLineage.builder().name("name").inputFields(ImmutableList.of()).build();
+    assertThat(columnLineage.getTransformationDescription()).isNull();
+    assertThat(columnLineage.getTransformationType()).isNull();
+  }
+
+  @Test
+  public void testGettersWhenInputFieldsAreNull() {
+    ColumnLineage columnLineage = ColumnLineage.builder().name("name").inputFields(null).build();
+    assertThat(columnLineage.getTransformationDescription()).isNull();
+    assertThat(columnLineage.getTransformationType()).isNull();
+  }
+}

--- a/clients/java/src/main/java/marquez/client/models/ColumnLineage.java
+++ b/clients/java/src/main/java/marquez/client/models/ColumnLineage.java
@@ -18,7 +18,5 @@ import lombok.ToString;
 @Getter
 public class ColumnLineage {
   @NonNull private String name;
-  @NonNull private List<DatasetFieldId> inputFields;
-  @NonNull private String transformationDescription;
-  @NonNull private String transformationType;
+  @NonNull private List<ColumnLineageInputField> inputFields;
 }

--- a/clients/java/src/main/java/marquez/client/models/ColumnLineageInputField.java
+++ b/clients/java/src/main/java/marquez/client/models/ColumnLineageInputField.java
@@ -19,4 +19,6 @@ public class ColumnLineageInputField {
   @NonNull private String namespace;
   @NonNull private String dataset;
   @NonNull private String field;
+  @NonNull String transformationDescription;
+  @NonNull String transformationType;
 }

--- a/clients/java/src/main/java/marquez/client/models/ColumnLineageNodeData.java
+++ b/clients/java/src/main/java/marquez/client/models/ColumnLineageNodeData.java
@@ -21,9 +21,7 @@ public class ColumnLineageNodeData implements NodeData {
   @NonNull String dataset;
   @NonNull String field;
   @NonNull String fieldType;
-  @NonNull String transformationDescription;
-  @NonNull String transformationType;
-  @NonNull List<DatasetFieldId> inputFields;
+  @NonNull List<ColumnLineageInputField> inputFields;
 
   public static ColumnLineageNodeData fromJson(@NonNull final String json) {
     return Utils.fromJson(json, new TypeReference<ColumnLineageNodeData>() {});

--- a/clients/java/src/test/java/marquez/client/MarquezClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezClientTest.java
@@ -68,6 +68,7 @@ import marquez.client.MarquezClient.Namespaces;
 import marquez.client.MarquezClient.Runs;
 import marquez.client.MarquezClient.Sources;
 import marquez.client.MarquezClient.Tags;
+import marquez.client.models.ColumnLineageInputField;
 import marquez.client.models.ColumnLineageNodeData;
 import marquez.client.models.Dataset;
 import marquez.client.models.DatasetFieldId;
@@ -963,10 +964,13 @@ public class MarquezClientTest {
                 DB_TABLE_NAME,
                 FIELD_NAME,
                 "String",
-                "transformationDescription",
-                "transformationType",
                 Collections.singletonList(
-                    new DatasetFieldId("namespace", "inDataset", "some-col1"))),
+                    new ColumnLineageInputField(
+                        "namespace",
+                        "inDataset",
+                        "some-col1",
+                        "transformationDescription",
+                        "transformationType"))),
             ImmutableSet.of(
                 Edge.of(
                     NodeId.of(DATASET_FIELD_ID),
@@ -1000,10 +1004,13 @@ public class MarquezClientTest {
                 DB_TABLE_NAME,
                 FIELD_NAME,
                 "String",
-                "transformationDescription",
-                "transformationType",
                 Collections.singletonList(
-                    new DatasetFieldId("namespace", "inDataset", "some-col1"))),
+                    new ColumnLineageInputField(
+                        "namespace",
+                        "inDataset",
+                        "some-col1",
+                        "transformationDescription",
+                        "transformationType"))),
             ImmutableSet.of(
                 Edge.of(
                     NodeId.of(DATASET_FIELD_ID),
@@ -1037,10 +1044,13 @@ public class MarquezClientTest {
                 DB_TABLE_NAME,
                 FIELD_NAME,
                 "String",
-                "transformationDescription",
-                "transformationType",
                 Collections.singletonList(
-                    new DatasetFieldId("namespace", "inDataset", "some-col1"))),
+                    new ColumnLineageInputField(
+                        "namespace",
+                        "inDataset",
+                        "some-col1",
+                        "transformationDescription",
+                        "transformationType"))),
             ImmutableSet.of(
                 Edge.of(
                     NodeId.of(DATASET_FIELD_ID),


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Current model of column-lineage API does not suit well scenario such that multiple different jobs write to same column of output dataset. Specifically, a response of the form:
```
         "transformationDescription": "identical",
         "transformationType": "IDENTITY",    
        ,    
         "inputFields": [
            { "namespace": "DBA", "name": "tableA", "field": "columnA"},
            { "namespace": "DBB", "name": "tableB", "field": "columnB"},
            { "namespace": "DBC", "name": "tableC", "field": "columnC"}
         ]
```
should be converted into: 
```
 "inputFields": [
            { 
                  "namespace": "DBA", 
                  "name": "tableA", 
                  "field": "columnA",   
                  "transformationDescription": "identical", 
                  "transformationType": "IDENTITY"
            },
            ....
         ]
```
with `transformationDescription` and `transformationType` contained per input field. 

### Solution

 * Update API model while still returning deprecated `transformationDescription` and `transformationType`, 
 * Write a test such that multiple different jobs write to same column,
 * Additionally, display column-lineage of a dataset in Marquez UI (which is helpful for debugging purposes)

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)