### PR TITLE
fix ci version in api-load-test

### DIFF
--- a/.circleci/api-load-test.sh
+++ b/.circleci/api-load-test.sh
@@ -14,7 +14,7 @@
 set -e
 
 # Build version of Marquez
-readonly MARQUEZ_VERSION="0.33.0-SNAPSHOT"
+readonly MARQUEZ_VERSION="0.34.0-SNAPSHOT"
 # Fully qualified path to marquez.jar
 readonly MARQUEZ_JAR="api/build/libs/marquez-api-${MARQUEZ_VERSION}.jar"
 

--- a/new-version.sh
+++ b/new-version.sh
@@ -132,6 +132,7 @@ sed -i "" "s/tag:.*/tag: ${RELEASE_VERSION}/g" ./chart/values.yaml
 # (3) Bump version in scripts
 sed -i "" "s/VERSION=.*/VERSION=${RELEASE_VERSION}/g" ./docker/up.sh
 sed -i "" "s/MARQUEZ_VERSION=.*/MARQUEZ_VERSION=${RELEASE_VERSION}/g" ./.circleci/db-migration.sh
+sed -i "" "s/MARQUEZ_VERSION=.*/MARQUEZ_VERSION=${RELEASE_VERSION}/g" ./.circleci/api-load-test.sh
 sed -i "" "s/TAG=.*/TAG=${RELEASE_VERSION}/g" .env.example
 
 # (4) Bump version in docs


### PR DESCRIPTION
### Problem

Fix CI

### Solution

Update Marquez version in `api-load-test.sh` and update `new_version.sh` to update Marquez to modify version in `api-load-test.sh` automatically during next releases.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)