### PR TITLE
Handle null run.jobVersion in DatasetInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/MarquezProject/marquez/compare/0.32.0...HEAD)
 
+### Fixed
+
+* UI: Handle null `run.jobVersion` in `DatasetInfo.tsx` to fix rendering issues.
+
 ## [0.32.0](https://github.com/MarquezProject/marquez/compare/0.31.0...0.32.0) - 2023-03-20
 
 ### Fixed

--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -119,7 +119,7 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = props => {
                 <MqText subdued>{stopWatchDuration(run.durationMs)}</MqText>
               </Box>
             </Box>
-            <MqText subdued>{run.jobVersion.name}</MqText>
+            <MqText subdued>{run.jobVersion && run.jobVersion.name}</MqText>
           </Box>
           {<MqCode code={(jobFacets?.sql as SqlFacet)?.query} language={'sql'}/>}
         </Box>


### PR DESCRIPTION
### Problem

In some cases Marquez UI fails to render DatasetInfo.

Closes: #2470

### Solution

One-line summary: Handle null run.jobVersion in DatasetInfo.tsx

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)