### PR TITLE
make `get_changes` modify changelog directly and update readme in dev

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -4,10 +4,11 @@ The `get_changes.sh` script uses a fork of saadmk11/changelog-ci to get all
 merged changes between two specified releases. To get all changes since the latest
 release, set `END_RELEASE_VERSION` to the planned next release. 
 
-The changes will appear in this directory in a new file, CHANGES.md.
+The changes will appear at the top of CHANGELOG.md.
 
 #### Requirements
 
+Python 3.10 or newer is required.
 See the requirements.txt file for required dependencies.
 
 The script also requires that the following environment variables be set:
@@ -17,6 +18,8 @@ The script also requires that the following environment variables be set:
 `INPUT_GITHUB_TOKEN`
 
 For example: `export END_RELEASE_VERSION=0.21.0`.
+
+Use the planned next release for the end release version.
 
 For instructions on creating a GitHub personal access token to use the GitHub API,
 see: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token.

--- a/dev/get_changes.sh
+++ b/dev/get_changes.sh
@@ -3,7 +3,7 @@
 # Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 
-export INPUT_CHANGELOG_FILENAME=CHANGES.md
+export INPUT_CHANGELOG_FILENAME=../CHANGELOG.md
 export GITHUB_REPOSITORY=MarquezProject/marquez
 
 git clone --branch add-testing-script --single-branch git@github.com:merobi-hub/changelog-ci.git


### PR DESCRIPTION
### Problem

The `get_changes` script in dev currently creates a new file in dev with the recent changes, but this requires one to copy and paste these into the changelog.

### Solution

This modifies the default path for the changes file so the script adds the changes directly to the changelog. The README has also been updated.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary: makes `get_changes` in dev modify the changelog directly

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)