### PR TITLE
Use `docker-compose.web.yml` as base compose file

### DIFF
--- a/docker/up.sh
+++ b/docker/up.sh
@@ -131,9 +131,9 @@ fi
 
 # Enable web UI
 if [[ "${NO_WEB}" = "false" ]]; then
-  # Enable building web UI from source; otherwise use 'latest' build
-  [[ "${BUILD}" = "true" ]] && compose_files+=" -f docker-compose.web-dev.yml" \
-    || compose_files+=" -f docker-compose.web.yml"
+  compose_files+=" -f docker-compose.web.yml"
+  # Enable building web UI from source
+  [[ "${BUILD}" = "true" ]] && compose_files+=" -f docker-compose.web-dev.yml"
 fi
 
 # Create docker volumes for Marquez


### PR DESCRIPTION
### Problem

When the web UI is enabled running `docker/up.sh`, the Marquez HTTP server is not set correctly:

```
marquez-web-1               | [HPM] Proxy created: /api/v1  -> http://undefined:undefined/
marquez-web-1               | App listening on port 3000!
```

### Solution

Use `docker-compose.web.yml` as base compose file, with overrides for `dev` set via `docker-compose.web-dev.yml`.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)