### PR TITLE
Support inputFacets and outputFacets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased](https://github.com/MarquezProject/marquez/compare/0.32.0...HEAD)
 
+### Added
+
+* Support `inputFacets` and `outputFacets` from Openlineage specificatio [`#2417`](https://github.com/MarquezProject/marquez/pull/2417) [@pawel-big-lebowski]( https://github.com/pawel-big-lebowski)  
+  *Adds the ability to store `inputFacets` / `outputFacets` which are sent within datasets.*
+  *Expose them through Marquez API as a member of `Run` resource.*
+
 ## [0.32.0](https://github.com/MarquezProject/marquez/compare/0.31.0...0.32.0) - 2023-03-20
 
 ### Fixed

--- a/api/src/main/java/marquez/common/models/InputDatasetVersion.java
+++ b/api/src/main/java/marquez/common/models/InputDatasetVersion.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.common.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+
+/**
+ * Class used to store dataset version and `inputFacets` which are assigned to datasets within
+ * OpenLineage spec, but are exposed within Marquez api as a part of {@link
+ * marquez.service.models.Run}
+ */
+@EqualsAndHashCode
+@ToString
+@Getter
+public class InputDatasetVersion {
+
+  private final DatasetVersionId datasetVersionId;
+  private final ImmutableMap<String, Object> facets;
+
+  public InputDatasetVersion(
+      @JsonProperty("datasetVersionId") @NonNull DatasetVersionId datasetVersionId,
+      @JsonProperty("facets") @NonNull ImmutableMap<String, Object> facets) {
+    this.datasetVersionId = datasetVersionId;
+    this.facets = facets;
+  }
+}

--- a/api/src/main/java/marquez/common/models/OutputDatasetVersion.java
+++ b/api/src/main/java/marquez/common/models/OutputDatasetVersion.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.common.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+
+/**
+ * Class used to store dataset version and `outputFacets` which are assigned to datasets within
+ * OpenLineage spec, but are exposed within Marquez api as a part of {@link
+ * marquez.service.models.Run}
+ */
+@EqualsAndHashCode
+@ToString
+@Getter
+public class OutputDatasetVersion {
+
+  private final DatasetVersionId datasetVersionId;
+  private final ImmutableMap<String, Object> facets;
+
+  public OutputDatasetVersion(
+      @JsonProperty("datasetVersionId") @NonNull DatasetVersionId datasetVersionId,
+      @JsonProperty("facets") @NonNull ImmutableMap<String, Object> facets) {
+    this.datasetVersionId = datasetVersionId;
+    this.facets = facets;
+  }
+}

--- a/api/src/main/java/marquez/db/Columns.java
+++ b/api/src/main/java/marquez/db/Columns.java
@@ -55,6 +55,7 @@ public final class Columns {
   public static final String NAMESPACE_NAME = "namespace_name";
   public static final String DATASET_NAME = "dataset_name";
   public static final String FACETS = "facets";
+  public static final String DATASET_FACETS = "dataset_facets";
   public static final String TAGS = "tags";
   public static final String IS_HIDDEN = "is_hidden";
 

--- a/api/src/main/java/marquez/db/DatasetDao.java
+++ b/api/src/main/java/marquez/db/DatasetDao.java
@@ -86,7 +86,7 @@ public interface DatasetDao extends BaseDao {
               df.dataset_version_uuid,
               JSONB_AGG(df.facet ORDER BY df.lineage_event_time ASC) AS facets
           FROM dataset_facets_view AS df
-          WHERE df.facet IS NOT NULL
+          WHERE df.facet IS NOT NULL AND (df.type ILIKE 'dataset' OR df.type ILIKE 'unknown')
           GROUP BY df.dataset_version_uuid
       ) f ON f.dataset_version_uuid = d.current_version_uuid
       WHERE CAST((:namespaceName, :datasetName) AS DATASET_NAME) = ANY(d.dataset_symlinks)
@@ -134,7 +134,7 @@ public interface DatasetDao extends BaseDao {
               df.dataset_version_uuid,
               JSONB_AGG(df.facet ORDER BY df.lineage_event_time ASC) AS facets
           FROM dataset_facets_view AS df
-          WHERE df.facet IS NOT NULL
+          WHERE df.facet IS NOT NULL AND (df.type ILIKE 'dataset' OR df.type ILIKE 'unknown')
           GROUP BY df.dataset_version_uuid
       ) f ON f.dataset_version_uuid = d.current_version_uuid
       WHERE d.namespace_name = :namespaceName

--- a/api/src/main/java/marquez/db/DatasetFacetsDao.java
+++ b/api/src/main/java/marquez/db/DatasetFacetsDao.java
@@ -149,6 +149,58 @@ public interface DatasetFacetsDao {
                     FacetUtils.toPgObject(fieldName, jsonNode.get(fieldName))));
   }
 
+  default void insertInputDatasetFacetsFor(
+      @NonNull UUID datasetUuid,
+      @NonNull UUID datasetVersionUuid,
+      @NonNull UUID runUuid,
+      @NonNull Instant lineageEventTime,
+      @NonNull String lineageEventType,
+      @NonNull LineageEvent.InputDatasetFacets inputFacets) {
+    final Instant now = Instant.now();
+
+    JsonNode jsonNode = Utils.getMapper().valueToTree(inputFacets);
+    StreamSupport.stream(
+            Spliterators.spliteratorUnknownSize(jsonNode.fieldNames(), Spliterator.DISTINCT), false)
+        .forEach(
+            fieldName ->
+                insertDatasetFacet(
+                    now,
+                    datasetUuid,
+                    datasetVersionUuid,
+                    runUuid,
+                    lineageEventTime,
+                    lineageEventType,
+                    Type.INPUT,
+                    fieldName,
+                    FacetUtils.toPgObject(fieldName, jsonNode.get(fieldName))));
+  }
+
+  default void insertOutputDatasetFacetsFor(
+      @NonNull UUID datasetUuid,
+      @NonNull UUID datasetVersionUuid,
+      @NonNull UUID runUuid,
+      @NonNull Instant lineageEventTime,
+      @NonNull String lineageEventType,
+      @NonNull LineageEvent.OutputDatasetFacets outputFacets) {
+    final Instant now = Instant.now();
+
+    JsonNode jsonNode = Utils.getMapper().valueToTree(outputFacets);
+    StreamSupport.stream(
+            Spliterators.spliteratorUnknownSize(jsonNode.fieldNames(), Spliterator.DISTINCT), false)
+        .forEach(
+            fieldName ->
+                insertDatasetFacet(
+                    now,
+                    datasetUuid,
+                    datasetVersionUuid,
+                    runUuid,
+                    lineageEventTime,
+                    lineageEventType,
+                    Type.OUTPUT,
+                    fieldName,
+                    FacetUtils.toPgObject(fieldName, jsonNode.get(fieldName))));
+  }
+
   record DatasetFacetRow(
       Instant createdAt,
       UUID datasetUuid,

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -279,6 +279,18 @@ public interface OpenLineageDao extends BaseDao {
                         now,
                         event.getEventType(),
                         facets));
+
+        // InputFacets ...
+        Optional.ofNullable(dataset.getInputFacets())
+            .ifPresent(
+                facets ->
+                    datasetFacetsDao.insertInputDatasetFacetsFor(
+                        record.getDatasetRow().getUuid(),
+                        record.getDatasetVersionRow().getUuid(),
+                        runUuid,
+                        now,
+                        event.getEventType(),
+                        facets));
       }
     }
     bag.setInputs(Optional.ofNullable(datasetInputs));
