### PR TITLE
UI: Change color for selected node and edges on graph

### DIFF
--- a/web/src/components/lineage/components/edge/Edge.tsx
+++ b/web/src/components/lineage/components/edge/Edge.tsx
@@ -52,7 +52,7 @@ class Edge extends React.Component<EdgeProps> {
             data={edge.points}
             x={(d, index) => (index === 0 ? d.x + 20 : d.x - 25)}
             y={d => d.y}
-            stroke={edge.isSelected ? theme.palette.common.white : theme.palette.secondary.main}
+            stroke={edge.isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
             strokeWidth={1}
             opacity={1}
             shapeRendering='geometricPrecision'
@@ -66,7 +66,7 @@ class Edge extends React.Component<EdgeProps> {
             y={edge.y - ICON_SIZE / 2}
             width={ICON_SIZE}
             height={ICON_SIZE}
-            color={edge.isSelected ? theme.palette.common.white : theme.palette.secondary.main}
+            color={edge.isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
           />
         ))}
       </>

--- a/web/src/components/lineage/components/node/Node.tsx
+++ b/web/src/components/lineage/components/node/Node.tsx
@@ -62,7 +62,7 @@ class Node extends React.Component<NodeProps> {
               style={{ cursor: 'pointer' }}
               r={RADIUS}
               fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
-              stroke={isSelected ? theme.palette.common.white : theme.palette.secondary.main}
+              stroke={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
               strokeWidth={BORDER / 2}
               cx={node.x}
               cy={node.y}
@@ -76,7 +76,7 @@ class Node extends React.Component<NodeProps> {
               height={ICON_SIZE}
               x={node.x - ICON_SIZE / 2}
               y={node.y - ICON_SIZE / 2}
-              color={isSelected ? theme.palette.common.white : theme.palette.secondary.main}
+              color={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
             />
           </g>
         ) : (
@@ -86,7 +86,7 @@ class Node extends React.Component<NodeProps> {
               x={node.x - RADIUS}
               y={node.y - RADIUS}
               fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
-              stroke={isSelected ? theme.palette.common.white : theme.palette.secondary.main}
+              stroke={isSelected ? theme.palette.primary.main: theme.palette.secondary.main}
               strokeWidth={BORDER / 2}
               width={RADIUS * 2}
               height={RADIUS * 2}
@@ -109,7 +109,7 @@ class Node extends React.Component<NodeProps> {
               height={ICON_SIZE}
               x={node.x - ICON_SIZE / 2}
               y={node.y - ICON_SIZE / 2}
-              color={isSelected ? theme.palette.common.white : theme.palette.secondary.main}
+              color={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
             />
           </g>
         )}


### PR DESCRIPTION
### Problem

Currently selected node and edges are not stand out from others too much.
Due to proposition from last comment from this PR https://github.com/MarquezProject/marquez/pull/2384

### Solution

Selected node and edges highligthed with primary (green) color which more visible than previous.

![image](https://user-images.githubusercontent.com/16538183/228294667-26281a40-df76-4ccb-9665-e1277e7ca253.png)

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)