### PR TITLE
add missing special characters to committer name

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -24,7 +24,7 @@ They take responsibility for guiding new pull requests into the main branch.
 | Michael Robinson   | [@merobi-hub](https://github.com/merobi-hub)         |
 | Ross Turk          | [@rossturk](https://github.com/rossturk)             |
 | Minkyu Park        | [@fm100](https://github.com/fm100)                   |
-| Pawel Leszczynski  | [@pawel-big-lebowski](https://github.com/pawel-big-lebowski) |
+| Paweł Leszczyński  | [@pawel-big-lebowski](https://github.com/pawel-big-lebowski) |
      
 ## Emeritus
 


### PR DESCRIPTION
### Problem

Paweł's name is not spelled correctly in the committers list.

### Solution

This corrects the spelling.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary: corrects spelling of name in `COMMITTERS.md`

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)