### PR TITLE
Removed jobs_fqn table and moved FQN into jobs directly in order to enforce unique constraints

### DIFF
--- a/api/src/main/java/marquez/api/JobResource.java
+++ b/api/src/main/java/marquez/api/JobResource.java
@@ -187,8 +187,7 @@ public class JobResource extends BaseResource {
             .findJobByName(namespaceName.getValue(), jobName.getValue())
             .orElseThrow(() -> new JobNotFoundException(jobName));
 
-    // Should be simple name from `jobs_fqn`.
-    jobService.delete(namespaceName.getValue(), job.getSimpleName());
+    jobService.delete(namespaceName.getValue(), job.getName().getValue());
     return Response.ok(job).build();
   }
 

--- a/api/src/main/java/marquez/db/JobDao.java
+++ b/api/src/main/java/marquez/db/JobDao.java
@@ -72,7 +72,6 @@ public interface JobDao extends BaseDao {
       GROUP BY e.run_uuid
     ) f ON f.run_uuid=jv.latest_run_uuid
     WHERE j.namespace_name=:namespaceName AND (j.name=:jobName OR :jobName = ANY(j.aliases))
-    AND j.symlink_target_uuid IS NULL
   """)
   Optional<Job> findJobByName(String namespaceName, String jobName);
 
@@ -121,7 +120,6 @@ public interface JobDao extends BaseDao {
     INNER JOIN namespaces AS n ON j.namespace_uuid = n.uuid
     WHERE j.namespace_name=:namespaceName AND
       (j.name=:jobName OR :jobName = ANY(j.aliases))
-    AND j.symlink_target_uuid IS NULL
   """)
   Optional<JobRow> findJobByNameAsRow(String namespaceName, String jobName);
 
@@ -143,7 +141,6 @@ public interface JobDao extends BaseDao {
       GROUP BY e.run_uuid
     ) f ON f.run_uuid=jv.latest_run_uuid
     WHERE j.namespace_name = :namespaceName
