### PR TITLE
Fix job update SQL to correctly use simple_name for job updates

### DIFF
--- a/api/src/main/resources/marquez/db/migration/R__1_Jobs_view_and_rewrite_function.sql
+++ b/api/src/main/resources/marquez/db/migration/R__1_Jobs_view_and_rewrite_function.sql
@@ -62,7 +62,7 @@ BEGIN
         DO UPDATE SET updated_at               = now(),
                       parent_job_uuid = COALESCE(jobs.parent_job_uuid, EXCLUDED.parent_job_uuid),
                       simple_name = CASE
-                            WHEN EXCLUDED.parent_job_uuid IS NOT NULL THEN EXCLUDED.name
+                            WHEN EXCLUDED.parent_job_uuid IS NOT NULL THEN EXCLUDED.simple_name
                             ELSE jobs.name
                             END,
                       type                     = EXCLUDED.type,

--- a/api/src/test/java/marquez/OpenLineageIntegrationTest.java
+++ b/api/src/test/java/marquez/OpenLineageIntegrationTest.java
@@ -545,7 +545,8 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
     assertThat(job)
         .isNotNull()
         .hasFieldOrPropertyWithValue("id", new JobId(NAMESPACE_NAME, dagName + "." + task1Name))
-        .hasFieldOrPropertyWithValue("parentJobName", dagName);
+        .hasFieldOrPropertyWithValue("parentJobName", dagName)
+        .hasFieldOrPropertyWithValue("simpleName", task1Name);
 
     Job parentJob = client.getJob(NAMESPACE_NAME, dagName);
     assertThat(parentJob)


### PR DESCRIPTION
### Problem

In #2448 we updated the job update logic to support adding a parent to an existing job. However, there was a bug in the update SQL that set the `simple_name` field to the fully qualified name instead. This fix addresses that bug and adds an assertion to the test that covers this case.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)