### PR TITLE
update i18n for column lineage

### DIFF
--- a/web/src/components/datasets/DatasetDetailPage.tsx
+++ b/web/src/components/datasets/DatasetDetailPage.tsx
@@ -170,7 +170,7 @@ const DatasetDetailPage: FunctionComponent<IProps> = props => {
                 disableRipple={true}
               />
               <Tab
-                label={i18next.t('datasets.column_lineage')}
+                label={i18next.t('datasets.column_lineage_tab')}
                 {...a11yProps(1)}
                 disableRipple={true}
               />

--- a/web/src/i18n/config.ts
+++ b/web/src/i18n/config.ts
@@ -64,7 +64,7 @@ i18next
           datasets: {
             latest_tab: 'LATEST SCHEMA',
             history_tab: 'VERSION HISTORY',
-            column_lineage: 'COLUMN LINEAGE',
+            column_lineage_tab: 'COLUMN LINEAGE',
             dialog_delete: 'DELETE',
             dialog_confirmation_title: 'Are you sure?'
           },
@@ -169,6 +169,7 @@ i18next
           datasets: {
             latest_tab: 'DERNIER SCHEMA',
             history_tab: 'HISTORIQUE DES VERSIONS',
+            column_lineage_tab: 'LIGNÉE DE COLONNE',
             dialog_delete: 'EFFACER',
             dialog_confirmation_title: 'Êtes-vous sûr?'
           },
@@ -276,8 +277,10 @@ i18next
           datasets: {
             latest_tab: 'ESQUEMA ÚLTIMO',
             history_tab: 'HISTORIAL DE VERSIONES',
+            column_lineage_tab: 'LINAJE DE COLUMNA',
             dialog_delete: 'ELIMINAR',
-            dialog_confirmation_title: 'Estás seguro?'
+            dialog_confirmation_title: 'Estás seguro?',
+            column_lineage: ''
           },
           datasets_route: {
             empty_title: 'No se encontraron conjuntos de datos',
@@ -383,6 +386,7 @@ i18next
           datasets: {
             latest_tab: 'NAJNOWSZY SCHEMAT',
             history_tab: 'HISTORIA WERSJI',
+            column_lineage_tab: 'RODOWÓD KOLUMNOWY',
             dialog_delete: 'USUNĄĆ',
             dialog_confirmation_title: 'Jesteś pewny?'
           },

--- a/web/src/i18n/config.ts
+++ b/web/src/i18n/config.ts
@@ -279,8 +279,7 @@ i18next
             history_tab: 'HISTORIAL DE VERSIONES',
             column_lineage_tab: 'LINAJE DE COLUMNA',
             dialog_delete: 'ELIMINAR',
-            dialog_confirmation_title: 'Estás seguro?',
-            column_lineage: ''
+            dialog_confirmation_title: 'Estás seguro?'
           },
           datasets_route: {
             empty_title: 'No se encontraron conjuntos de datos',


### PR DESCRIPTION
### Problem

The addition of column lineage included new text in the UI, so the configuration of i18next, the internationalization plugin, needs to be updated to support the new feature.

### Solution

This adds the missing translations to update the i18n for column lineage.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)