### PR TITLE
configure renovate to label pull requests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,11 +15,13 @@
   "packageRules": [
     {
       "matchPackageNames": ["com.graphql-java:graphql-java"],
-      "allowedVersions": "/^[0-9]+\\.[0-9]+(\\.[0-9]+)?$/"
+      "allowedVersions": "/^[0-9]+\\.[0-9]+(\\.[0-9]+)?$/",
+      "addLabels": ["dependencies", "renovate"]
     },
     {
       "matchPackagePatterns": ["^org.apache.spark:", ".css$", "^gradle$"],
-      "automerge": false
+      "automerge": false,
+      "addLabels": ["dependencies", "renovate"]
     }
   ],
   "ignorePaths": ["**/chart/**"]


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

Labeling PRs from renovate and dependabot would make managing the volume of PRs from these bots more manageable. Because boring-cyborg uses a path-based approach to labeling, it can't be used for this.

### Solution

This change uses renovate's config to add labels to its PRs.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)