### PR TITLE
Handle null `job.latestRun` before `runStateColor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/MarquezProject/marquez/compare/0.32.0...HEAD)
 
+### Fixed
+* UI: better handling of null job latestRun for Jobs page [#2467](https://github.com/MarquezProject/marquez/pull/2467) [@perttus](https://github.com/perttus)
 ## [0.32.0](https://github.com/MarquezProject/marquez/compare/0.31.0...0.32.0) - 2023-03-20
 
 ### Fixed

--- a/web/src/routes/jobs/Jobs.tsx
+++ b/web/src/routes/jobs/Jobs.tsx
@@ -118,8 +118,8 @@ class Jobs extends React.Component<JobsProps> {
                           </TableCell>
                           <TableCell key={i18next.t('jobs_route.latest_run_col')} align='left'>
                             <MqStatus
-                              color={runStateColor(job.latestRun.state)}
-                              label={job.latestRun.state}
+                              color={job.latestRun && runStateColor(job.latestRun.state)}
+                              label={job.latestRun && job.latestRun.state ? job.latestRun.state : 'N/A'}
                             />
                           </TableCell>
                         </TableRow>

--- a/web/src/routes/jobs/Jobs.tsx
+++ b/web/src/routes/jobs/Jobs.tsx
@@ -118,7 +118,7 @@ class Jobs extends React.Component<JobsProps> {
                           </TableCell>
                           <TableCell key={i18next.t('jobs_route.latest_run_col')} align='left'>
                             <MqStatus
-                              color={job.latestRun && runStateColor(job.latestRun.state)}
+                              color={job.latestRun && runStateColor(job.latestRun.state || 'NEW')}
                               label={job.latestRun && job.latestRun.state ? job.latestRun.state : 'N/A'}
                             />
                           </TableCell>


### PR DESCRIPTION
### Problem

Fixes a bug where Jobs view fails to load where some jobs don't have `latestRun` 

Closes: #2462

### Solution

Handle null `job.latestRun` before calling `runStateColor` and conditionally format the label.

One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)