### PR TITLE
Define `marquez.yml` for API load test

### DIFF
--- a/.circleci/api-load-test.sh
+++ b/.circleci/api-load-test.sh
@@ -19,7 +19,7 @@ readonly MARQUEZ_VERSION="0.30.0-SNAPSHOT"
 readonly MARQUEZ_JAR="api/build/libs/marquez-api-${MARQUEZ_VERSION}.jar"
 
 readonly MARQUEZ_HOST="localhost"
-readonly MARQUEZ_ADMIN_PORT=5001 # Use default 'dev' admin port
+readonly MARQUEZ_ADMIN_PORT=8081
 readonly MARQUEZ_URL="http://${MARQUEZ_HOST}:${MARQUEZ_ADMIN_PORT}"
 readonly MARQUEZ_DB="marquez-db"
 
@@ -30,6 +30,24 @@ readonly METADATA_STATS_QUERY=$(cat <<-END
    GROUP BY run_uuid;
 END
 )
+
+# marquez.yml
+cat > marquez.yml <<EOF
+server:
+  applicationConnectors:
+  - type: http
+    port: 8080
+    httpCompliance: RFC7230_LEGACY
+  adminConnectors:
+  - type: http
+    port: 8081
+
+db:
+  driverClass: org.postgresql.Driver
+  url: jdbc:postgresql://localhost:5432/marquez
+  user: marquez
+  password: marquez
+EOF
 
 log() {
   echo -e "\033[1m>>\033[0m ${1}"
@@ -42,8 +60,8 @@ cpu_and_mem_info() {
   cat /proc/meminfo
 }
 
-ol_events_stats() {
-    # Query db for OL events stats
+metadata_stats() {
+  # Query db for metadata stats
   log "load test metadata stats:"
   docker exec "${MARQUEZ_DB}" \
     psql -U marquez -c "${METADATA_STATS_QUERY}"
@@ -64,7 +82,7 @@ log "build http API server..."
 # (3) Start HTTP API server
 log "start http API server..."
 mkdir marquez && \
-  java -jar "${MARQUEZ_JAR}" server marquez.dev.yml > marquez/http.log 2>&1 &
+  java -jar "${MARQUEZ_JAR}" server marquez.yml > marquez/http.log 2>&1 &
 
 # (4) Wait for HTTP API server
 log "waiting for http API server (${MARQUEZ_URL})..."
@@ -87,7 +105,7 @@ mkdir -p k6/results && \
   k6 run --vus 25 --duration 30s api/load-testing/http.js \
     --out json=k6/results/full.json --summary-export=k6/results/summary.json
 
-# Display OL event stats
-ol_events_stats
+# Display metadata stats
+metadata_stats
 
 echo "DONE!"

--- a/api/load-testing/http.js
+++ b/api/load-testing/http.js
@@ -10,7 +10,7 @@ const metadata = new SharedArray('metadata', function () {
 });
 
 export default function () {
-  const url = 'http://localhost:5000/api/v1/lineage';
+  const url = 'http://localhost:8080/api/v1/lineage';
   const params = {
     headers: {
       'Content-Type': 'application/json',

--- a/marquez.dev.yml
+++ b/marquez.dev.yml
@@ -9,7 +9,7 @@ server:
 
 db:
   driverClass: org.postgresql.Driver
-  url: jdbc:postgresql://${POSTGRES_HOST:-localhost}:5432/marquez
+  url: jdbc:postgresql://postgres:5432/marquez
   user: marquez
   password: marquez
 


### PR DESCRIPTION
### Problem

PR #2047 updated the DB host in [`marquez.dev.yml`](https://github.com/MarquezProject/marquez/blob/main/marquez.dev.yml) needed for [`api-load-test.sh`](https://github.com/MarquezProject/marquez/blob/main/.circleci/api-load-test.sh). The update in the config file was a breaking change as discussed in PR [2355](https://github.com/MarquezProject/marquez/pull/2355#discussion_r1073237324) 

### Solution

This PR generates a `marquez.yml` file used by `api-load-test.sh` to run the API load test. This PR also reverts the  DB host update in `marquez.dev.yml`.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)