### PR TITLE
Remove volumes on `docker/down.sh`

### DIFF
--- a/.circleci/api-load-test.sh
+++ b/.circleci/api-load-test.sh
@@ -14,7 +14,7 @@
 set -e
 
 # Build version of Marquez
-readonly MARQUEZ_VERSION=0.34.0
+readonly MARQUEZ_VERSION=0.35.0-SNAPSHOT
 # Fully qualified path to marquez.jar
 readonly MARQUEZ_JAR="api/build/libs/marquez-api-${MARQUEZ_VERSION}.jar"
 

--- a/docker/down.sh
+++ b/docker/down.sh
@@ -24,8 +24,8 @@ cd "${project_root}/"
 compose_files="-f docker-compose.yml"
 args="--remove-orphans"
 
-# We can ignore the tag and ports when stopping
-# running containers and deleting old volumes
+# We can ignore the tag and port(s) when cleaning up running
+# containers and volumes
 TAG=any
 
 API_PORT=${RANDOM} API_ADMIN_PORT=${RANDOM} WEB_PORT=${RANDOM} TAG=${RANDOM} docker-compose $compose_files down $args && \

--- a/docker/down.sh
+++ b/docker/down.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 #
+# Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
+#
+# Usage: $ ./down.sh
 
 set -e
 
@@ -9,14 +12,8 @@ title() {
 }
 
 usage() {
-  echo "usage: ./$(basename -- ${0}) [--api-port PORT] [--web-port PORT] [--tag TAG]"
+  echo "usage: ./$(basename -- ${0})"
   echo "A script used to bring down Marquez when run via Docker"
-  echo
-  title "ARGUMENTS:"
-  echo "  -a, --api-port int          api port (default: 5000)"
-  echo "  -m, --api-admin-port int    api admin port (default: 5001)"
-  echo "  -w, --web-port int          web port (default: 3000)"
-  echo "  -t, --tag string            image tag (default: latest)"
   echo
 }
 
@@ -27,37 +24,12 @@ cd "${project_root}/"
 compose_files="-f docker-compose.yml"
 args="--remove-orphans"
 
-API_PORT=5000
-API_ADMIN_PORT=5001
-WEB_PORT=3000
-TAG=0.19.0
-while [ $# -gt 0 ]; do
-  case $1 in
-    -a|'--api-port')
-       shift
-       API_PORT="${1}"
-       ;;
-    -m|'--api-admin-port')
-       shift
-       API_ADMIN_PORT="${1}"
-       ;;
-    -w|'--web-port')
-       shift
-       WEB_PORT="${1}"
-       ;;
-    -t|'--tag')
-       shift
-       TAG="${1}"
-       ;;
-    -h|'--help')
-       usage
-       exit 0
-       ;;
-    *) usage
-       exit 1
-       ;;
-  esac
-  shift
-done
+# We can ignore the tag and ports when stopping
+# running containers and deleting old volumes
+TAG=any
 
-API_PORT=${API_PORT} API_ADMIN_PORT=${API_ADMIN_PORT} WEB_PORT=${WEB_PORT} TAG="${TAG}" docker-compose $compose_files down $args
+API_PORT=${RANDOM} API_ADMIN_PORT=${RANDOM} WEB_PORT=${RANDOM} TAG=${RANDOM} docker-compose $compose_files down $args && \
+  docker volume rm marquez_data && \
+  docker volume rm marquez_db-backup && \
+  docker volume rm marquez_db-conf && \
+  docker volume rm marquez_db-init

--- a/docker/up.sh
+++ b/docker/up.sh
@@ -3,7 +3,7 @@
 # Copyright 2018-2023 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 #
-# Usage: $ ./build-and-push.sh [FLAGS] [ARG...]
+# Usage: $ ./up.sh [FLAGS] [ARG...]
 
 set -e
 

--- a/new-version.sh
+++ b/new-version.sh
@@ -132,7 +132,6 @@ sed -i "" -E -e "/postgresql/,\$b" -e "s/tag:.*/tag: ${RELEASE_VERSION}/g" ./cha
 # (3) Bump version in scripts
 sed -i "" "s/VERSION=.*/VERSION=${RELEASE_VERSION}/g" ./docker/up.sh
 sed -i "" "s/MARQUEZ_VERSION=.*/MARQUEZ_VERSION=${RELEASE_VERSION}/g" ./.circleci/db-migration.sh
-sed -i "" "s/MARQUEZ_VERSION=.*/MARQUEZ_VERSION=${RELEASE_VERSION}/g" ./.circleci/api-load-test.sh
 sed -i "" "s/TAG=.*/TAG=${RELEASE_VERSION}/g" .env.example
 
 # (4) Bump version in docs
@@ -163,6 +162,7 @@ if [[ "${NEXT_VERSION}" == *-rc.? ||
 fi
 sed -i "" "s/version=.*/version=${NEXT_VERSION}/g" gradle.properties
 sed -i "" "s/^  version:.*/  version: ${NEXT_VERSION}/g" ./spec/openapi.yml
+sed -i "" "s/MARQUEZ_VERSION=.*/MARQUEZ_VERSION=${NEXT_VERSION}/g" ./.circleci/api-load-test.sh
 
 # (9) Prepare next development version commit
 git commit -sam "Prepare next development version ${NEXT_VERSION}" --no-verify


### PR DESCRIPTION
### Problem

Docker volumes are **not** delete when running [`docker/down.sh`](https://github.com/MarquezProject/marquez/blob/main/docker/down.sh).

### Solution

Add support for deleting docker volumes when running [`docker/down.sh`](https://github.com/MarquezProject/marquez/blob/main/docker/down.sh); ensures the metadata stored in `marquez-db` is deleted and not present on `docker/up.sh` invocations.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)