### PR TITLE
update SPDX headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -894,3 +894,7 @@
 ## [0.1.0](https://github.com/MarquezProject/marquez/releases/tag/0.1.0) - 2018-12-18
 
 * Marquez initial public release.
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -129,3 +129,7 @@ at [https://www.contributor-covenant.org/translations][translations].
 [Mozilla CoC]: https://github.com/mozilla/diversity
 [FAQ]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/CODE_QUALITY_AND_SECURITY.md
+++ b/CODE_QUALITY_AND_SECURITY.md
@@ -28,3 +28,7 @@ For more information about our approach to quality and security, feel free to re
 
 - Slack: [Marquezproject.slack.com](http://bit.ly/MarquezSlack)
 - Twitter: [@MarquezProject](https://twitter.com/MarquezProject)
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -36,3 +36,7 @@ contributions, we have a strong foundation to build on.
 
 A Contributor may become a Committer by the approval of a majority of the
 existing Committers (as per the project [charter](https://wiki.lfaidata.foundation/download/attachments/18481434/Marquez%20Project%20Technical%20Charter%20Final_Adopted%2005.21.20.pdf?version=1&modificationDate=1591718661000&api=v2)).
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,3 +247,7 @@ We use [SPDX](https://spdx.dev) for copyright and license information. The follo
 * [Keeping a Changelog](https://keepachangelog.com)
 * [Code Review Developer Guide](https://google.github.io/eng-practices/review)
 * [Signing Commits](https://docs.github.com/en/github/authenticating-to-github/signing-commits)
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -142,5 +142,5 @@ be resolved by voting. The voting process is a simple majority in which each com
 
 
 ----
-License: Apache-2.0, 
-Copyright 2018-2022 contributors to the Marquez project.
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/METRICS.md
+++ b/METRICS.md
@@ -10,3 +10,7 @@
 | `marquez_job_versions_total`     | _count_ | `namespace_name`, <br> `job_type`, <br> `job_name`         | Total number of job versions.       |
 | `marquez_job_runs_active`        | _gauge_ |                                                            | Total number of active job runs.    |
 | `marquez_job_runs_completed`     | _gauge_ |                                                            | Total number of completed job runs. |
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/README.md
+++ b/README.md
@@ -156,3 +156,7 @@ See [CONTRIBUTING.md](https://github.com/MarquezProject/marquez/blob/main/CONTRI
 ## Reporting a Vulnerability
 
 If you discover a vulnerability in the project, please open an issue and attach the "security" label.
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,3 +32,7 @@ Alternatively, if after 2 days the release has received at least one +1 and no -
 If the proposed release receives no +1s in two days, it is not authorized and the proposer must make a new request to reset the clock.
 
 Once a release is authorized, it will be initiated within two business days. Releases will not be made on a Friday unless doing so will address an important defect, an issue with project infrastructure, or a security vulnerability.
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/api/src/main/java/marquez/MarquezApp.java
+++ b/api/src/main/java/marquez/MarquezApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/MarquezConfig.java
+++ b/api/src/main/java/marquez/MarquezConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/MarquezContext.java
+++ b/api/src/main/java/marquez/MarquezContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/BaseResource.java
+++ b/api/src/main/java/marquez/api/BaseResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/ColumnLineageResource.java
+++ b/api/src/main/java/marquez/api/ColumnLineageResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/DatasetResource.java
+++ b/api/src/main/java/marquez/api/DatasetResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/JobResource.java
+++ b/api/src/main/java/marquez/api/JobResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/NamespaceResource.java
+++ b/api/src/main/java/marquez/api/NamespaceResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/OpenLineageResource.java
+++ b/api/src/main/java/marquez/api/OpenLineageResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/RunResource.java
+++ b/api/src/main/java/marquez/api/RunResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/SearchResource.java
+++ b/api/src/main/java/marquez/api/SearchResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/SourceResource.java
+++ b/api/src/main/java/marquez/api/SourceResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/TagResource.java
+++ b/api/src/main/java/marquez/api/TagResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/exceptions/DatasetNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/DatasetNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/exceptions/DatasetVersionNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/DatasetVersionNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/exceptions/FieldNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/FieldNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/exceptions/JdbiExceptionExceptionMapper.java
+++ b/api/src/main/java/marquez/api/exceptions/JdbiExceptionExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/exceptions/JobNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/JobNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/exceptions/JobVersionNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/JobVersionNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/exceptions/JsonProcessingExceptionMapper.java
+++ b/api/src/main/java/marquez/api/exceptions/JsonProcessingExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/exceptions/NamespaceNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/NamespaceNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/exceptions/RunAlreadyExistsException.java
+++ b/api/src/main/java/marquez/api/exceptions/RunAlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/exceptions/RunNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/RunNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/exceptions/SourceNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/SourceNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/exceptions/TagNotFoundException.java
+++ b/api/src/main/java/marquez/api/exceptions/TagNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/filter/JobRedirectFilter.java
+++ b/api/src/main/java/marquez/api/filter/JobRedirectFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/models/JobVersion.java
+++ b/api/src/main/java/marquez/api/models/JobVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/models/ResultsPage.java
+++ b/api/src/main/java/marquez/api/models/ResultsPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/models/SearchFilter.java
+++ b/api/src/main/java/marquez/api/models/SearchFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/models/SearchResult.java
+++ b/api/src/main/java/marquez/api/models/SearchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/models/SearchSort.java
+++ b/api/src/main/java/marquez/api/models/SearchSort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/api/models/SortDirection.java
+++ b/api/src/main/java/marquez/api/models/SortDirection.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package marquez.api.models;
 
 import lombok.AllArgsConstructor;

--- a/api/src/main/java/marquez/cli/MetadataCommand.java
+++ b/api/src/main/java/marquez/cli/MetadataCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/cli/SeedCommand.java
+++ b/api/src/main/java/marquez/cli/SeedCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/Utils.java
+++ b/api/src/main/java/marquez/common/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/base/MorePreconditions.java
+++ b/api/src/main/java/marquez/common/base/MorePreconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/DatasetFieldId.java
+++ b/api/src/main/java/marquez/common/models/DatasetFieldId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/DatasetFieldVersionId.java
+++ b/api/src/main/java/marquez/common/models/DatasetFieldVersionId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/DatasetId.java
+++ b/api/src/main/java/marquez/common/models/DatasetId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/DatasetName.java
+++ b/api/src/main/java/marquez/common/models/DatasetName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/DatasetType.java
+++ b/api/src/main/java/marquez/common/models/DatasetType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/DatasetVersionId.java
+++ b/api/src/main/java/marquez/common/models/DatasetVersionId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/Field.java
+++ b/api/src/main/java/marquez/common/models/Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/FieldName.java
+++ b/api/src/main/java/marquez/common/models/FieldName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/FlexibleDateTimeDeserializer.java
+++ b/api/src/main/java/marquez/common/models/FlexibleDateTimeDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/JobId.java
+++ b/api/src/main/java/marquez/common/models/JobId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/JobName.java
+++ b/api/src/main/java/marquez/common/models/JobName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/JobType.java
+++ b/api/src/main/java/marquez/common/models/JobType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/JobVersionId.java
+++ b/api/src/main/java/marquez/common/models/JobVersionId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/NamespaceName.java
+++ b/api/src/main/java/marquez/common/models/NamespaceName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/OwnerName.java
+++ b/api/src/main/java/marquez/common/models/OwnerName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/RunId.java
+++ b/api/src/main/java/marquez/common/models/RunId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/RunState.java
+++ b/api/src/main/java/marquez/common/models/RunState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/SourceName.java
+++ b/api/src/main/java/marquez/common/models/SourceName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/SourceType.java
+++ b/api/src/main/java/marquez/common/models/SourceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/TagName.java
+++ b/api/src/main/java/marquez/common/models/TagName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/common/models/Version.java
+++ b/api/src/main/java/marquez/common/models/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/BaseDao.java
+++ b/api/src/main/java/marquez/db/BaseDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/ColumnLineageDao.java
+++ b/api/src/main/java/marquez/db/ColumnLineageDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/Columns.java
+++ b/api/src/main/java/marquez/db/Columns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/DatasetDao.java
+++ b/api/src/main/java/marquez/db/DatasetDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/DatasetFieldDao.java
+++ b/api/src/main/java/marquez/db/DatasetFieldDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/DatasetSymlinkDao.java
+++ b/api/src/main/java/marquez/db/DatasetSymlinkDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/DatasetVersionDao.java
+++ b/api/src/main/java/marquez/db/DatasetVersionDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/DbMigration.java
+++ b/api/src/main/java/marquez/db/DbMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/FlywayFactory.java
+++ b/api/src/main/java/marquez/db/FlywayFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/JobContextDao.java
+++ b/api/src/main/java/marquez/db/JobContextDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/JobDao.java
+++ b/api/src/main/java/marquez/db/JobDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/JobVersionDao.java
+++ b/api/src/main/java/marquez/db/JobVersionDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/NamespaceDao.java
+++ b/api/src/main/java/marquez/db/NamespaceDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/RunArgsDao.java
+++ b/api/src/main/java/marquez/db/RunArgsDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/RunDao.java
+++ b/api/src/main/java/marquez/db/RunDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/RunStateDao.java
+++ b/api/src/main/java/marquez/db/RunStateDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/SearchDao.java
+++ b/api/src/main/java/marquez/db/SearchDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/SourceDao.java
+++ b/api/src/main/java/marquez/db/SourceDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/StreamVersionDao.java
+++ b/api/src/main/java/marquez/db/StreamVersionDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/TagDao.java
+++ b/api/src/main/java/marquez/db/TagDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/ColumnLineageNodeDataMapper.java
+++ b/api/src/main/java/marquez/db/mappers/ColumnLineageNodeDataMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/ColumnLineageRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/ColumnLineageRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/DatasetDataMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetDataMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/DatasetFieldMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetFieldMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/DatasetFieldRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetFieldRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/DatasetMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/DatasetRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/DatasetSymlinksRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetSymlinksRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/DatasetVersionMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetVersionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/DatasetVersionRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/DatasetVersionRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/ExtendedDatasetVersionRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/ExtendedDatasetVersionRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/ExtendedJobVersionRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/ExtendedJobVersionRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/ExtendedRunRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/ExtendedRunRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/FieldDataMapper.java
+++ b/api/src/main/java/marquez/db/mappers/FieldDataMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/JobContextRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/JobContextRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/JobDataMapper.java
+++ b/api/src/main/java/marquez/db/mappers/JobDataMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/JobMapper.java
+++ b/api/src/main/java/marquez/db/mappers/JobMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/JobRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/JobRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/JobVersionMapper.java
+++ b/api/src/main/java/marquez/db/mappers/JobVersionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/LineageEventMapper.java
+++ b/api/src/main/java/marquez/db/mappers/LineageEventMapper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package marquez.db.mappers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/api/src/main/java/marquez/db/mappers/MapperUtils.java
+++ b/api/src/main/java/marquez/db/mappers/MapperUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/NamespaceMapper.java
+++ b/api/src/main/java/marquez/db/mappers/NamespaceMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/NamespaceRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/NamespaceRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/OwnerRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/OwnerRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/PairUuidInstantMapper.java
+++ b/api/src/main/java/marquez/db/mappers/PairUuidInstantMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/RunArgsRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/RunArgsRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/RunMapper.java
+++ b/api/src/main/java/marquez/db/mappers/RunMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/RunRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/RunRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/RunStateRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/RunStateRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/SearchResultMapper.java
+++ b/api/src/main/java/marquez/db/mappers/SearchResultMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/SourceMapper.java
+++ b/api/src/main/java/marquez/db/mappers/SourceMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/SourceRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/SourceRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/TagMapper.java
+++ b/api/src/main/java/marquez/db/mappers/TagMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/mappers/TagRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/TagRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/migrations/V44_1__UpdateRunsWithJobUUID.java
+++ b/api/src/main/java/marquez/db/migrations/V44_1__UpdateRunsWithJobUUID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/migrations/V44_2__BackfillAirflowParentRuns.java
+++ b/api/src/main/java/marquez/db/migrations/V44_2__BackfillAirflowParentRuns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/migrations/V44_3_BackfillJobsWithParents.java
+++ b/api/src/main/java/marquez/db/migrations/V44_3_BackfillJobsWithParents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/ColumnLineageNodeData.java
+++ b/api/src/main/java/marquez/db/models/ColumnLineageNodeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/ColumnLineageRow.java
+++ b/api/src/main/java/marquez/db/models/ColumnLineageRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/DatasetData.java
+++ b/api/src/main/java/marquez/db/models/DatasetData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/DatasetFieldRow.java
+++ b/api/src/main/java/marquez/db/models/DatasetFieldRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/DatasetRow.java
+++ b/api/src/main/java/marquez/db/models/DatasetRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/DatasetSymlinkRow.java
+++ b/api/src/main/java/marquez/db/models/DatasetSymlinkRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/DatasetVersionRow.java
+++ b/api/src/main/java/marquez/db/models/DatasetVersionRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/ExtendedDatasetVersionRow.java
+++ b/api/src/main/java/marquez/db/models/ExtendedDatasetVersionRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/ExtendedJobVersionRow.java
+++ b/api/src/main/java/marquez/db/models/ExtendedJobVersionRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/ExtendedRunRow.java
+++ b/api/src/main/java/marquez/db/models/ExtendedRunRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/InputFieldData.java
+++ b/api/src/main/java/marquez/db/models/InputFieldData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/InputFieldNodeData.java
+++ b/api/src/main/java/marquez/db/models/InputFieldNodeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/JobContextRow.java
+++ b/api/src/main/java/marquez/db/models/JobContextRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/JobData.java
+++ b/api/src/main/java/marquez/db/models/JobData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/JobRow.java
+++ b/api/src/main/java/marquez/db/models/JobRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/JobVersionRow.java
+++ b/api/src/main/java/marquez/db/models/JobVersionRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/NamespaceRow.java
+++ b/api/src/main/java/marquez/db/models/NamespaceRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/NodeData.java
+++ b/api/src/main/java/marquez/db/models/NodeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/OwnerRow.java
+++ b/api/src/main/java/marquez/db/models/OwnerRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/RunArgsRow.java
+++ b/api/src/main/java/marquez/db/models/RunArgsRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/RunRow.java
+++ b/api/src/main/java/marquez/db/models/RunRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/RunStateRow.java
+++ b/api/src/main/java/marquez/db/models/RunStateRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/SourceRow.java
+++ b/api/src/main/java/marquez/db/models/SourceRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/TagRow.java
+++ b/api/src/main/java/marquez/db/models/TagRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/db/models/UpdateLineageRow.java
+++ b/api/src/main/java/marquez/db/models/UpdateLineageRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/graphql/GraphqlConfig.java
+++ b/api/src/main/java/marquez/graphql/GraphqlConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/graphql/GraphqlDaos.java
+++ b/api/src/main/java/marquez/graphql/GraphqlDaos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/graphql/GraphqlDataFetchers.java
+++ b/api/src/main/java/marquez/graphql/GraphqlDataFetchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/graphql/GraphqlSchemaBuilder.java
+++ b/api/src/main/java/marquez/graphql/GraphqlSchemaBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/graphql/MarquezGraphqlServletBuilder.java
+++ b/api/src/main/java/marquez/graphql/MarquezGraphqlServletBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/graphql/mapper/LineageResultMapper.java
+++ b/api/src/main/java/marquez/graphql/mapper/LineageResultMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/graphql/mapper/ObjectMapMapper.java
+++ b/api/src/main/java/marquez/graphql/mapper/ObjectMapMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/graphql/mapper/RowMap.java
+++ b/api/src/main/java/marquez/graphql/mapper/RowMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/logging/LoggingMdcFilter.java
+++ b/api/src/main/java/marquez/logging/LoggingMdcFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/logging/MdcPropagating.java
+++ b/api/src/main/java/marquez/logging/MdcPropagating.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/ColumnLineageService.java
+++ b/api/src/main/java/marquez/service/ColumnLineageService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/DatasetFieldService.java
+++ b/api/src/main/java/marquez/service/DatasetFieldService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/DatasetService.java
+++ b/api/src/main/java/marquez/service/DatasetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/DatasetVersionService.java
+++ b/api/src/main/java/marquez/service/DatasetVersionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/DelegatingDaos.java
+++ b/api/src/main/java/marquez/service/DelegatingDaos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/JobMetrics.java
+++ b/api/src/main/java/marquez/service/JobMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/JobService.java
+++ b/api/src/main/java/marquez/service/JobService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/LineageService.java
+++ b/api/src/main/java/marquez/service/LineageService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/NamespaceService.java
+++ b/api/src/main/java/marquez/service/NamespaceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/NodeIdNotFoundException.java
+++ b/api/src/main/java/marquez/service/NodeIdNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/OpenLineageService.java
+++ b/api/src/main/java/marquez/service/OpenLineageService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/RunService.java
+++ b/api/src/main/java/marquez/service/RunService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/RunTransitionListener.java
+++ b/api/src/main/java/marquez/service/RunTransitionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/ServiceFactory.java
+++ b/api/src/main/java/marquez/service/ServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/SourceService.java
+++ b/api/src/main/java/marquez/service/SourceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/TagService.java
+++ b/api/src/main/java/marquez/service/TagService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/BaseJsonModel.java
+++ b/api/src/main/java/marquez/service/models/BaseJsonModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/ColumnLineage.java
+++ b/api/src/main/java/marquez/service/models/ColumnLineage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/ColumnLineageInputField.java
+++ b/api/src/main/java/marquez/service/models/ColumnLineageInputField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/Dataset.java
+++ b/api/src/main/java/marquez/service/models/Dataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/DatasetMeta.java
+++ b/api/src/main/java/marquez/service/models/DatasetMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/DatasetVersion.java
+++ b/api/src/main/java/marquez/service/models/DatasetVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/DbTable.java
+++ b/api/src/main/java/marquez/service/models/DbTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/DbTableMeta.java
+++ b/api/src/main/java/marquez/service/models/DbTableMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/DbTableVersion.java
+++ b/api/src/main/java/marquez/service/models/DbTableVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/Edge.java
+++ b/api/src/main/java/marquez/service/models/Edge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/Graph.java
+++ b/api/src/main/java/marquez/service/models/Graph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/Job.java
+++ b/api/src/main/java/marquez/service/models/Job.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/JobMeta.java
+++ b/api/src/main/java/marquez/service/models/JobMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/Lineage.java
+++ b/api/src/main/java/marquez/service/models/Lineage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/LineageEvent.java
+++ b/api/src/main/java/marquez/service/models/LineageEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/Namespace.java
+++ b/api/src/main/java/marquez/service/models/Namespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/NamespaceMeta.java
+++ b/api/src/main/java/marquez/service/models/NamespaceMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/Node.java
+++ b/api/src/main/java/marquez/service/models/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/NodeId.java
+++ b/api/src/main/java/marquez/service/models/NodeId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/NodeType.java
+++ b/api/src/main/java/marquez/service/models/NodeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/Run.java
+++ b/api/src/main/java/marquez/service/models/Run.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/RunMeta.java
+++ b/api/src/main/java/marquez/service/models/RunMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/Source.java
+++ b/api/src/main/java/marquez/service/models/Source.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/SourceMeta.java
+++ b/api/src/main/java/marquez/service/models/SourceMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/Stream.java
+++ b/api/src/main/java/marquez/service/models/Stream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/StreamMeta.java
+++ b/api/src/main/java/marquez/service/models/StreamMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/StreamVersion.java
+++ b/api/src/main/java/marquez/service/models/StreamVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/service/models/Tag.java
+++ b/api/src/main/java/marquez/service/models/Tag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/tracing/SentryConfig.java
+++ b/api/src/main/java/marquez/tracing/SentryConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/tracing/SentryPropagating.java
+++ b/api/src/main/java/marquez/tracing/SentryPropagating.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/tracing/TracingContainerResponseFilter.java
+++ b/api/src/main/java/marquez/tracing/TracingContainerResponseFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/tracing/TracingSQLLogger.java
+++ b/api/src/main/java/marquez/tracing/TracingSQLLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/java/marquez/tracing/TracingServletFilter.java
+++ b/api/src/main/java/marquez/tracing/TracingServletFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/main/resources/assets/graphql-playground/index.htm
+++ b/api/src/main/resources/assets/graphql-playground/index.htm
@@ -1,4 +1,7 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+Copyright 2018-2023 contributors to the Marquez project
+SPDX-License-Identifier: Apache-2.0 
+-->
 
 <!DOCTYPE html>
 

--- a/api/src/test/java/marquez/BaseIntegrationTest.java
+++ b/api/src/test/java/marquez/BaseIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/ColumnLineageIntegrationTest.java
+++ b/api/src/test/java/marquez/ColumnLineageIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/DatasetIntegrationTest.java
+++ b/api/src/test/java/marquez/DatasetIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/FlowIntegrationTest.java
+++ b/api/src/test/java/marquez/FlowIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/Generator.java
+++ b/api/src/test/java/marquez/Generator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/MarquezAppIntegrationTest.java
+++ b/api/src/test/java/marquez/MarquezAppIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/NamespaceIntegrationTest.java
+++ b/api/src/test/java/marquez/NamespaceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/OpenLineageIntegrationTest.java
+++ b/api/src/test/java/marquez/OpenLineageIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/PostgresContainer.java
+++ b/api/src/test/java/marquez/PostgresContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/RunIntegrationTest.java
+++ b/api/src/test/java/marquez/RunIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/TagIntegrationTest.java
+++ b/api/src/test/java/marquez/TagIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/api/ApiTestUtils.java
+++ b/api/src/test/java/marquez/api/ApiTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/api/ApiTestUtilsTest.java
+++ b/api/src/test/java/marquez/api/ApiTestUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/api/ColumnLineageResourceTest.java
+++ b/api/src/test/java/marquez/api/ColumnLineageResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/api/JdbiUtils.java
+++ b/api/src/test/java/marquez/api/JdbiUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/api/OpenLineageResourceTest.java
+++ b/api/src/test/java/marquez/api/OpenLineageResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/common/UtilsTest.java
+++ b/api/src/test/java/marquez/common/UtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/common/api/JobResourceIntegrationTest.java
+++ b/api/src/test/java/marquez/common/api/JobResourceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/common/base/MorePreconditionsTest.java
+++ b/api/src/test/java/marquez/common/base/MorePreconditionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/common/models/CommonModelGenerator.java
+++ b/api/src/test/java/marquez/common/models/CommonModelGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/common/models/NamespaceNameTest.java
+++ b/api/src/test/java/marquez/common/models/NamespaceNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/common/models/RunIdTest.java
+++ b/api/src/test/java/marquez/common/models/RunIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/BackfillTestUtils.java
+++ b/api/src/test/java/marquez/db/BackfillTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/ColumnLineageDaoTest.java
+++ b/api/src/test/java/marquez/db/ColumnLineageDaoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/ColumnLineageTestUtils.java
+++ b/api/src/test/java/marquez/db/ColumnLineageTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/ColumnsTest.java
+++ b/api/src/test/java/marquez/db/ColumnsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/DatasetDaoTest.java
+++ b/api/src/test/java/marquez/db/DatasetDaoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/DbTestUtils.java
+++ b/api/src/test/java/marquez/db/DbTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/FlywayFactoryTest.java
+++ b/api/src/test/java/marquez/db/FlywayFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/JobDaoTest.java
+++ b/api/src/test/java/marquez/db/JobDaoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/JobVersionDaoTest.java
+++ b/api/src/test/java/marquez/db/JobVersionDaoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/LineageDaoTest.java
+++ b/api/src/test/java/marquez/db/LineageDaoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/LineageTestUtils.java
+++ b/api/src/test/java/marquez/db/LineageTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/NamespaceDaoTest.java
+++ b/api/src/test/java/marquez/db/NamespaceDaoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/OpenLineageDaoTest.java
+++ b/api/src/test/java/marquez/db/OpenLineageDaoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/RunDaoTest.java
+++ b/api/src/test/java/marquez/db/RunDaoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/SearchDaoTest.java
+++ b/api/src/test/java/marquez/db/SearchDaoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/mappers/DatasetMapperTest.java
+++ b/api/src/test/java/marquez/db/mappers/DatasetMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/mappers/JobMapperTest.java
+++ b/api/src/test/java/marquez/db/mappers/JobMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/models/ColumnLineageNodeDataTest.java
+++ b/api/src/test/java/marquez/db/models/ColumnLineageNodeDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/db/models/DbModelGenerator.java
+++ b/api/src/test/java/marquez/db/models/DbModelGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/graphql/GraphqlTest.java
+++ b/api/src/test/java/marquez/graphql/GraphqlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/graphql/LineageTest.java
+++ b/api/src/test/java/marquez/graphql/LineageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/jdbi/JdbiExternalPostgresExtension.java
+++ b/api/src/test/java/marquez/jdbi/JdbiExternalPostgresExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/jdbi/MarquezJdbiExternalPostgresExtension.java
+++ b/api/src/test/java/marquez/jdbi/MarquezJdbiExternalPostgresExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/jdbi/Migration.java
+++ b/api/src/test/java/marquez/jdbi/Migration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/service/ColumnLineageServiceTest.java
+++ b/api/src/test/java/marquez/service/ColumnLineageServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/service/LineageServiceTest.java
+++ b/api/src/test/java/marquez/service/LineageServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/service/OpenLineageServiceIntegrationTest.java
+++ b/api/src/test/java/marquez/service/OpenLineageServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/service/models/ColumnLineageTest.java
+++ b/api/src/test/java/marquez/service/models/ColumnLineageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/service/models/GraphTest.java
+++ b/api/src/test/java/marquez/service/models/GraphTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/service/models/LineageEventTest.java
+++ b/api/src/test/java/marquez/service/models/LineageEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/service/models/NodeIdTest.java
+++ b/api/src/test/java/marquez/service/models/NodeIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/service/models/ServiceModelGenerator.java
+++ b/api/src/test/java/marquez/service/models/ServiceModelGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/api/src/test/java/marquez/service/models/VersionTest.java
+++ b/api/src/test/java/marquez/service/models/VersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -200,3 +200,7 @@ kubectl logs -p <podName>
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/MarquezProject/marquez-chart/blob/master/CONTRIBUTING.md) for more details about how to contribute.
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -56,3 +56,7 @@ MarquezClient client = MarquezClient.builder()
   .baseUrl("https://localhost:5000")
   .build();
 ```
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/clients/java/src/main/java/marquez/client/Clients.java
+++ b/clients/java/src/main/java/marquez/client/Clients.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/MarquezClient.java
+++ b/clients/java/src/main/java/marquez/client/MarquezClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/MarquezClientException.java
+++ b/clients/java/src/main/java/marquez/client/MarquezClientException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/MarquezHttp.java
+++ b/clients/java/src/main/java/marquez/client/MarquezHttp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/MarquezHttpException.java
+++ b/clients/java/src/main/java/marquez/client/MarquezHttpException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/MarquezPathV1.java
+++ b/clients/java/src/main/java/marquez/client/MarquezPathV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/MarquezUrl.java
+++ b/clients/java/src/main/java/marquez/client/MarquezUrl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/Utils.java
+++ b/clients/java/src/main/java/marquez/client/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/ColumnLineage.java
+++ b/clients/java/src/main/java/marquez/client/models/ColumnLineage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/ColumnLineageInputField.java
+++ b/clients/java/src/main/java/marquez/client/models/ColumnLineageInputField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/ColumnLineageNodeData.java
+++ b/clients/java/src/main/java/marquez/client/models/ColumnLineageNodeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/Dataset.java
+++ b/clients/java/src/main/java/marquez/client/models/Dataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/DatasetFieldId.java
+++ b/clients/java/src/main/java/marquez/client/models/DatasetFieldId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/DatasetFieldVersionId.java
+++ b/clients/java/src/main/java/marquez/client/models/DatasetFieldVersionId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/DatasetId.java
+++ b/clients/java/src/main/java/marquez/client/models/DatasetId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/DatasetMeta.java
+++ b/clients/java/src/main/java/marquez/client/models/DatasetMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/DatasetType.java
+++ b/clients/java/src/main/java/marquez/client/models/DatasetType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/DatasetVersion.java
+++ b/clients/java/src/main/java/marquez/client/models/DatasetVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/DatasetVersionId.java
+++ b/clients/java/src/main/java/marquez/client/models/DatasetVersionId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/DbTable.java
+++ b/clients/java/src/main/java/marquez/client/models/DbTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/DbTableMeta.java
+++ b/clients/java/src/main/java/marquez/client/models/DbTableMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/DbTableVersion.java
+++ b/clients/java/src/main/java/marquez/client/models/DbTableVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/Edge.java
+++ b/clients/java/src/main/java/marquez/client/models/Edge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/Field.java
+++ b/clients/java/src/main/java/marquez/client/models/Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/Job.java
+++ b/clients/java/src/main/java/marquez/client/models/Job.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/JobId.java
+++ b/clients/java/src/main/java/marquez/client/models/JobId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/JobMeta.java
+++ b/clients/java/src/main/java/marquez/client/models/JobMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/JobType.java
+++ b/clients/java/src/main/java/marquez/client/models/JobType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/JobVersion.java
+++ b/clients/java/src/main/java/marquez/client/models/JobVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/JobVersionId.java
+++ b/clients/java/src/main/java/marquez/client/models/JobVersionId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/LineageEvent.java
+++ b/clients/java/src/main/java/marquez/client/models/LineageEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/Namespace.java
+++ b/clients/java/src/main/java/marquez/client/models/Namespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/NamespaceMeta.java
+++ b/clients/java/src/main/java/marquez/client/models/NamespaceMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/Node.java
+++ b/clients/java/src/main/java/marquez/client/models/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/NodeData.java
+++ b/clients/java/src/main/java/marquez/client/models/NodeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/NodeId.java
+++ b/clients/java/src/main/java/marquez/client/models/NodeId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/NodeType.java
+++ b/clients/java/src/main/java/marquez/client/models/NodeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/Run.java
+++ b/clients/java/src/main/java/marquez/client/models/Run.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/RunMeta.java
+++ b/clients/java/src/main/java/marquez/client/models/RunMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/RunState.java
+++ b/clients/java/src/main/java/marquez/client/models/RunState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/SearchFilter.java
+++ b/clients/java/src/main/java/marquez/client/models/SearchFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/SearchResult.java
+++ b/clients/java/src/main/java/marquez/client/models/SearchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/SearchResults.java
+++ b/clients/java/src/main/java/marquez/client/models/SearchResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/SearchSort.java
+++ b/clients/java/src/main/java/marquez/client/models/SearchSort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/Source.java
+++ b/clients/java/src/main/java/marquez/client/models/Source.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/SourceMeta.java
+++ b/clients/java/src/main/java/marquez/client/models/SourceMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/Stream.java
+++ b/clients/java/src/main/java/marquez/client/models/Stream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/StreamMeta.java
+++ b/clients/java/src/main/java/marquez/client/models/StreamMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/StreamVersion.java
+++ b/clients/java/src/main/java/marquez/client/models/StreamVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/main/java/marquez/client/models/Tag.java
+++ b/clients/java/src/main/java/marquez/client/models/Tag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/MarquezClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/MarquezPathV1Test.java
+++ b/clients/java/src/test/java/marquez/client/MarquezPathV1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/MarquezUrlTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezUrlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/UtilsTest.java
+++ b/clients/java/src/test/java/marquez/client/UtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/DbTableMetaTest.java
+++ b/clients/java/src/test/java/marquez/client/models/DbTableMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/DbTableTest.java
+++ b/clients/java/src/test/java/marquez/client/models/DbTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/DbTableVersionTest.java
+++ b/clients/java/src/test/java/marquez/client/models/DbTableVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/EdgeTest.java
+++ b/clients/java/src/test/java/marquez/client/models/EdgeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/JobMetaTest.java
+++ b/clients/java/src/test/java/marquez/client/models/JobMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/JobTest.java
+++ b/clients/java/src/test/java/marquez/client/models/JobTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/JsonGenerator.java
+++ b/clients/java/src/test/java/marquez/client/models/JsonGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/ModelGenerator.java
+++ b/clients/java/src/test/java/marquez/client/models/ModelGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/NamespaceMetaTest.java
+++ b/clients/java/src/test/java/marquez/client/models/NamespaceMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/NamespaceTest.java
+++ b/clients/java/src/test/java/marquez/client/models/NamespaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/NodeIdTest.java
+++ b/clients/java/src/test/java/marquez/client/models/NodeIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/RunMetaTest.java
+++ b/clients/java/src/test/java/marquez/client/models/RunMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/RunTest.java
+++ b/clients/java/src/test/java/marquez/client/models/RunTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/SourceMetaTest.java
+++ b/clients/java/src/test/java/marquez/client/models/SourceMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/SourceTest.java
+++ b/clients/java/src/test/java/marquez/client/models/SourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/StreamMetaTest.java
+++ b/clients/java/src/test/java/marquez/client/models/StreamMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/StreamTest.java
+++ b/clients/java/src/test/java/marquez/client/models/StreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/java/src/test/java/marquez/client/models/StreamVersionTest.java
+++ b/clients/java/src/test/java/marquez/client/models/StreamVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 contributors to the Marquez project
+ * Copyright 2018-2023 contributors to the Marquez project
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -56,3 +56,7 @@ To run the entire test suite:
 ```bash
 $ pytest
 ```
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/clients/python/examples/simple.py
+++ b/clients/python/examples/simple.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 
 from marquez_client import Clients

--- a/clients/python/marquez_client/__init__.py
+++ b/clients/python/marquez_client/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 #
 # -*- coding: utf-8 -*-

--- a/clients/python/marquez_client/client.py
+++ b/clients/python/marquez_client/client.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/clients/python/marquez_client/clients.py
+++ b/clients/python/marquez_client/clients.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/clients/python/marquez_client/constants.py
+++ b/clients/python/marquez_client/constants.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 
 DEFAULT_TIMEOUT_MS = 10000

--- a/clients/python/marquez_client/errors.py
+++ b/clients/python/marquez_client/errors.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 
 class MarquezError(Exception):

--- a/clients/python/marquez_client/models.py
+++ b/clients/python/marquez_client/models.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/clients/python/marquez_client/utils.py
+++ b/clients/python/marquez_client/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 #
 # -*- coding: utf-8 -*-

--- a/clients/python/tests/__init__.py
+++ b/clients/python/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 #
 # -*- coding: utf-8 -*-

--- a/clients/python/tests/test_marquez_client.py
+++ b/clients/python/tests/test_marquez_client.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 
 import mock

--- a/clients/python/tests/test_marquez_clients.py
+++ b/clients/python/tests/test_marquez_clients.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/clients/python/tests/test_utils.py
+++ b/clients/python/tests/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest.mock import patch, MagicMock

--- a/docker/build-and-push.sh
+++ b/docker/build-and-push.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 #
 # Usage: $ ./build-and-push.sh <version>

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 #
 # Usage: $ ./entrypoint.sh

--- a/docker/init-db.sh
+++ b/docker/init-db.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 #
 # Usage: $ ./init-db.sh

--- a/docker/login.sh
+++ b/docker/login.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 #
 # Usage: $ ./login.sh

--- a/docker/prune.sh
+++ b/docker/prune.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 #
 # Usage: $ ./prune.sh

--- a/docker/seed.sh
+++ b/docker/seed.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 #
 # Usage: $ ./seed.sh

--- a/docker/up.sh
+++ b/docker/up.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/docker/volumes.sh
+++ b/docker/volumes.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 
 VOLUME_PREFIX=$1

--- a/docker/wait-for-it.sh
+++ b/docker/wait-for-it.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 #
 # see: https://github.com/vishnubob/wait-for-it

--- a/docs/_layouts/deployment-overview.html
+++ b/docs/_layouts/deployment-overview.html
@@ -1,3 +1,8 @@
+<!--
+Copyright 2018-2023 contributors to the Marquez project
+SPDX-License-Identifier: Apache-2.0 
+-->
+
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
 <head>

--- a/docs/_layouts/index.html
+++ b/docs/_layouts/index.html
@@ -1,3 +1,8 @@
+<!--
+Copyright 2018-2023 contributors to the Marquez project
+SPDX-License-Identifier: Apache-2.0 
+-->
+
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>

--- a/docs/_layouts/quickstart.html
+++ b/docs/_layouts/quickstart.html
@@ -1,3 +1,8 @@
+<!--
+Copyright 2018-2023 contributors to the Marquez project
+SPDX-License-Identifier: Apache-2.0 
+-->
+
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>

--- a/docs/_layouts/running-on-aws.html
+++ b/docs/_layouts/running-on-aws.html
@@ -1,3 +1,8 @@
+<!--
+Copyright 2018-2023 contributors to the Marquez project
+SPDX-License-Identifier: Apache-2.0 
+-->
+
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
 <head>

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -37,3 +37,7 @@ $ flyway migrate \
     -password=*** \
     -locations=filesystem:path/to/marquez/db/migration
 ```
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/docs/deployment-overview.md
+++ b/docs/deployment-overview.md
@@ -59,3 +59,7 @@ Our [clients](https://github.com/MarquezProject/marquez/tree/main/clients) suppo
 The following guides will help you and your team effectively deploy and manage Marquez in a cloud environment:
 
 * [Running Marquez on AWS](running-on-aws.html)
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,3 +105,7 @@ If you’re interested in using or learning more about Marquez, reach out to us 
 * [Data Lineage with Apache Airflow using Marquez](https://www.youtube.com/watch?v=BIVUXruv5io) by Willy Lulciuc at CRUNCH '19
 * [Marquez: An Open Source Metadata Service for ML Platforms](https://www.slideshare.net/WillyLulciuc/marquez-an-open-source-metadata-service-for-ml-platforms) by Willy Lulciuc, Shawn Shah at AI NEXTCon SF '19
 * [Marquez: A Metadata Service for Data Abstraction, Data Lineage, and Event-based Triggers](https://www.datacouncil.ai/speaker/marquez-a-metadata-service-for-data-abstraction-data-lineage-and-event-based-triggers) by Willy Lulciuc at DataEngConf NYC '18
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -88,3 +88,7 @@ export default function () {
    ```
 
    > **Note:** To learn how to run tests locally with `k6`, see [_Running k6_](https://k6.io/docs/getting-started/running-k6).
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/docs/openapi.html
+++ b/docs/openapi.html
@@ -1,3 +1,8 @@
+<!--
+Copyright 2018-2023 contributors to the Marquez project
+SPDX-License-Identifier: Apache-2.0 
+-->
+
 <!DOCTYPE html>
 <html>
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -112,3 +112,7 @@ In this simple example, we showed you how to write sample lineage metadata to a 
 ## Feedback
 
 What did you think of this guide? You can reach out to us on [slack](http://bit.ly/MarquezSlack) and leave us feedback, or [open a pull request](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#submitting-a-pull-request) with your suggestions!  
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -89,3 +89,7 @@ If the job can not be introspected statically, we will have to capture the infor
  Now that we have updated all the dependencies of the job we can update the job itself, we **must refer to the runId** that this is for.
 - POST /namespaces/{namespace}/jobs/{name}/runs/{id}/complete
  We mark the run as successful (similarly 'fail' for a failed job)
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/docs/run-state-transitions.md
+++ b/docs/run-state-transitions.md
@@ -225,3 +225,7 @@ Parent job failure does not impact the status of the datasets created by child j
   * JobC@Run1 produces DatasetZ@V2
   
 ![Parent has failed child jobs](./assets/dot/parent_job_failed_dataset_creation.dot.png)
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/docs/running-on-aws.md
+++ b/docs/running-on-aws.md
@@ -110,3 +110,7 @@ Next, create an AWS RDS instance as outlined in the AWS RDS [documentation](http
 ```bash
 helm uninstall marquez --namespace marquez
 ```
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/examples/airflow/README.md
+++ b/examples/airflow/README.md
@@ -308,3 +308,7 @@ _Congrats_! You successfully step through a troubleshooting scenario of a failin
 # Feedback
 
 What did you think of this example? You can reach out to us on [slack](http://bit.ly/MarquezSlack) and leave us feedback, or [open a pull request](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#submitting-a-pull-request) with your suggestions!
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/examples/airflow/docker/build.sh
+++ b/examples/airflow/docker/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 
 REPO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd ../../../ &> /dev/null && pwd )"

--- a/examples/airflow/docker/init-db.sh
+++ b/examples/airflow/docker/init-db.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 #
 # Usage: $ ./init-db.sh

--- a/examples/airflow/docker/wait-for-it.sh
+++ b/examples/airflow/docker/wait-for-it.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 #
 # see: https://github.com/vishnubob/wait-for-it

--- a/generate_dot_images.sh
+++ b/generate_dot_images.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+#
+# Copyright 2018-2023 contributors to the Marquez project
+# SPDX-License-Identifier: Apache-2.0
 
 for l in `ls docs/assets/dot/*.dot`; do
   name=$(basename $l)

--- a/new-version.sh
+++ b/new-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 #
 # Requirements:

--- a/proposals/2045-column-lineage-endpoint.md
+++ b/proposals/2045-column-lineage-endpoint.md
@@ -148,3 +148,7 @@ Dataset version -> run that produced it -> consumed Dataset Versions.
 ## Next Steps
 
 Review of this proposal and production of detailed design for the implementation.:
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/proposals/2078-optimization-ol-facets.md
+++ b/proposals/2078-optimization-ol-facets.md
@@ -201,3 +201,7 @@ The second migration step will not start unless the condition is met.
 For users, who attempt to run two migration steps in a single run,
 the second step will fail and ask to manually run data migration command and retry migration after
 the command runs successfully. Table `migration_lock` will be dropped at the end of second migration step.
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/proposals/2117-marquez-over-time.md
+++ b/proposals/2117-marquez-over-time.md
@@ -37,3 +37,7 @@ Future steps
  
  * Implementing Run-Level Lineage may require database model changes in Marquez and this deserves a separate proposal or design document which is out of scope of this doc. 
  * Run-Level column lineage can be implemented within issue #2262.
+
+ ----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/proposals/2180-search-service.md
+++ b/proposals/2180-search-service.md
@@ -121,3 +121,7 @@ interface SearchService {
 
 Current implementation of `SearchDao` should be renamed into `SimpleSearchDao` and used by a `SimpleSearchService` 
 with empty `index` methods. 
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -21,3 +21,7 @@ Once your proposal has been _`accepted`_, and has been associated with a milesto
 ## Questions?
 
 If you need help with the proposal process, please reach out to us on our [slack](http://bit.ly/MarquezSlack) channel.
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/proposals/TEMPLATE.md
+++ b/proposals/TEMPLATE.md
@@ -23,3 +23,11 @@ Dicussion: [_Link to issue with dicussion on the change being proposed._]
 ## Next Steps
 
 [_A discussion of related issue(s) for this proposal, who will be assigned to work on them, timeline for when the change being proposed will be worked on, etc. **You may omit this section if there are none.**_]
+
+## License Footer
+
+[_Include an Apache 2.0 license footer. Feel free to copy and paste the footer below._]
+
+----
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.

--- a/web/docker/entrypoint.sh
+++ b/web/docker/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2018-2022 contributors to the Marquez project
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 #
 # Usage: $ ./entrypoint.sh

--- a/web/globalSetup.ts
+++ b/web/globalSetup.ts
@@ -1,3 +1,6 @@
+// Copyright 2018-2023 contributors to the Marquez project
+// SPDX-License-Identifier: Apache-2.0
+
 module.exports = async () => {
   process.env.TZ = 'UTC'
 }

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,4 +1,7 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+Copyright 2018-2023 contributors to the Marquez project
+SPDX-License-Identifier: Apache-2.0 
+-->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/web/setupEnzyme.ts
+++ b/web/setupEnzyme.ts
@@ -1,3 +1,6 @@
+// Copyright 2018-2023 contributors to the Marquez project
+// SPDX-License-Identifier: Apache-2.0
+
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 

--- a/web/setupJest.ts
+++ b/web/setupJest.ts
@@ -1,3 +1,6 @@
+// Copyright 2018-2023 contributors to the Marquez project
+// SPDX-License-Identifier: Apache-2.0
+
 require('es6-promise').polyfill()
 
 global.__NODE_ENV__ = 'test'

--- a/web/src/__tests__/components/AppBar.test.tsx
+++ b/web/src/__tests__/components/AppBar.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 describe('AppBar Test', () => {

--- a/web/src/__tests__/components/DatasetDetailPage.test.tsx
+++ b/web/src/__tests__/components/DatasetDetailPage.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react'

--- a/web/src/__tests__/components/Dialog.test.tsx
+++ b/web/src/__tests__/components/Dialog.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react'

--- a/web/src/__tests__/components/JobDetailPage.test.tsx
+++ b/web/src/__tests__/components/JobDetailPage.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react'

--- a/web/src/__tests__/helpers/index.test.ts
+++ b/web/src/__tests__/helpers/index.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { createNetworkData, formatUpdatedAt } from '../../helpers'

--- a/web/src/__tests__/reducers/datasets.test.ts
+++ b/web/src/__tests__/reducers/datasets.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as actionTypes from '../../store/actionCreators/actionTypes'

--- a/web/src/__tests__/reducers/jobs.test.ts
+++ b/web/src/__tests__/reducers/jobs.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as actionTypes from '../../store/actionCreators/actionTypes'

--- a/web/src/__tests__/requests/index.test.ts
+++ b/web/src/__tests__/requests/index.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as requestUtils from '../../store/requests'

--- a/web/src/__tests__/sagas/index.test.ts
+++ b/web/src/__tests__/sagas/index.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as actionTypes from '../../store/actionCreators/actionTypes'

--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box, Container, CssBaseline } from '@material-ui/core'

--- a/web/src/components/Dialog.tsx
+++ b/web/src/components/Dialog.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react'

--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react'

--- a/web/src/components/bottom-bar/BottomBar.tsx
+++ b/web/src/components/bottom-bar/BottomBar.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react'

--- a/web/src/components/core/chip/MqChip.tsx
+++ b/web/src/components/core/chip/MqChip.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'

--- a/web/src/components/core/chip/MqChipGroup.tsx
+++ b/web/src/components/core/chip/MqChipGroup.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react'

--- a/web/src/components/core/code/MqCode.tsx
+++ b/web/src/components/core/code/MqCode.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { THEME_EXTRA, theme } from '../../../helpers/theme'

--- a/web/src/components/core/code/MqJson.tsx
+++ b/web/src/components/core/code/MqJson.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { THEME_EXTRA, theme } from '../../../helpers/theme'

--- a/web/src/components/core/date-picker/MqDatePicker.tsx
+++ b/web/src/components/core/date-picker/MqDatePicker.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { DateTimePicker } from '@material-ui/pickers'

--- a/web/src/components/core/empty/MqEmpty.tsx
+++ b/web/src/components/core/empty/MqEmpty.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box, Theme, createStyles } from '@material-ui/core'

--- a/web/src/components/core/icon-button/MqIconButton.tsx
+++ b/web/src/components/core/icon-button/MqIconButton.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react'

--- a/web/src/components/core/input-base/MqInputBase.tsx
+++ b/web/src/components/core/input-base/MqInputBase.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { Theme, createStyles, withStyles } from '@material-ui/core'

--- a/web/src/components/core/screen-load/MqScreenLoad.tsx
+++ b/web/src/components/core/screen-load/MqScreenLoad.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { HEADER_HEIGHT } from '../../../helpers/theme'

--- a/web/src/components/core/small-icon/MqSmallIcon.tsx
+++ b/web/src/components/core/small-icon/MqSmallIcon.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/web/src/components/core/text/MqText.tsx
+++ b/web/src/components/core/text/MqText.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react'

--- a/web/src/components/datasets/DatasetColumnLineage.tsx
+++ b/web/src/components/datasets/DatasetColumnLineage.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as Redux from 'redux'

--- a/web/src/components/datasets/DatasetDetailPage.tsx
+++ b/web/src/components/datasets/DatasetDetailPage.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as Redux from 'redux'

--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core'

--- a/web/src/components/datasets/DatasetVersions.tsx
+++ b/web/src/components/datasets/DatasetVersions.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { ArrowBackIosRounded } from '@material-ui/icons'

--- a/web/src/components/header/Header.tsx
+++ b/web/src/components/header/Header.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { API_DOCS_URL } from '../../globals'

--- a/web/src/components/jobs/JobDetailPage.tsx
+++ b/web/src/components/jobs/JobDetailPage.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ChangeEvent, FunctionComponent, SetStateAction, useEffect } from 'react'

--- a/web/src/components/jobs/RunInfo.tsx
+++ b/web/src/components/jobs/RunInfo.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box } from '@material-ui/core'

--- a/web/src/components/jobs/RunStatus.tsx
+++ b/web/src/components/jobs/RunStatus.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box, Theme, Tooltip, WithStyles, createStyles, withStyles } from '@material-ui/core'

--- a/web/src/components/jobs/Runs.tsx
+++ b/web/src/components/jobs/Runs.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { ArrowBackIosRounded } from '@material-ui/icons'

--- a/web/src/components/lineage/Lineage.tsx
+++ b/web/src/components/lineage/Lineage.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react'

--- a/web/src/components/lineage/components/drag-bar/DragBar.tsx
+++ b/web/src/components/lineage/components/drag-bar/DragBar.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react'

--- a/web/src/components/lineage/components/edge/Edge.tsx
+++ b/web/src/components/lineage/components/edge/Edge.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { GraphEdge } from 'dagre'

--- a/web/src/components/lineage/components/node/Node.tsx
+++ b/web/src/components/lineage/components/node/Node.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react'

--- a/web/src/components/lineage/components/node/NodeText.tsx
+++ b/web/src/components/lineage/components/node/NodeText.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { Node as GraphNode } from 'dagre'

--- a/web/src/components/lineage/config.ts
+++ b/web/src/components/lineage/config.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 export const DAGRE_CONFIG = {

--- a/web/src/components/lineage/types.ts
+++ b/web/src/components/lineage/types.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { Field, Run, Tag } from '../../types/api'

--- a/web/src/components/namespace-select/NamespaceSelect.tsx
+++ b/web/src/components/namespace-select/NamespaceSelect.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as Redux from 'redux'

--- a/web/src/components/search/Search.tsx
+++ b/web/src/components/search/Search.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as Redux from 'redux'

--- a/web/src/components/search/SearchListItem.tsx
+++ b/web/src/components/search/SearchListItem.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box, Theme, createStyles, darken } from '@material-ui/core'

--- a/web/src/components/search/SearchPlaceholder.tsx
+++ b/web/src/components/search/SearchPlaceholder.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box, Theme, createStyles } from '@material-ui/core'

--- a/web/src/components/sidenav/Sidenav.tsx
+++ b/web/src/components/sidenav/Sidenav.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react'

--- a/web/src/globals.ts
+++ b/web/src/globals.ts
@@ -1,3 +1,6 @@
+// Copyright 2018-2023 contributors to the Marquez project
+// SPDX-License-Identifier: Apache-2.0
+
 //  from webpack
 declare const __NODE_ENV__: string
 declare const __DEVELOPMENT__: boolean

--- a/web/src/helpers/index.ts
+++ b/web/src/helpers/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { isoParse, timeFormat } from 'd3-time-format'

--- a/web/src/helpers/nodes.ts
+++ b/web/src/helpers/nodes.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { JobOrDataset, LineageDataset, LineageJob, MqNode } from '../components/lineage/types'

--- a/web/src/helpers/runs.ts
+++ b/web/src/helpers/runs.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 const globalStyles = require('../global_styles.css')

--- a/web/src/helpers/theme.ts
+++ b/web/src/helpers/theme.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { createTheme } from '@material-ui/core'

--- a/web/src/helpers/time.ts
+++ b/web/src/helpers/time.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import moment from 'moment'

--- a/web/src/i18n/config.ts
+++ b/web/src/i18n/config.ts
@@ -1,3 +1,6 @@
+// Copyright 2018-2023 contributors to the Marquez project
+// SPDX-License-Identifier: Apache-2.0
+
 import { initReactI18next } from 'react-i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -1,4 +1,8 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- 
+Copyright 2018-2023 contributors to the Marquez project
+SPDX-License-Identifier: Apache-2.0SPDX-License-Identifier: Apache-2.0 
+-->
+
 <!DOCTYPE html>
 <html>
   <head>

--- a/web/src/index.prod.html
+++ b/web/src/index.prod.html
@@ -1,4 +1,8 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- 
+Copyright 2018-2023 contributors to the Marquez project
+SPDX-License-Identifier: Apache-2.0SPDX-License-Identifier: Apache-2.0 
+-->
+
 <!DOCTYPE html>
 <html>
     <head>

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -1,3 +1,6 @@
+// Copyright 2018-2023 contributors to the Marquez project
+// SPDX-License-Identifier: Apache-2.0
+
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import App from './components/App'

--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as Redux from 'redux'

--- a/web/src/routes/events/Events.tsx
+++ b/web/src/routes/events/Events.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as Redux from 'redux'

--- a/web/src/routes/jobs/Jobs.tsx
+++ b/web/src/routes/jobs/Jobs.tsx
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as Redux from 'redux'

--- a/web/src/store/actionCreators/actionTypes.ts
+++ b/web/src/store/actionCreators/actionTypes.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 export const APPLICATION_ERROR = 'APPLICATION_ERROR'

--- a/web/src/store/actionCreators/index.ts
+++ b/web/src/store/actionCreators/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as actionTypes from './actionTypes'

--- a/web/src/store/reducers/dataset.ts
+++ b/web/src/store/reducers/dataset.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { Dataset } from '../../types/api'

--- a/web/src/store/reducers/datasetVersions.ts
+++ b/web/src/store/reducers/datasetVersions.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { DatasetVersions } from '../../types/api'

--- a/web/src/store/reducers/datasets.ts
+++ b/web/src/store/reducers/datasets.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { Dataset } from '../../types/api'

--- a/web/src/store/reducers/display.ts
+++ b/web/src/store/reducers/display.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { APPLICATION_ERROR, DIALOG_TOGGLE } from '../actionCreators/actionTypes'

--- a/web/src/store/reducers/events.ts
+++ b/web/src/store/reducers/events.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { Event } from '../../types/api'

--- a/web/src/store/reducers/index.ts
+++ b/web/src/store/reducers/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { History } from 'history'

--- a/web/src/store/reducers/jobs.ts
+++ b/web/src/store/reducers/jobs.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { FETCH_JOBS, FETCH_JOBS_SUCCESS, RESET_JOBS } from '../actionCreators/actionTypes'

--- a/web/src/store/reducers/lineage.ts
+++ b/web/src/store/reducers/lineage.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import {

--- a/web/src/store/reducers/namespaces.ts
+++ b/web/src/store/reducers/namespaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { Namespace } from '../../types/api'

--- a/web/src/store/reducers/runs.ts
+++ b/web/src/store/reducers/runs.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { FETCH_RUNS, FETCH_RUNS_SUCCESS, RESET_RUNS } from '../actionCreators/actionTypes'

--- a/web/src/store/reducers/search.ts
+++ b/web/src/store/reducers/search.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { FETCH_SEARCH, FETCH_SEARCH_SUCCESS } from '../actionCreators/actionTypes'

--- a/web/src/store/requests/datasets.ts
+++ b/web/src/store/requests/datasets.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { API_URL } from '../../globals'

--- a/web/src/store/requests/events.ts
+++ b/web/src/store/requests/events.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { API_URL } from '../../globals'

--- a/web/src/store/requests/index.ts
+++ b/web/src/store/requests/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { APIError, HttpMethod } from '../../types'

--- a/web/src/store/requests/jobs.ts
+++ b/web/src/store/requests/jobs.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { API_URL } from '../../globals'

--- a/web/src/store/requests/lineage.ts
+++ b/web/src/store/requests/lineage.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { API_URL } from '../../globals'

--- a/web/src/store/requests/namespaces.ts
+++ b/web/src/store/requests/namespaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { API_URL } from '../../globals'

--- a/web/src/store/requests/search.ts
+++ b/web/src/store/requests/search.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { API_URL } from '../../globals'

--- a/web/src/store/sagas/index.ts
+++ b/web/src/store/sagas/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as Effects from 'redux-saga/effects'

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { JobOrDataset, LineageNode } from '../components/lineage/types'

--- a/web/src/types/i18next.d.ts
+++ b/web/src/types/i18next.d.ts
@@ -1,3 +1,6 @@
+// Copyright 2018-2023 contributors to the Marquez project
+// SPDX-License-Identifier: Apache-2.0
+
 import { defaultNS, resources } from '../i18n/config'
 
 declare module 'i18next' {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { Job, Run } from './api'

--- a/web/src/types/util/Nullable.ts
+++ b/web/src/types/util/Nullable.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 export type Nullable<T> = T | null

--- a/web/src/types/util/groupBy.ts
+++ b/web/src/types/util/groupBy.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 export function groupBy<T, K extends keyof T>(list: T[], key: K) {

--- a/web/styles.d.ts
+++ b/web/styles.d.ts
@@ -1,3 +1,6 @@
+// Copyright 2018-2023 contributors to the Marquez project
+// SPDX-License-Identifier: Apache-2.0
+
 declare module '*.css' {
   const content: any;
   export = content;

--- a/why-the-dco.md
+++ b/why-the-dco.md
@@ -28,5 +28,5 @@ makes it suitable to add to this project.  See
 
 
 ----
-License: Apache-2.0, 
-Copyright 2018-2022 contributors to the Marquez project.
+SPDX-License-Identifier: Apache-2.0 
+Copyright 2018-2023 contributors to the Marquez project.


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

The SPDX license headers that we added to the project last year are out of date now that it's 2023.

### Solution

This updates the headers across the project with the current year, adding headers where needed.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)