### PR TITLE
manage eslint errors on accented characters

### DIFF
--- a/web/.eslintrc.js
+++ b/web/.eslintrc.js
@@ -57,6 +57,15 @@ module.exports = {
       "ignoreCase": false,
       "ignoreMemberSort": false,
       "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
-    }]
-  }
+    }] 
+  },
+  'overrides': [
+    {
+      'files': './src/i18n/config.ts',
+      'rules': {
+        '@typescript-eslint/quotes': 'off' 
+      }
+    }
+  ]
+
 }

--- a/web/src/i18n/config.ts
+++ b/web/src/i18n/config.ts
@@ -8,7 +8,7 @@ const DETECTION_OPTIONS = {
   order: ['localStorage'],
   lookupLocalStorage: 'lng',
   caches: ['localStorage']
-};
+}
 
 i18next
   .use(LanguageDetector)
@@ -123,16 +123,16 @@ i18next
           },
           jobs: {
             latest_tab: 'DERNIÈRE COURSE',
-            history_tab: 'HISTORIQUE D\'EXECUTION',
+            history_tab: "HISTORIQUE D'EXECUTION",
             location: 'EMPLACEMENT',
             empty_title: 'Pas de Course les Informations Disponibles',
-            empty_body: 'Essayez d\'ajouter quelques exécutions pour ce travail.',
+            empty_body: "Essayez d'ajouter quelques exécutions pour ce travail.",
             runinfo_subhead: 'FACETTES',
             runs_subhead: 'FACETTES'
           },
           search: {
             search: 'Recherche',
-            jobs: 'd\'Emplois',
+            jobs: "d'Emplois",
             and: 'et',
             datasets: 'Jeux de Données'
           },
@@ -151,7 +151,7 @@ i18next
           },
           dataset_info: {
             empty_title: 'Aucun jeu de données trouvé',
-            empty_body: 'Essayez d\'ajouter des champs de jeu de données.',
+            empty_body: "Essayez d'ajouter des champs de jeu de données.",
             facets_subhead: 'FACETTES',
             run_subhead: 'Créé par Run',
             duration: 'Durée'
@@ -178,7 +178,7 @@ i18next
             name_col: 'NOM',
             namespace_col: 'ESPACE DE NOMS',
             updated_col: 'MISE À JOUR À',
-            latest_run_col: 'DERNIÈRE DURÉE D\'EXÉCUTION'
+            latest_run_col: "DERNIÈRE DURÉE D'EXÉCUTION"
           },
           runs_columns: {
             id: 'ID',

--- a/web/src/types/i18next.d.ts
+++ b/web/src/types/i18next.d.ts
@@ -1,5 +1,4 @@
-import i18next from '../i18n/config'
-import { resources, defaultNS } from '../i18n/config'
+import { defaultNS, resources } from '../i18n/config'
 
 declare module 'i18next' {
   interface CustomTypeOptions {


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

Eslint was reporting quote errors on lines in i18n/config whether the lines used single OR double quotes. 

### Solution

This change replaces back ticks with double quotes in lines with accented characters and edits .eslintrc to override quote errors in i18n/config. Also, an unused import is removed from src/types/i18next.d.ts.
 
> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)