### PR TITLE
restore the favicon

### DIFF
--- a/web/webpack.common.js
+++ b/web/webpack.common.js
@@ -46,6 +46,10 @@ module.exports = {
         test: /\.tsx?$/,
         loader: "awesome-typescript-loader"
       },
+      {
+        test: /\.ico$/,
+        loader: 'file-loader'
+      }
     ]
   },
   resolve: {

--- a/web/webpack.prod.js
+++ b/web/webpack.prod.js
@@ -14,7 +14,8 @@ const webpackProd = {
       hash: true,
       minify: true,
       inject: false,
-      template: 'src/index.prod.html'
+      template: 'src/index.prod.html',
+      favicon: 'src/img/favicon.png'
     }),
     new webpack.DefinePlugin({
       __DEVELOPMENT__: JSON.stringify(false),


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

The UI's favicon was not visible in the browser.

### Solution

This configures `HtmlWebpackPlugin` in `webpack.prod` and adds a rule in `webpack.common` to add the icon to the build.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)