### PR TITLE
adding indexed created_at column to lineage events table

### DIFF
--- a/api/src/main/resources/marquez/db/migration/V52__lineage_events_created_at_indexed.sql
+++ b/api/src/main/resources/marquez/db/migration/V52__lineage_events_created_at_indexed.sql
@@ -1,4 +1,0 @@
-ALTER TABLE lineage_events ADD created_at TIMESTAMP;
-
-create index lineage_events_created_at_index
-    on lineage_events (created_at desc);

--- a/api/src/main/resources/marquez/db/migration/V52__lineage_events_created_at_indexed.sql
+++ b/api/src/main/resources/marquez/db/migration/V52__lineage_events_created_at_indexed.sql
@@ -1,0 +1,4 @@
+ALTER TABLE lineage_events ADD created_at TIMESTAMP;
+
+create index lineage_events_created_at_index
+    on lineage_events (created_at desc);

--- a/api/src/main/resources/marquez/db/migration/V54__lineage_events_created_at_indexed.sql
+++ b/api/src/main/resources/marquez/db/migration/V54__lineage_events_created_at_indexed.sql
@@ -1,9 +1,7 @@
+-- new column will be created with 'null' filled for existing rows
 ALTER TABLE lineage_events ADD created_at TIMESTAMP;
 
 create index lineage_events_created_at_index on lineage_events (created_at desc);
 
-UPDATE lineage_events
-SET created_at = (event_time AT TIME ZONE 'UTC')::timestamp;
-
+-- The new default set to UTC now() will only apply in subsequent INSERT or UPDATE commands; it does not cause rows already in the table to change.
 ALTER TABLE lineage_events ALTER COLUMN created_at SET DEFAULT (now() AT TIME ZONE 'UTC');
-

--- a/api/src/main/resources/marquez/db/migration/V54__lineage_events_created_at_indexed.sql
+++ b/api/src/main/resources/marquez/db/migration/V54__lineage_events_created_at_indexed.sql
@@ -1,7 +1,7 @@
 -- new column will be created with 'null' filled for existing rows
 ALTER TABLE lineage_events ADD created_at TIMESTAMP WITH TIME ZONE;
 
-create index lineage_events_created_at_index on lineage_events (created_at desc);
+create index lineage_events_created_at_index on lineage_events (created_at desc NULLS LAST);
 
 -- The new default set to UTC now() will only apply in subsequent INSERT or UPDATE commands; it does not cause rows already in the table to change.
 ALTER TABLE lineage_events ALTER COLUMN created_at SET DEFAULT (now() AT TIME ZONE 'UTC')::timestamptz;

--- a/api/src/main/resources/marquez/db/migration/V54__lineage_events_created_at_indexed.sql
+++ b/api/src/main/resources/marquez/db/migration/V54__lineage_events_created_at_indexed.sql
@@ -1,0 +1,9 @@
+ALTER TABLE lineage_events ADD created_at TIMESTAMP;
+
+create index lineage_events_created_at_index on lineage_events (created_at desc);
+
+UPDATE lineage_events
+SET created_at = (event_time AT TIME ZONE 'UTC')::timestamp;
+
+ALTER TABLE lineage_events ALTER COLUMN created_at SET DEFAULT (now() AT TIME ZONE 'UTC');
+

--- a/api/src/main/resources/marquez/db/migration/V54__lineage_events_created_at_indexed.sql
+++ b/api/src/main/resources/marquez/db/migration/V54__lineage_events_created_at_indexed.sql
@@ -1,7 +1,7 @@
 -- new column will be created with 'null' filled for existing rows
-ALTER TABLE lineage_events ADD created_at TIMESTAMP;
+ALTER TABLE lineage_events ADD created_at TIMESTAMP WITH TIME ZONE;
 
 create index lineage_events_created_at_index on lineage_events (created_at desc);
 
 -- The new default set to UTC now() will only apply in subsequent INSERT or UPDATE commands; it does not cause rows already in the table to change.
-ALTER TABLE lineage_events ALTER COLUMN created_at SET DEFAULT (now() AT TIME ZONE 'UTC');
+ALTER TABLE lineage_events ALTER COLUMN created_at SET DEFAULT (now() AT TIME ZONE 'UTC')::timestamptz;


### PR DESCRIPTION
### Problem


For analytics use case we need to incrementally copy and export lineage_events to DWH. For this use case there is no good way to identify incrementally created events in database. The current event_time in lineage_events table is client generated and can be back dated.


Closes: #2300


### Solution


1. Proposing to alter lineage_events table to add a new created_at timestamp column. 
2. Also index this new column.
3. This is a _backwards-compatible_ change 
4. <EDIT> Existing rows in the lineage events table will be assigned null values.
5. New rows will have default value as DB server's UTC now() which determines the time when event was inserted in lineage_events table.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

I have tested by deploying the changes in my local database and migration script ran successfully on top of existing schema.

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)