### PR TITLE
Update migration query to make it work with existing view

### DIFF
--- a/api/src/main/resources/marquez/db/migration/V52__alter_dataset_symlinks.sql
+++ b/api/src/main/resources/marquez/db/migration/V52__alter_dataset_symlinks.sql
@@ -1,2 +1,28 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-ALTER TABLE dataset_symlinks ALTER COLUMN name TYPE VARCHAR;
+
+DO
+$$
+DECLARE
+    datasets_view_exists boolean;
+    datasets_view_definition text;
+BEGIN
+    SELECT EXISTS (
+        SELECT * FROM information_schema.views
+        WHERE table_schema='public' AND table_name='datasets_view'
+    ) INTO datasets_view_exists;
+
+    IF datasets_view_exists THEN
+        -- Altering is not allowed when the column is being used from views. So here,
+        -- we temporarily drop the view before altering and recreate it.
+        SELECT view_definition FROM information_schema.views
+        WHERE table_schema='public' AND table_name='datasets_view'
+        INTO datasets_view_definition;
+
+        DROP VIEW datasets_view;
+        ALTER TABLE dataset_symlinks ALTER COLUMN name TYPE VARCHAR;
+        EXECUTE format('CREATE VIEW datasets_view AS %s', datasets_view_definition);
+    ELSE
+        ALTER TABLE dataset_symlinks ALTER COLUMN name TYPE VARCHAR;
+    END IF;
+END
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
Signed-off-by: Minkyu Park <minkyu.park.200@gmail.com>

### Problem
V52 migration fails if the `datasets_view` is already created by the previous migration, because postgresql does not allow altering the type of the column when it is being used by views.

Closes: #2298 

### Solution
This PR changes the V52 migration query to drop the view before `ALTER`. Because repeatable migration runs only when its checksum changes, we have to get the view definition first, and then drop and recreate it as before.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)