### PR TITLE
Skip regex after `postgresql` in `chart/values.yaml`

### DIFF
--- a/new-version.sh
+++ b/new-version.sh
@@ -127,7 +127,7 @@ sed -i "" "s/version=.*/version=${RELEASE_VERSION}/g" gradle.properties
 
 # (2) Bump version in helm chart
 sed -i "" "s/^version:.*/version: ${RELEASE_VERSION}/g" ./chart/Chart.yaml
-sed -i "" "s/tag:.*/tag: ${RELEASE_VERSION}/g" ./chart/values.yaml
+sed -i "" -E -e "/postgresql/,\$b" -e "s/tag:.*/tag: ${RELEASE_VERSION}/g" ./chart/values.yaml
 
 # (3) Bump version in scripts
 sed -i "" "s/VERSION=.*/VERSION=${RELEASE_VERSION}/g" ./docker/up.sh


### PR DESCRIPTION
### Problem

On a release, the `tag` for `postgresql` is bumped and set to the current version of Marquez.

### Solution

Update `regex` for chart verson bump to find and replace occurrences of `tag:.*` in the file, but not modify lines after `postgresql`.

One-line summary:

Fix regex for version bump of `chart/values.yaml` in `new-version.sh`.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)