-    AND j.symlink_target_uuid IS NULL
     ORDER BY j.name LIMIT :limit OFFSET :offset
   """)
   List<Job> findAll(String namespaceName, int limit, int offset);
@@ -292,7 +289,6 @@ public interface JobDao extends BaseDao {
     INSERT INTO jobs_view AS j (
       uuid,
       parent_job_uuid,
-      parent_job_uuid_string,
       type,
       created_at,
       updated_at,
@@ -307,7 +303,6 @@ public interface JobDao extends BaseDao {
     ) VALUES (
       :uuid,
       :parentJobUuid,
-      COALESCE(:parentJobUuid::text, ''),
       :type,
       :now,
       :now,

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -170,19 +170,8 @@ public interface OpenLineageDao extends BaseDao {
     Optional<UUID> parentUuid = parentRun.map(Utils::findParentRunUuid);
 
     JobRow job =
-        runDao
-            .findJobRowByRunUuid(runToUuid(event.getRun().getRunId()))
-            .orElseGet(
-                () ->
-                    buildJobFromEvent(
-                        event,
-                        mapper,
-                        jobDao,
-                        now,
-                        namespace,
-                        nominalStartTime,
-                        nominalEndTime,
-                        parentRun));
+        buildJobFromEvent(
+            event, mapper, jobDao, now, namespace, nominalStartTime, nominalEndTime, parentRun);
 
     bag.setJob(job);
 
@@ -812,7 +801,7 @@ public interface OpenLineageDao extends BaseDao {
                 log.error(
                     "Cannot produce column lineage for missing output field in output dataset: {}",
                     columnName);
-                return Stream.<ColumnLineageRow>empty();
+                return Stream.empty();
               }
 
               // get field uuids of input columns related to this run

--- a/api/src/main/resources/marquez/db/migration/R__2_Runs_view.sql
+++ b/api/src/main/resources/marquez/db/migration/R__2_Runs_view.sql
@@ -18,7 +18,8 @@ SELECT r.uuid,
        ended_at,
        job_context_uuid,
        job_uuid,
-       j.name AS job_name,
-       j.namespace_name
+       COALESCE(s.name, j.name) AS job_name,
+       COALESCE(s.namespace_name, j.namespace_name) AS namespace_name
 FROM runs r
-INNER JOIN jobs_view j ON j.uuid = r.job_uuid;
+INNER JOIN jobs j ON j.uuid = r.job_uuid
+LEFT JOIN jobs_view s ON j.symlink_target_uuid=s.uuid;

--- a/api/src/main/resources/marquez/db/migration/V61__unique_job_fqn_index.sql
+++ b/api/src/main/resources/marquez/db/migration/V61__unique_job_fqn_index.sql
@@ -1,0 +1,33 @@
+UPDATE jobs SET symlink_target_uuid=q.target_uuid
+FROM (
+         SELECT j.uuid, j.namespace_name, j.name, j.simple_name, jv.uuid AS target_uuid, jv.simple_name
+         FROM jobs_view j INNER JOIN jobs_view jv ON j.namespace_name=jv.namespace_name AND j.name=jv.name AND j.simple_name != jv.simple_name
+         WHERE j.symlink_target_uuid IS NULL
+           AND jv.symlink_target_uuid IS NULL
+           AND j.parent_job_uuid IS NULL) q
+WHERE jobs.uuid=q.uuid;
+
+ALTER TABLE jobs RENAME COLUMN name TO simple_name;
+ALTER TABLE jobs ADD COLUMN name varchar;
+ALTER TABLE jobs ADD COLUMN aliases varchar[];
+
+WITH RECURSIVE
+    job_fqn AS (SELECT j.uuid,
+                   j.simple_name AS simple_name,
+                   j.simple_name AS name
+            FROM jobs j
+            WHERE j.parent_job_uuid IS NULL
+            UNION
+            SELECT j1.uuid,
+                   j1.simple_name AS simple_name,
+                   f.name || '.' || j1.simple_name AS name
+            FROM jobs j1
+            INNER JOIN job_fqn f ON f.uuid = j1.parent_job_uuid)
+UPDATE jobs SET simple_name=f.simple_name, name=f.name
+FROM job_fqn f
+WHERE jobs.uuid=f.uuid;
+
+ALTER TABLE jobs ALTER COLUMN name SET NOT NULL;
+
+ALTER TABLE jobs DROP CONSTRAINT unique_jobs_namespace_uuid_name_parent;
+ALTER TABLE jobs ADD CONSTRAINT unique_jobs_namespace_uuid_name_parent UNIQUE (namespace_uuid, name);

--- a/api/src/test/java/marquez/api/JdbiUtils.java
+++ b/api/src/test/java/marquez/api/JdbiUtils.java
@@ -30,6 +30,7 @@ public class JdbiUtils {
           handle.execute("DELETE FROM run_args");
           handle.execute("DELETE FROM job_versions_io_mapping");
           handle.execute("DELETE FROM job_versions");
+          handle.execute("DELETE FROM jobs_fqn");
           handle.execute("DELETE FROM jobs");
           handle.execute("DELETE FROM dataset_fields_tag_mapping");
           handle.execute("DELETE FROM dataset_fields");

--- a/api/src/test/java/marquez/db/JobDaoTest.java
+++ b/api/src/test/java/marquez/db/JobDaoTest.java
@@ -57,6 +57,7 @@ public class JobDaoTest {
 
   @AfterEach
   public void cleanUp(Jdbi jdbi) {
+    jdbi.inTransaction(h -> h.execute("DELETE FROM jobs_fqn"));
     jdbi.inTransaction(h -> h.execute("DELETE FROM jobs"));
   }
 


### PR DESCRIPTION
### Problem
The introduction of parent jobs and the `jobs_fqn` table intended to allow Marquez to support jobs that had the same name, but were triggered by different parents (e.g., a Spark job fired by different Airflow DAGs). The `jobs` table tracked the simple name of the job, while the `jobs_fqn` table tracked the fully qualified name (FQN). In addition, the `jobs_fqn` table became responsible for tracking the FQN of symlinked jobs, as it was too expensive to determine the new FQN of a job by following symlinks at query time. Instead, the FQN of a symlinked job is updated when the symlink is created so we return only the FQN of the symlink target rather than the FQN of the original job. 

Unfortunately, this means that neither the `jobs` table nor the `jobs_fqn` table can enforce the uniqueness constraint we had on the fully qualified name of a job. Thus, in production, we see errors like the following when trying to load a job by its name:
```
java.lang.IllegalStateException: Multiple values for optional: ['JobRow(uuid=b971d547-ea9d-44c1-908f-9dcc14faba98, type=BATCH, createdAt=2022-12-10T10:01:56.653991Z, updatedAt=2022-12-10T10:01:56.653991Z, namespaceName=...']
```

In particular, this happens on two occasions when receiving Airflow OpenLineage events:
1. We receive a `FAIL` event with no start event - the parent facet of the run is omitted, so Marquez creates a job with no parent, but the same FQN
2. We receive a `FAIL` event _prior_ to the `START` event - usually, this happens when requests are queued by the load balancer or sometimes when the `START` event itself is particularly large and deserializing takes longer than deserializing the `FAIL` event.

### Solution

This change eliminates the `job_fqn` table and reestablishes the uniqueness constraint on the `jobs` table's `name` column. It also adds a `simple_name` column to the table, which is used by the view to return the column of the same name. Tests for the two cases mentioned above are added to ensure we can handle Airflow events that omit the parent facet.

The `jobs_view` is also updated to omit symlinked jobs so that the read queries no longer have to omit them. `aliases` are moved from the `jobs_fqn` table to the `jobs` table so old job names can still be found. 
### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)