### PR TITLE
Always render MqCode.

### DIFF
--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -121,7 +121,7 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = props => {
             </Box>
             <MqText subdued>{run.jobVersion.name}</MqText>
           </Box>
-          {jobFacets.sql && <MqCode code={(jobFacets.sql as SqlFacet).query} language={'sql'} />}
+          {<MqCode code={(jobFacets?.sql as SqlFacet)?.query} language={'sql'}/>}
         </Box>
       )}
     </Box>

--- a/web/src/components/jobs/RunInfo.tsx
+++ b/web/src/components/jobs/RunInfo.tsx
@@ -53,7 +53,7 @@ const RunInfo: FunctionComponent<RunInfoProps> = props => {
 
   return (
     <Box mt={2}>
-      {jobFacets.sql && <MqCode code={(jobFacets.sql as SqlFacet).query} />}
+      {<MqCode code={(jobFacets?.sql as SqlFacet)?.query} language={'sql'}/>}
       <Box display={'flex'} justifyContent={'flex-end'} alignItems={'center'} mt={1}>
         <Box ml={1}>
           <MqText subdued>{formatUpdatedAt(run.updatedAt)}</MqText>


### PR DESCRIPTION
### Problem

When no SqlJobFacet exists, Dataset and Job info pages fail to render.

Closes: #2453 

### Solution

Always render `MqCode` component and safely pass null if no `sql` property.

One-line summary:

Fix rendering Dataset and Job pages when no SqlJobFacet exists.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)