### PR TITLE
Add a new script for stopping docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/MarquezProject/marquez/compare/0.29.0...HEAD)
 
+* Added new `docker/down.sh` script that makes it easier to stop local deployment when run detached [`#2380`](https://github.com/MarquezProject/marquez/pull/2380)
+
 ## [0.29.0](https://github.com/MarquezProject/marquez/compare/0.28.0...0.29.0) - 2022-12-19
 
 ### Added

--- a/docker/down.sh
+++ b/docker/down.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+title() {
+  echo -e "\033[1m${1}\033[0m"
+}
+
+usage() {
+  echo "usage: ./$(basename -- ${0}) [--api-port PORT] [--web-port PORT] [--tag TAG]"
+  echo "A script used to bring down Marquez when run via Docker"
+  echo
+  title "ARGUMENTS:"
+  echo "  -a, --api-port int          api port (default: 5000)"
+  echo "  -m, --api-admin-port int    api admin port (default: 5001)"
+  echo "  -w, --web-port int          web port (default: 3000)"
+  echo "  -t, --tag string            image tag (default: latest)"
+  echo
+}
+
+# Change working directory to project root
+project_root=$(git rev-parse --show-toplevel)
+cd "${project_root}/"
+
+compose_files="-f docker-compose.yml"
+args="--remove-orphans"
+
+API_PORT=5000
+API_ADMIN_PORT=5001
+WEB_PORT=3000
+TAG=0.19.0
+while [ $# -gt 0 ]; do
+  case $1 in
+    -a|'--api-port')
+       shift
+       API_PORT="${1}"
+       ;;
+    -m|'--api-admin-port')
+       shift
+       API_ADMIN_PORT="${1}"
+       ;;
+    -w|'--web-port')
+       shift
+       WEB_PORT="${1}"
+       ;;
+    -t|'--tag')
+       shift
+       TAG="${1}"
+       ;;
+    -h|'--help')
+       usage
+       exit 0
+       ;;
+    *) usage
+       exit 1
+       ;;
+  esac
+  shift
+done
+
+API_PORT=${API_PORT} API_ADMIN_PORT=${API_ADMIN_PORT} WEB_PORT=${WEB_PORT} TAG="${TAG}" docker-compose $compose_files down $args


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross@rossturk.com>

### Problem

When starting Docker with `docker/up.sh -d` and wanting to later stop the deployment, there is no clean way to do it.

### Solution

This adds a `docker/down.sh` script that works similarly to up.sh, passing the proper arguments to `docker-compose down`. This is not earth-shattering.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [x] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)