### PR TITLE
UI: Show location button when link to code exist

### DIFF
--- a/web/src/components/jobs/JobDetailPage.tsx
+++ b/web/src/components/jobs/JobDetailPage.tsx
@@ -150,9 +150,11 @@ const JobDetailPage: FunctionComponent<IProps> = props => {
             />
           </Box>
           <Box mr={1}>
-            <Button variant='outlined' color='primary' target={'_blank'} href={job.location}>
-              {i18next.t('jobs.location')}
-            </Button>
+            {job.location && (
+              <Button variant='outlined' color='primary' target={'_blank'} href={job.location}>
+                {i18next.t('jobs.location')}
+              </Button>
+            )}
           </Box>
           <IconButton onClick={() => history.push('/')}>
             <CloseIcon />

--- a/web/src/components/jobs/JobDetailPage.tsx
+++ b/web/src/components/jobs/JobDetailPage.tsx
@@ -150,11 +150,15 @@ const JobDetailPage: FunctionComponent<IProps> = props => {
             />
           </Box>
           <Box mr={1}>
-            {job.location && (
-              <Button variant='outlined' color='primary' target={'_blank'} href={job.location}>
-                {i18next.t('jobs.location')}
-              </Button>
-            )}
+            <Button
+              variant='outlined'
+              color='primary'
+              target={'_blank'}
+              href={job.location}
+              disabled={!job.location}
+            >
+              {i18next.t('jobs.location')}
+            </Button>
           </Box>
           <IconButton onClick={() => history.push('/')}>
             <CloseIcon />


### PR DESCRIPTION
### Problem

According to the issue we are showing button Location (in "Latest Run" tab) also when link is not exist, which is not correct and should be clickable only if link not empty.

Closes: https://github.com/MarquezProject/marquez/issues/2302

### Solution

This PR provide those changes

<img width="1081" alt="image" src="https://user-images.githubusercontent.com/16538183/216466127-6a98cf32-b0b2-434b-b0dd-d8c90198ce1e.png">


### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)