@@ -308,6 +320,18 @@ public interface OpenLineageDao extends BaseDao {
             .ifPresent(
                 facets ->
                     datasetFacetsDao.insertDatasetFacetsFor(
+                        record.getDatasetRow().getUuid(),
+                        record.getDatasetVersionRow().getUuid(),
+                        runUuid,
+                        now,
+                        event.getEventType(),
+                        facets));
+
+        // OutputFacets ...
+        Optional.ofNullable(dataset.getOutputFacets())
+            .ifPresent(
+                facets ->
+                    datasetFacetsDao.insertOutputDatasetFacetsFor(
                         record.getDatasetRow().getUuid(),
                         record.getDatasetVersionRow().getUuid(),
                         runUuid,

--- a/api/src/main/java/marquez/db/mappers/RunMapper.java
+++ b/api/src/main/java/marquez/db/mappers/RunMapper.java
@@ -6,6 +6,7 @@
 package marquez.db.mappers;
 
 import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.util.stream.Collectors.toList;
 import static marquez.common.models.RunState.NEW;
 import static marquez.db.Columns.stringOrNull;
 import static marquez.db.Columns.stringOrThrow;
@@ -15,7 +16,10 @@ import static marquez.db.Columns.uuidOrNull;
 import static marquez.db.Columns.uuidOrThrow;
 import static marquez.db.mappers.MapperUtils.toFacetsOrNull;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.sql.ResultSet;
@@ -26,18 +30,29 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 import marquez.common.Utils;
+import marquez.common.models.DatasetName;
 import marquez.common.models.DatasetVersionId;
+import marquez.common.models.InputDatasetVersion;
+import marquez.common.models.NamespaceName;
+import marquez.common.models.OutputDatasetVersion;
 import marquez.common.models.RunId;
 import marquez.common.models.RunState;
 import marquez.db.Columns;
 import marquez.service.models.Run;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.postgresql.util.PGobject;
 
+@Slf4j
 public final class RunMapper implements RowMapper<Run> {
   private final String columnPrefix;
+
+  private static final ObjectMapper MAPPER = Utils.getMapper();
 
   public RunMapper() {
     this("");
@@ -56,6 +71,14 @@ public final class RunMapper implements RowMapper<Run> {
     Optional<Long> durationMs =
         Optional.ofNullable(timestampOrNull(results, columnPrefix + Columns.ENDED_AT))
             .flatMap(endedAt -> startedAt.map(s -> s.until(endedAt, MILLIS)));
+    List<QueryDatasetVersion> inputDatasetVersions =
+        columnNames.contains(columnPrefix + Columns.INPUT_VERSIONS)
+            ? toQueryDatasetVersion(results, columnPrefix + Columns.INPUT_VERSIONS)
+            : ImmutableList.of();
+    List<QueryDatasetVersion> outputDatasetVersions =
+        columnNames.contains(columnPrefix + Columns.OUTPUT_VERSIONS)
+            ? toQueryDatasetVersion(results, columnPrefix + Columns.OUTPUT_VERSIONS)
+            : ImmutableList.of();
     return new Run(
         RunId.of(uuidOrThrow(results, columnPrefix + Columns.ROW_UUID)),
         timestampOrThrow(results, columnPrefix + Columns.CREATED_AT),
@@ -77,21 +100,18 @@ public final class RunMapper implements RowMapper<Run> {
         stringOrThrow(results, columnPrefix + Columns.JOB_NAME),
         uuidOrNull(results, columnPrefix + Columns.JOB_VERSION),
         stringOrNull(results, columnPrefix + Columns.LOCATION),
-        columnNames.contains(columnPrefix + Columns.INPUT_VERSIONS)
-            ? toDatasetVersion(results, columnPrefix + Columns.INPUT_VERSIONS)
-            : ImmutableList.of(),
-        columnNames.contains(columnPrefix + Columns.OUTPUT_VERSIONS)
-            ? toDatasetVersion(results, columnPrefix + Columns.OUTPUT_VERSIONS)
-            : ImmutableList.of(),
+        toInputDatasetVersions(results, inputDatasetVersions, true),
+        toOutputDatasetVersions(results, outputDatasetVersions, false),
         toFacetsOrNull(results, columnPrefix + Columns.FACETS));
   }
 
-  private List<DatasetVersionId> toDatasetVersion(ResultSet rs, String column) throws SQLException {
+  private List<QueryDatasetVersion> toQueryDatasetVersion(ResultSet rs, String column)
+      throws SQLException {
     String dsString = rs.getString(column);
     if (dsString == null) {
       return Collections.emptyList();
     }
-    return Utils.fromJson(dsString, new TypeReference<List<DatasetVersionId>>() {});
+    return Utils.fromJson(dsString, new TypeReference<List<QueryDatasetVersion>>() {});
   }
 
   private Map<String, String> toArgsOrNull(ResultSet results, String argsColumn)
@@ -104,5 +124,95 @@ public final class RunMapper implements RowMapper<Run> {
       return null;
     }
     return Utils.fromJson(args, new TypeReference<Map<String, String>>() {});
+  }
+
+  private List<InputDatasetVersion> toInputDatasetVersions(
+      ResultSet rs, List<QueryDatasetVersion> datasetVersionIds, boolean input)
+      throws SQLException {
+    ImmutableList<QueryDatasetFacet> queryFacets = getQueryDatasetFacets(rs);
+    try {
+      return datasetVersionIds.stream()
+          .map(
+              version ->
+                  new InputDatasetVersion(
+                      version.toDatasetVersionId(), getFacetsMap(input, queryFacets, version)))
+          .collect(toList());
+    } catch (IllegalStateException e) {
+      return Collections.emptyList();
+    }
+  }
+
+  private List<OutputDatasetVersion> toOutputDatasetVersions(
+      ResultSet rs, List<QueryDatasetVersion> datasetVersionIds, boolean input)
+      throws SQLException {
+    ImmutableList<QueryDatasetFacet> queryFacets = getQueryDatasetFacets(rs);
+    try {
+      return datasetVersionIds.stream()
+          .map(
+              version ->
+                  new OutputDatasetVersion(
+                      version.toDatasetVersionId(), getFacetsMap(input, queryFacets, version)))
+          .collect(toList());
+    } catch (IllegalStateException e) {
+      return Collections.emptyList();
+    }
+  }
+
+  private ImmutableMap<String, Object> getFacetsMap(
+      boolean input,
+      ImmutableList<QueryDatasetFacet> queryDatasetFacets,
+      QueryDatasetVersion queryDatasetVersion) {
+    return ImmutableMap.copyOf(
+        queryDatasetFacets.stream()
+            .filter(rf -> rf.type.equalsIgnoreCase(input ? "input" : "output"))
+            .filter(rf -> rf.datasetVersionUUID.equals(queryDatasetVersion.datasetVersionUUID))
+            .collect(
+                Collectors.toMap(
+                    QueryDatasetFacet::name,
+                    facet ->
+                        Utils.getMapper()
+                            .convertValue(
+                                Utils.getMapper().valueToTree(facet.facet).get(facet.name),
+                                Object.class),
+                    (a1, a2) -> a2 // in case of duplicates, choose more recent
+                    )));
+  }
+
+  private ImmutableList<QueryDatasetFacet> getQueryDatasetFacets(ResultSet resultSet)
+      throws SQLException {
+    String column = columnPrefix + Columns.DATASET_FACETS;
+    ImmutableList<QueryDatasetFacet> queryDatasetFacets = ImmutableList.of();
+    if (Columns.exists(resultSet, column) && resultSet.getObject(column) != null) {
+      try {
+        queryDatasetFacets =
+            MAPPER.readValue(
+                ((PGobject) resultSet.getObject(column)).getValue(),
+                new TypeReference<ImmutableList<QueryDatasetFacet>>() {});
+      } catch (JsonProcessingException e) {
+        log.error(String.format("Could not read dataset from job row %s", column), e);
+      }
+    }
+    return queryDatasetFacets;
+  }
+
+  record QueryDatasetFacet(
+      @JsonProperty("dataset_version_uuid") String datasetVersionUUID,
+      String name,
+      String type,
+      Object facet) {}
+
+  record QueryDatasetVersion(
+      String namespace,
+      String name,
+      UUID version,
+      // field required to merge input versions with input dataset facets
+      @JsonProperty("dataset_version_uuid") String datasetVersionUUID) {
+    public DatasetVersionId toDatasetVersionId() {
+      return DatasetVersionId.builder()
+          .name(DatasetName.of(name))
+          .namespace(NamespaceName.of(namespace))
+          .version(version)
+          .build();
+    }
   }
 }

--- a/api/src/main/java/marquez/service/models/LineageEvent.java
+++ b/api/src/main/java/marquez/service/models/LineageEvent.java
@@ -309,6 +309,22 @@ public class LineageEvent extends BaseJsonModel {
     @NotNull private String namespace;
     @NotNull private String name;
     @Valid private DatasetFacets facets;
+    @Valid private InputDatasetFacets inputFacets;
+    @Valid private OutputDatasetFacets outputFacets;
+
+    /**
+     * Constructor with three args added manually to support dozens of existing usages created
+     * before adding inputFacets and outputFacets, as Lombok does not provide SomeArgsConstructor.
+     *
+     * @param namespace
+     * @param name
+     * @param facets
+     */
+    public Dataset(String namespace, String name, DatasetFacets facets) {
+      this.namespace = namespace;
+      this.name = name;
+      this.facets = facets;
+    }
   }
 
   @Builder
@@ -560,5 +576,49 @@ public class LineageEvent extends BaseJsonModel {
     @NotNull private String namespace;
     @NotNull private String name;
     @NotNull private String field;
+  }
+
+  @Builder
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Setter
+  @Getter
+  @Valid
+  @ToString
+  public static class InputDatasetFacets {
+
+    @Builder.Default @JsonIgnore private Map<String, Object> additional = new LinkedHashMap<>();
+
+    @JsonAnySetter
+    public void setInputFacet(String key, Object value) {
+      additional.put(key, value);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalFacets() {
+      return additional;
+    }
+  }
+
+  @Builder
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Setter
+  @Getter
+  @Valid
+  @ToString
+  public static class OutputDatasetFacets {
+
+    @Builder.Default @JsonIgnore private Map<String, Object> additional = new LinkedHashMap<>();
+
+    @JsonAnySetter
+    public void setOutputFacet(String key, Object value) {
+      additional.put(key, value);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalFacets() {
+      return additional;
+    }
   }
 }

--- a/api/src/main/java/marquez/service/models/Run.java
+++ b/api/src/main/java/marquez/service/models/Run.java
@@ -25,10 +25,11 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import marquez.api.models.JobVersion;
-import marquez.common.models.DatasetVersionId;
+import marquez.common.models.InputDatasetVersion;
 import marquez.common.models.JobName;
 import marquez.common.models.JobVersionId;
 import marquez.common.models.NamespaceName;
+import marquez.common.models.OutputDatasetVersion;
 import marquez.common.models.RunId;
 import marquez.common.models.RunState;
 
@@ -58,9 +59,10 @@ public final class Run {
   private final String jobName;
   private final UUID jobVersion;
   private final String location;
-  @Getter private final List<DatasetVersionId> inputVersions;
-  @Getter private final List<DatasetVersionId> outputVersions;
+  @Getter private final List<InputDatasetVersion> inputDatasetVersions;
+  @Getter private final List<OutputDatasetVersion> outputDatasetVersions;
   @Getter private final ImmutableMap<String, Object> facets;
+  ;
 
   public Run(
       @NonNull final RunId id,
@@ -77,8 +79,8 @@ public final class Run {
       String jobName,
       UUID jobVersion,
       String location,
-      List<DatasetVersionId> inputVersions,
-      List<DatasetVersionId> outputVersions,
+      List<InputDatasetVersion> inputDatasetVersions,
+      List<OutputDatasetVersion> outputDatasetFacets,
       @Nullable final ImmutableMap<String, Object> facets) {
     this.id = id;
     this.createdAt = createdAt;
@@ -94,8 +96,8 @@ public final class Run {
     this.jobName = jobName;
     this.jobVersion = jobVersion;
     this.location = location;
-    this.inputVersions = inputVersions;
-    this.outputVersions = outputVersions;
+    this.inputDatasetVersions = inputDatasetVersions;
+    this.outputDatasetVersions = outputDatasetFacets;
     this.facets = (facets == null) ? ImmutableMap.of() : facets;
   }
 
@@ -161,11 +163,15 @@ public final class Run {
     private Map<String, String> args;
     private JobVersionId jobVersion;
     private String location;
-    private List<DatasetVersionId> inputVersions;
-    private List<DatasetVersionId> outputVersions;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private ImmutableMap<String, Object> facets;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<InputDatasetVersion> inputDatasetVersions;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<OutputDatasetVersion> outputDatasetVersions;
 
     public Run build() {
       return new Run(
@@ -183,8 +189,8 @@ public final class Run {
           jobVersion.getName().getValue(),
           jobVersion.getVersion(),
           location,
-          inputVersions,
-          outputVersions,
+          inputDatasetVersions,
+          outputDatasetVersions,
           facets);
     }
   }

--- a/api/src/test/java/marquez/FlowIntegrationTest.java
+++ b/api/src/test/java/marquez/FlowIntegrationTest.java
@@ -109,29 +109,41 @@ public class FlowIntegrationTest extends BaseIntegrationTest {
     client.markRunAs(createdRun.getId(), RunState.COMPLETED);
 
     Map<String, Object> body = getRunResponse(createdRun);
-    assertThat(((List<Map<String, String>>) body.get("outputVersions"))).size().isEqualTo(1);
+    assertThat(((List<Map<String, String>>) body.get("outputDatasetVersions"))).size().isEqualTo(1);
     assertInputDatasetVersionDiffersFromOutput(body);
   }
 
   private void assertInputDatasetVersionDiffersFromOutput(Map<String, Object> body)
       throws IOException {
 
-    List<Map<String, String>> inputDatasetVersionIds =
-        ((List<Map<String, String>>) body.get("inputVersions"));
-    assertThat(inputDatasetVersionIds.stream().map(Map::entrySet).collect(Collectors.toList()))
+    List<Map<String, Map<String, String>>> inputDatasetVersionIds =
+        ((List<Map<String, Map<String, String>>>) body.get("inputDatasetVersions"));
+    assertThat(
+            inputDatasetVersionIds.stream()
+                .map(e -> e.get("datasetVersionId"))
+                .map(Map::entrySet)
+                .collect(Collectors.toList()))
         .allMatch(e -> e.contains(entry("namespace", NAMESPACE_NAME)))
         .allMatch(e -> e.contains(entry("name", DATASET_NAME)));
 
-    List<Map<String, String>> outputDatasetVersionIds =
-        ((List<Map<String, String>>) body.get("outputVersions"));
-    assertThat(outputDatasetVersionIds.stream().map(Map::entrySet).collect(Collectors.toList()))
+    List<Map<String, Map<String, String>>> outputDatasetVersionIds =
+        ((List<Map<String, Map<String, String>>>) body.get("outputDatasetVersions"));
+    assertThat(
+            outputDatasetVersionIds.stream()
+                .map(e -> e.get("datasetVersionId"))
+                .map(Map::entrySet)
+                .collect(Collectors.toList()))
         .allMatch(e -> e.contains(entry("namespace", NAMESPACE_NAME)))
         .allMatch(e -> e.contains(entry("name", DATASET_NAME)));
 
     List<String> inputVersions =
-        inputDatasetVersionIds.stream().map(it -> it.get("version")).collect(Collectors.toList());
+        inputDatasetVersionIds.stream()
+            .map(it -> it.get("datasetVersionId").get("version"))
+            .collect(Collectors.toList());
     List<String> outputVersions =
-        outputDatasetVersionIds.stream().map(it -> it.get("version")).collect(Collectors.toList());
+        outputDatasetVersionIds.stream()
+            .map(it -> it.get("datasetVersionId").get("version"))
+            .collect(Collectors.toList());
 
     assertThat(Collections.disjoint(inputVersions, outputVersions)).isTrue();
   }

--- a/api/src/test/java/marquez/db/LineageDaoTest.java
+++ b/api/src/test/java/marquez/db/LineageDaoTest.java
@@ -841,7 +841,7 @@ public class LineageDaoTest {
     // assert that run_args, input/output versions, and run facets are fetched from the dao.
     for (Run run : currentRuns) {
       assertThat(run.getArgs()).hasSize(2);
-      assertThat(run.getOutputVersions()).hasSize(1);
+      assertThat(run.getOutputDatasetVersions()).hasSize(1);
       assertThat(run.getFacets()).hasSize(1);
     }
   }

--- a/api/src/test/java/marquez/db/RunDaoTest.java
+++ b/api/src/test/java/marquez/db/RunDaoTest.java
@@ -25,7 +25,9 @@ import java.util.stream.Stream;
 import marquez.api.JdbiUtils;
 import marquez.common.models.DatasetId;
 import marquez.common.models.DatasetVersionId;
+import marquez.common.models.InputDatasetVersion;
 import marquez.common.models.NamespaceName;
+import marquez.common.models.OutputDatasetVersion;
 import marquez.common.models.RunId;
 import marquez.common.models.RunState;
 import marquez.db.models.ExtendedRunRow;
@@ -87,16 +89,21 @@ class RunDaoTest {
     assertThat(run)
         .isPresent()
         .get()
-        .extracting(Run::getInputVersions, InstanceOfAssertFactories.list(DatasetVersionId.class))
+        .extracting(
+            Run::getInputDatasetVersions, InstanceOfAssertFactories.list(InputDatasetVersion.class))
         .hasSize(jobMeta.getInputs().size())
+        .map(InputDatasetVersion::getDatasetVersionId)
         .map(DatasetVersionId::getName)
         .containsAll(
             jobMeta.getInputs().stream().map(DatasetId::getName).collect(Collectors.toSet()));
 
     assertThat(run)
         .get()
-        .extracting(Run::getOutputVersions, InstanceOfAssertFactories.list(DatasetVersionId.class))
+        .extracting(
+            Run::getOutputDatasetVersions,
+            InstanceOfAssertFactories.list(OutputDatasetVersion.class))
         .hasSize(jobMeta.getOutputs().size())
+        .map(OutputDatasetVersion::getDatasetVersionId)
         .map(DatasetVersionId::getName)
         .containsAll(
             jobMeta.getOutputs().stream().map(DatasetId::getName).collect(Collectors.toSet()));

--- a/api/src/test/java/marquez/service/LineageServiceTest.java
+++ b/api/src/test/java/marquez/service/LineageServiceTest.java
@@ -16,10 +16,11 @@ import java.util.List;
 import java.util.Optional;
 import marquez.api.JdbiUtils;
 import marquez.common.models.DatasetName;
-import marquez.common.models.DatasetVersionId;
+import marquez.common.models.InputDatasetVersion;
 import marquez.common.models.JobId;
 import marquez.common.models.JobName;
 import marquez.common.models.NamespaceName;
+import marquez.common.models.OutputDatasetVersion;
 import marquez.db.DatasetDao;
 import marquez.db.JobDao;
 import marquez.db.LineageDao;
@@ -158,10 +159,13 @@ public class LineageServiceTest {
             .get();
     runAssert.extracting(r -> r.getId().getValue()).isEqualTo(secondRun.getRun().getUuid());
     runAssert
-        .extracting(Run::getInputVersions, InstanceOfAssertFactories.list(DatasetVersionId.class))
+        .extracting(
+            Run::getInputDatasetVersions, InstanceOfAssertFactories.list(InputDatasetVersion.class))
         .hasSize(0);
     runAssert
-        .extracting(Run::getOutputVersions, InstanceOfAssertFactories.list(DatasetVersionId.class))
+        .extracting(
+            Run::getOutputDatasetVersions,
+            InstanceOfAssertFactories.list(OutputDatasetVersion.class))
         .hasSize(1);
 
     // check the output edges for the commonDataset node
@@ -267,10 +271,13 @@ public class LineageServiceTest {
             .get();
     runAssert.extracting(r -> r.getId().getValue()).isEqualTo(secondRun.getRun().getUuid());
     runAssert
-        .extracting(Run::getInputVersions, InstanceOfAssertFactories.list(DatasetVersionId.class))
+        .extracting(
+            Run::getInputDatasetVersions, InstanceOfAssertFactories.list(InputDatasetVersion.class))
         .hasSize(0);
     runAssert
-        .extracting(Run::getOutputVersions, InstanceOfAssertFactories.list(DatasetVersionId.class))
+        .extracting(
+            Run::getOutputDatasetVersions,
+            InstanceOfAssertFactories.list(InputDatasetVersion.class))
         .hasSize(1);
 
     // check the output edges for the commonDataset node

--- a/clients/java/src/main/java/marquez/client/models/InputDatasetVersion.java
+++ b/clients/java/src/main/java/marquez/client/models/InputDatasetVersion.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.client.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import lombok.NonNull;
+import lombok.Value;
+
+/** Class to contain inputFacets. */
+@Value
+public class InputDatasetVersion {
+
+  private final DatasetVersionId datasetVersionId;
+  private final ImmutableMap<String, Object> facets;
+
+  public InputDatasetVersion(
+      @JsonProperty("datasetVersionId") @NonNull DatasetVersionId datasetVersionId,
+      @JsonProperty("facets") @NonNull ImmutableMap<String, Object> facets) {
+    this.datasetVersionId = datasetVersionId;
+    this.facets = facets;
+  }
+}

--- a/clients/java/src/main/java/marquez/client/models/OutputDatasetVersion.java
+++ b/clients/java/src/main/java/marquez/client/models/OutputDatasetVersion.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.client.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import lombok.NonNull;
+import lombok.Value;
+
+/** Class to contain outputFacets. */
+@Value
+public class OutputDatasetVersion {
+
+  private final DatasetVersionId datasetVersionId;
+  private final ImmutableMap<String, Object> facets;
+
+  public OutputDatasetVersion(
+      @JsonProperty("datasetVersionId") @NonNull DatasetVersionId datasetVersionId,
+      @JsonProperty("facets") @NonNull ImmutableMap<String, Object> facets) {
+    this.datasetVersionId = datasetVersionId;
+    this.facets = facets;
+  }
+}

--- a/clients/java/src/main/java/marquez/client/models/Run.java
+++ b/clients/java/src/main/java/marquez/client/models/Run.java
@@ -8,6 +8,8 @@ package marquez.client.models;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -27,6 +29,8 @@ public final class Run extends RunMeta {
   @Nullable private final Long durationMs;
   @Nullable private final Instant endedAt;
   @Getter private final Map<String, Object> facets;
+  @Getter private final List<InputDatasetVersion> inputDatasetVersions;
+  @Getter private final List<OutputDatasetVersion> outputDatasetVersions;
 
   public Run(
       @NonNull final String id,
@@ -39,7 +43,9 @@ public final class Run extends RunMeta {
       @Nullable final Instant endedAt,
       @Nullable final Long durationMs,
       @Nullable final Map<String, String> args,
-      @Nullable final Map<String, Object> facets) {
+      @Nullable final Map<String, Object> facets,
+      @Nullable final List<InputDatasetVersion> inputDatasetVersions,
+      @Nullable final List<OutputDatasetVersion> outputDatasetVersions) {
     super(id, nominalStartTime, nominalEndTime, args);
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
@@ -48,6 +54,10 @@ public final class Run extends RunMeta {
     this.durationMs = durationMs;
     this.endedAt = endedAt;
     this.facets = (facets == null) ? ImmutableMap.of() : ImmutableMap.copyOf(facets);
+    this.inputDatasetVersions =
+        (inputDatasetVersions == null) ? Collections.emptyList() : inputDatasetVersions;
+    this.outputDatasetVersions =
+        (outputDatasetVersions == null) ? Collections.emptyList() : outputDatasetVersions;
   }
 
   public Optional<Instant> getStartedAt() {

--- a/clients/java/src/test/java/marquez/client/MarquezClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezClientTest.java
@@ -14,11 +14,13 @@ import static marquez.client.models.ModelGenerator.newDatasetIdWith;
 import static marquez.client.models.ModelGenerator.newDatasetPhysicalName;
 import static marquez.client.models.ModelGenerator.newDescription;
 import static marquez.client.models.ModelGenerator.newFields;
+import static marquez.client.models.ModelGenerator.newInputDatasetVersion;
 import static marquez.client.models.ModelGenerator.newInputs;
 import static marquez.client.models.ModelGenerator.newJobIdWith;
 import static marquez.client.models.ModelGenerator.newJobType;
 import static marquez.client.models.ModelGenerator.newLocation;
 import static marquez.client.models.ModelGenerator.newNamespaceName;
+import static marquez.client.models.ModelGenerator.newOutputDatasetVersion;
 import static marquez.client.models.ModelGenerator.newOutputs;
 import static marquez.client.models.ModelGenerator.newOwnerName;
 import static marquez.client.models.ModelGenerator.newRunArgs;
@@ -78,6 +80,7 @@ import marquez.client.models.DbTableMeta;
 import marquez.client.models.DbTableVersion;
 import marquez.client.models.Edge;
 import marquez.client.models.Field;
+import marquez.client.models.InputDatasetVersion;
 import marquez.client.models.Job;
 import marquez.client.models.JobId;
 import marquez.client.models.JobMeta;
@@ -89,6 +92,7 @@ import marquez.client.models.NamespaceMeta;
 import marquez.client.models.Node;
 import marquez.client.models.NodeId;
 import marquez.client.models.NodeType;
+import marquez.client.models.OutputDatasetVersion;
 import marquez.client.models.Run;
 import marquez.client.models.RunMeta;
 import marquez.client.models.RunState;
@@ -261,6 +265,13 @@ public class MarquezClientTest {
   private static final Instant ENDED_AT = START_AT.plusMillis(1000L);
   private static final long DURATION = START_AT.until(ENDED_AT, MILLIS);
   private static final Map<String, String> RUN_ARGS = newRunArgs();
+
+  private static final List<InputDatasetVersion> INPUT_RUN_DATASET_FACETS =
+      Collections.singletonList(newInputDatasetVersion());
+
+  private static final List<OutputDatasetVersion> OUTPUT_RUN_DATASET_FACETS =
+      Collections.singletonList(newOutputDatasetVersion());
+
   private static final Run NEW =
       new Run(
           newRunId(),
@@ -273,7 +284,9 @@ public class MarquezClientTest {
           ENDED_AT,
           DURATION,
           RUN_ARGS,
-          null);
+          null,
+          INPUT_RUN_DATASET_FACETS,
+          OUTPUT_RUN_DATASET_FACETS);
   private static final Run RUNNING =
       new Run(
           newRunId(),
@@ -286,7 +299,9 @@ public class MarquezClientTest {
           ENDED_AT,
           DURATION,
           RUN_ARGS,
-          null);
+          null,
+          INPUT_RUN_DATASET_FACETS,
+          OUTPUT_RUN_DATASET_FACETS);
   private static final Run COMPLETED =
       new Run(
           newRunId(),
@@ -299,7 +314,9 @@ public class MarquezClientTest {
           ENDED_AT,
           DURATION,
           RUN_ARGS,
-          null);
+          null,
+          INPUT_RUN_DATASET_FACETS,
+          OUTPUT_RUN_DATASET_FACETS);
   private static final Run ABORTED =
       new Run(
           newRunId(),
@@ -312,7 +329,9 @@ public class MarquezClientTest {
           ENDED_AT,
           DURATION,
           RUN_ARGS,
-          null);
+          null,
+          INPUT_RUN_DATASET_FACETS,
+          OUTPUT_RUN_DATASET_FACETS);
   private static final Run FAILED =
       new Run(
           newRunId(),
@@ -325,7 +344,9 @@ public class MarquezClientTest {
           ENDED_AT,
           DURATION,
           RUN_ARGS,
-          null);
+          null,
+          INPUT_RUN_DATASET_FACETS,
+          OUTPUT_RUN_DATASET_FACETS);
 
   private static final String RUN_ID = newRunId();
   private static final Job JOB_WITH_LATEST_RUN =
@@ -353,7 +374,9 @@ public class MarquezClientTest {
               ENDED_AT,
               DURATION,
               RUN_ARGS,
-              null),
+              null,
+              INPUT_RUN_DATASET_FACETS,
+              OUTPUT_RUN_DATASET_FACETS),
           null,
           null);
 

--- a/clients/java/src/test/java/marquez/client/models/JsonGenerator.java
+++ b/clients/java/src/test/java/marquez/client/models/JsonGenerator.java
@@ -310,12 +310,17 @@ public final class JsonGenerator {
             .put("id", run.getId())
             .put("createdAt", ISO_INSTANT.format(run.getCreatedAt()))
             .put("updatedAt", ISO_INSTANT.format(run.getUpdatedAt()));
+    final ArrayNode inputDatasetVersions = MAPPER.valueToTree(run.getInputDatasetVersions());
+    final ArrayNode outputDatasetVersions = MAPPER.valueToTree(run.getOutputDatasetVersions());
+
     obj.put("nominalStartTime", run.getNominalStartTime().map(ISO_INSTANT::format).orElse(null));
     obj.put("nominalEndTime", run.getNominalEndTime().map(ISO_INSTANT::format).orElse(null));
     obj.put("state", run.getState().name());
     obj.put("startedAt", run.getStartedAt().map(ISO_INSTANT::format).orElse(null));
     obj.put("endedAt", run.getEndedAt().map(ISO_INSTANT::format).orElse(null));
     obj.put("durationMs", run.getDurationMs().orElse(null));
+    obj.putArray("inputDatasetVersions").addAll(inputDatasetVersions);
+    obj.putArray("outputDatasetVersions").addAll(outputDatasetVersions);
 
     final ObjectNode runArgs = MAPPER.createObjectNode();
     run.getArgs().forEach(runArgs::put);

--- a/clients/java/src/test/java/marquez/client/models/ModelGenerator.java
+++ b/clients/java/src/test/java/marquez/client/models/ModelGenerator.java
@@ -238,7 +238,19 @@ public final class ModelGenerator {
   public static Run newRun() {
     final Instant now = newTimestamp();
     return new Run(
-        newRunId(), now, now, now, now, RunState.NEW, null, null, null, newRunArgs(), null);
+        newRunId(),
+        now,
+        now,
+        now,
+        now,
+        RunState.NEW,
+        null,
+        null,
+        null,
+        newRunArgs(),
+        null,
+        null,
+        null);
   }
 
   public static String newOwnerName() {
@@ -393,5 +405,17 @@ public final class ModelGenerator {
 
   public static Map.Entry<String, String> newFacetSchemaURL() {
     return new AbstractMap.SimpleImmutableEntry<>("_schemaURL", "test_schemaURL" + newId());
+  }
+
+  public static InputDatasetVersion newInputDatasetVersion() {
+    return new InputDatasetVersion(
+        new DatasetVersionId(newNamespaceName(), newDatasetName(), UUID.randomUUID()),
+        ImmutableMap.of("datasetFacet", "{some-facet1}"));
+  }
+
+  public static OutputDatasetVersion newOutputDatasetVersion() {
+    return new OutputDatasetVersion(
+        new DatasetVersionId(newNamespaceName(), newDatasetName(), UUID.randomUUID()),
+        ImmutableMap.of("datasetFacet", "{some-facet1}"));
   }
 }

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -475,7 +475,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IncompleteRun'
+                $ref: '#/components/schemas/Run'
 
   /jobs/runs/{id}/facets:
     parameters:
@@ -1734,20 +1734,20 @@ components:
 
     Run:
       type: object
-      allOf:
+      anyOf:
         - $ref: '#/components/schemas/IncompleteRun'
         - type: object
           properties:
             jobVersion:
               $ref: '#/components/schemas/JobVersionId'
-            inputVersions:
+            inputDatasetVersions:
               type: array
               items:
-                $ref: '#/components/schemas/DatasetVersionId'
-            outputVersions:
+                $ref: '#/components/schemas/InputDatasetVersion'
+            outputDatasetVersions:
               type: array
               items:
-                $ref: '#/components/schemas/DatasetVersionId'
+                $ref: '#/components/schemas/OutputDatasetVersion'
             context:
               description: A key/value pair that must be of type `string`. A context can be used for getting additional details about the job.
               type: object
@@ -1956,3 +1956,31 @@ components:
           type: string
         facets:
           $ref: '#/components/schemas/CustomFacet'
+
+    InputDatasetVersion:
+      type: object
+      properties:
+        datasetVersionId:
+          $ref: '#/components/schemas/DatasetVersionId'
+        facets:
+          type: object
+          additionalProperties:
+            type: string
+          description: Dataset facets in run context, like `inputFacets`.
+      required:
+        - datasetVersionId
+        - facets
+
+    OutputDatasetVersion:
+      type: object
+      properties:
+        datasetVersionId:
+          $ref: '#/components/schemas/DatasetVersionId'
+        facets:
+          type: object
+          additionalProperties:
+            type: string
+          description: Dataset facets in run context, like `outputFacets`.
+      required:
+        - datasetVersionId
+        - facets


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Marquez does not support `inputFacets` and `outputFacets` sent in Ol event. They're not saved nor exposed in api. 

Closes: #2320

### Solution

We do have `dataset_facets` table designed for this but we don't store `inputFacets` and `outputFacets` there. 
Although `inputFacets` and `outputFacets` contained within Openlineage event as dataset properties, we want to expose them in `api` as part of a run bcz they describe specific runs rather than datasets or dataset's versions. 

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)