### PR TITLE
add `get_changes` script in new dev directory for automating changelog updates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,12 +10,14 @@ Please describe your change as it relates to the problem, or bug fix, as well as
 
 > **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.
 
+One-line summary:
+
 ### Checklist
 
 - [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
 - [ ] Your changes are accompanied by tests (_if relevant_)
 - [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
 - [ ] You've updated any relevant documentation (_if relevant_)
-- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
+- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
 - [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
 - [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)

--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -1,0 +1,2 @@
+CHANGES.md
+changelog-ci/

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,26 @@
+### Using `get_changes`
+
+The `get_changes.sh` script uses a fork of saadmk11/changelog-ci to get all 
+merged changes between two specified releases. To get all changes since the latest
+release, set `END_RELEASE_VERSION` to the planned next release. 
+
+The changes will appear in this directory in a new file, CHANGES.md.
+
+#### Requirements
+
+See the requirements.txt file for required dependencies.
+
+The script also requires that the following environment variables be set:
+
+`END_RELEASE_VERSION`\
+`START_RELEASE_VERSION`\
+`INPUT_GITHUB_TOKEN`
+
+For example: `export END_RELEASE_VERSION=0.21.0`.
+
+For instructions on creating a GitHub personal access token to use the GitHub API,
+see: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token.
+
+#### Running the script
+
+Make the script executable (the first time), then run it with `./get_changes.sh`.

--- a/dev/get_changes.sh
+++ b/dev/get_changes.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Copyright 2018-2023 contributors to the Marquez project
+# SPDX-License-Identifier: Apache-2.0
+
+export INPUT_CHANGELOG_FILENAME=CHANGES.md
+export GITHUB_REPOSITORY=MarquezProject/marquez
+
+git clone --branch add-testing-script --single-branch git@github.com:merobi-hub/changelog-ci.git
+
+python3 changelog-ci/scripts/main.py
+
+rm -rf changelog-ci 

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,0 +1,3 @@
+PyYAML~=5.4.1
+requests~=2.25.1
+github-action-utils~=1.1.0


### PR DESCRIPTION
### Problem

Tools exist for automatically updating the changelog with all the PRs merged between releases or since the most recent release. Using such tools reduces the burden on contributors when opening PRs. 

### Solution

This adds a script for doing this that can be run at any time, independent of GitHub Actions and CI. Adds minimal code to the project and zero workflows. A readme, requirements.txt and .gitignore are also included. The PR template is edited in line with the automation, as well.
 
> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [x] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)