### PR TITLE
Add OL compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ We invite everyone to help us improve and keep documentation up to date. Documen
 
 Versions of Marquez are compatible with OpenLineage unless noted otherwise. We ensure backward compatibility with a newer version of Marquez by recording events with an older OpenLineage specification version. **We strongly recommend understanding how the OpenLineage specification is** [versioned](https://github.com/OpenLineage/OpenLineage/blob/main/spec/Versioning.md) **and published**.
 
-| **Marquez**                                                                                      | **OpenLineage**                                                   | **Status**    |
-|--------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|---------------|
-| [`UNRELEASED`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md#unreleased)     | [`>=1-0-5`](https://openlineage.io/spec/1-0-5/OpenLineage.json)  | `CURRENT`     |
-| [`0.34.0`](https://github.com/MarquezProject/marquez/blob/0.34.0/CHANGELOG.md#0340---2023-05-18) | [`1-0-5`](https://openlineage.io/spec/1-0-5/OpenLineage.json)  | `RECOMMENDED` |
-| [`0.33.0`](https://github.com/MarquezProject/marquez/blob/0.34.0/CHANGELOG.md#0330---2023-04-19) | [`<=1-0-5`](https://openlineage.io/spec/1-0-5/OpenLineage.json)  | `MAINTENANCE` |
+| **Marquez**                                                                                      | **OpenLineage**                                               | **Status**    |
+|--------------------------------------------------------------------------------------------------|---------------------------------------------------------------|---------------|
+| [`UNRELEASED`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md#unreleased)     | [`1-0-5`](https://openlineage.io/spec/1-0-5/OpenLineage.json) | `CURRENT`     |
+| [`0.34.0`](https://github.com/MarquezProject/marquez/blob/0.34.0/CHANGELOG.md#0340---2023-05-18) | [`1-0-5`](https://openlineage.io/spec/1-0-5/OpenLineage.json) | `RECOMMENDED` |
+| [`0.33.0`](https://github.com/MarquezProject/marquez/blob/0.33.0/CHANGELOG.md#0330---2023-04-19) | [`1-0-5`](https://openlineage.io/spec/1-0-0/OpenLineage.json) | `MAINTENANCE` |
 
 > **Note:** The [`openlineage-python`](https://pypi.org/project/openlineage-python) and [`openlineage-java`](https://central.sonatype.com/artifact/io.openlineage/openlineage-java) libraries will a higher version than the OpenLineage [specification](https://github.com/OpenLineage/OpenLineage/tree/main/spec) as they have different version requirements.
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Versions of Marquez are compatible with OpenLineage unless noted otherwise. We e
 
 | **Marquez**                                                                                      | **OpenLineage**                                                   | **Status**    |
 |--------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|---------------|
-| [`UNRELEASED`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md#unreleased)     | [`>= 1-0-5`](https://openlineage.io/spec/1-0-5/OpenLineage.json)  | `CURRENT`     |
-| [`0.34.0`](https://github.com/MarquezProject/marquez/blob/0.34.0/CHANGELOG.md#0340---2023-05-18) | [`>= 1-0-5`](https://openlineage.io/spec/1-0-5/OpenLineage.json)  | `RECOMMENDED` |
-| [`0.33.0`](https://github.com/MarquezProject/marquez/blob/0.34.0/CHANGELOG.md#0330---2023-04-19) | [`<= 1-0-5`](https://openlineage.io/spec/1-0-5/OpenLineage.json)  | `MAINTENANCE` |
+| [`UNRELEASED`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md#unreleased)     | [`>=1-0-5`](https://openlineage.io/spec/1-0-5/OpenLineage.json)  | `CURRENT`     |
+| [`0.34.0`](https://github.com/MarquezProject/marquez/blob/0.34.0/CHANGELOG.md#0340---2023-05-18) | [`1-0-5`](https://openlineage.io/spec/1-0-5/OpenLineage.json)  | `RECOMMENDED` |
+| [`0.33.0`](https://github.com/MarquezProject/marquez/blob/0.34.0/CHANGELOG.md#0330---2023-04-19) | [`<=1-0-5`](https://openlineage.io/spec/1-0-5/OpenLineage.json)  | `MAINTENANCE` |
 
 > **Note:** The [`openlineage-python`](https://pypi.org/project/openlineage-python) and [`openlineage-java`](https://central.sonatype.com/artifact/io.openlineage/openlineage-java) libraries will a higher version than the OpenLineage [specification](https://github.com/OpenLineage/OpenLineage/tree/main/spec) as they have different version requirements.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Versions of Marquez are compatible with OpenLineage unless noted otherwise. We e
 
 > **Note:** The [`openlineage-python`](https://pypi.org/project/openlineage-python) and [`openlineage-java`](https://central.sonatype.com/artifact/io.openlineage/openlineage-java) libraries will a higher version than the OpenLineage [specification](https://github.com/OpenLineage/OpenLineage/tree/main/spec) as they have different version requirements.
 
-We currently maintain three categories of compatibility: `CURRENT`, `RECOMMENDED`, and `MAINTENANCE`. When a new version of Marquez is released, it's marked as `RECOMMENDED`, while the previous version enters `MAINTENANCE` mode (which gets bug fixes whenever possible). The unrelease version of Marquez is marked `CURRENT` and does not come with any guarantees, but is assumed to remain compatible with OpenLineage, although surprises happen and there maybe rare exceptions.
+We currently maintain three categories of compatibility: `CURRENT`, `RECOMMENDED`, and `MAINTENANCE`. When a new version of Marquez is released, it's marked as `RECOMMENDED`, while the previous version enters `MAINTENANCE` mode (which gets bug fixes whenever possible). The unreleased version of Marquez is marked `CURRENT` and does not come with any guarantees, but is assumed to remain compatible with OpenLineage, although surprises happen and there maybe rare exceptions.
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can open [http://localhost:3000](http://localhost:3000) to begin exploring t
 
 **`HTTP API`**
 
-The Marquez [HTTP API](https://marquezproject.github.io/marquez/openapi.html) listens on port `5000` for all calls and port `5001` for the admin interface. The admin interface exposes helpful endpoints like `/healthcheck` and `/metrics`. To verify the HTTP API server is running and listening on `localhost`, browse to [http://localhost:5001](http://localhost:5001). To begin collecting lineage metadata as OpenLineage events, use the [LineageAPI](https://marquezproject.github.io/marquez/openapi.html#tag/Lineage/paths/~1lineage/post) or an OpenLineage [integration](https://openlineage.io/integration).
+The Marquez [HTTP API](https://marquezproject.github.io/marquez/openapi.html) listens on port `5000` for all calls and port `5001` for the admin interface. The admin interface exposes helpful endpoints like `/healthcheck` and `/metrics`. To verify the HTTP API server is running and listening on `localhost`, browse to [http://localhost:5001](http://localhost:5001). To begin collecting lineage metadata as OpenLineage events, use the [LineageAPI](https://marquezproject.github.io/marquez/openapi.html#tag/Lineage/paths/~1lineage/post) or an OpenLineage [integration](https://openlineage.io/docs/integrations/about).
 
 > **Note:** By default, the HTTP API does not require any form of authentication or authorization.
 
@@ -74,7 +74,7 @@ We invite everyone to help us improve and keep documentation up to date. Documen
 
 ## Versions and OpenLineage Compatibility
 
-Versions of Marquez are compatible with OpenLineage unless noted otherwise. We ensure backward compatibility with a newer version of Marquez by recording events with an older OpenLineage specification version. We strongly recommend understanding how the OpenLineage specification is [versioned](https://github.com/OpenLineage/OpenLineage/blob/main/spec/Versioning.md) and published.
+Versions of Marquez are compatible with OpenLineage unless noted otherwise. We ensure backward compatibility with a newer version of Marquez by recording events with an older OpenLineage specification version. **We strongly recommend understanding how the OpenLineage specification is** [versioned](https://github.com/OpenLineage/OpenLineage/blob/main/spec/Versioning.md) **and published**.
 
 | **Marquez**                                                                                      | **OpenLineage**                                                   | **Status**    |
 |--------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|---------------|
@@ -83,6 +83,8 @@ Versions of Marquez are compatible with OpenLineage unless noted otherwise. We e
 | [`0.33.0`](https://github.com/MarquezProject/marquez/blob/0.34.0/CHANGELOG.md#0330---2023-04-19) | [`<= 1-0-5`](https://openlineage.io/spec/1-0-5/OpenLineage.json)  | `MAINTENANCE` |
 
 > **Note:** The [`openlineage-python`](https://pypi.org/project/openlineage-python) and [`openlineage-java`](https://central.sonatype.com/artifact/io.openlineage/openlineage-java) libraries will a higher version than the OpenLineage [specification](https://github.com/OpenLineage/OpenLineage/tree/main/spec) as they have different version requirements.
+
+We currently maintain three categories of compatibility: `CURRENT`, `RECOMMENDED`, and `MAINTENANCE`. When a new version of Marquez is released, it's marked as `RECOMMENDED`, while the previous version enters `MAINTENANCE` mode (which gets bug fixes whenever possible). The unrelease version of Marquez is marked `CURRENT` and does not come with any guarantees, but is assumed to remain compatible with OpenLineage, although surprises happen and there maybe rare exceptions.
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,15 @@ We invite everyone to help us improve and keep documentation up to date. Documen
 
 ## Versions and OpenLineage Compatibility
 
-| **Marquez**                                                                                      | **OpenLineage**                                                                                     | **Status**    |
-|--------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|---------------|
-| [`UNRELEASED`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md#unreleased)     | [`>= 0.26.+`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md#0260---2023-05-18)  | `CURRENT`     |
-| [`0.34.0`](https://github.com/MarquezProject/marquez/blob/0.34.0/CHANGELOG.md#0330---2023-04-19) | [`>= 0.20.+`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md#0204---2023-02-07)  | `RECOMMENDED` |
-| [`0.33.0`](https://github.com/MarquezProject/marquez/blob/0.34.0/CHANGELOG.md#0330---2023-04-19) | [`<= 0.20.+`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md#0204---2023-02-07)  | `MAINTENANCE` |
+Versions of Marquez are compatible with OpenLineage unless noted otherwise. We ensure backward compatibility with a newer version of Marquez by recording events with an older OpenLineage specification version. We strongly recommend understanding how the OpenLineage specification is [versioned](https://github.com/OpenLineage/OpenLineage/blob/main/spec/Versioning.md) and published.
+
+| **Marquez**                                                                                      | **OpenLineage**                                                   | **Status**    |
+|--------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|---------------|
+| [`UNRELEASED`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md#unreleased)     | [`>= 1-0-5`](https://openlineage.io/spec/1-0-5/OpenLineage.json)  | `CURRENT`     |
+| [`0.34.0`](https://github.com/MarquezProject/marquez/blob/0.34.0/CHANGELOG.md#0340---2023-05-18) | [`>= 1-0-5`](https://openlineage.io/spec/1-0-5/OpenLineage.json)  | `RECOMMENDED` |
+| [`0.33.0`](https://github.com/MarquezProject/marquez/blob/0.34.0/CHANGELOG.md#0330---2023-04-19) | [`<= 1-0-5`](https://openlineage.io/spec/1-0-5/OpenLineage.json)  | `MAINTENANCE` |
+
+> **Note:** The [`openlineage-python`](https://pypi.org/project/openlineage-python) and [`openlineage-java`](https://central.sonatype.com/artifact/io.openlineage/openlineage-java) libraries will a higher version than the OpenLineage [specification](https://github.com/OpenLineage/OpenLineage/tree/main/spec) as they have different version requirements.
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ We invite everyone to help us improve and keep documentation up to date. Documen
 
 > **Note:** To begin collecting metadata with Marquez, follow our [quickstart](https://marquezproject.github.io/marquez/quickstart.html) guide. Below you will find the steps to get up and running from source.
 
+## Versions and OpenLineage Compatibility
+
+| **Marquez**                                                                                      | **OpenLineage**                                                                                     | **Status**    |
+|--------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|---------------|
+| [`UNRELEASED`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md#unreleased)     | [`>= 0.26.+`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md#0260---2023-05-18)  | `CURRENT`     |
+| [`0.34.0`](https://github.com/MarquezProject/marquez/blob/0.34.0/CHANGELOG.md#0330---2023-04-19) | [`>= 0.20.+`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md#0204---2023-02-07)  | `RECOMMENDED` |
+| [`0.33.0`](https://github.com/MarquezProject/marquez/blob/0.34.0/CHANGELOG.md#0330---2023-04-19) | [`<= 0.20.+`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md#0204---2023-02-07)  | `MAINTENANCE` |
+
 ## Modules
 
 Marquez uses a _multi_-project structure and contains the following modules:
@@ -158,5 +166,5 @@ See [CONTRIBUTING.md](https://github.com/MarquezProject/marquez/blob/main/CONTRI
 If you discover a vulnerability in the project, please open an issue and attach the "security" label.
 
 ----
-SPDX-License-Identifier: Apache-2.0 
+SPDX-License-Identifier: Apache-2.0
 Copyright 2018-2023 contributors to the Marquez project.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,9 @@
 # Releasing
 
 1. Update [`CHANGELOG.md`](CHANGELOG.md)
-2. Make sure you've installed the required dependencies (see [`new-version.sh`](new-version.sh)).
-3. Tag the release and prepare for the next version with:
+2. Update [_Versions and OpenLineage Compatibility_](https://github.com/MarquezProject/marquez/blob/main/README.md#versions-and-openlineage-compatibility) following compatibility guidelines
+3. Make sure you've installed the required dependencies (see [`new-version.sh`](new-version.sh)).
+4. Tag the release and prepare for the next version with:
 
    ```bash
    $ ./new-version.sh --release-version X.Y.Z --next-version X.Y.Z --no-push
@@ -10,10 +11,10 @@
 
    > **Tip:** Use `--help` to see script usage
 
-4. Push the tag with the command supplied by the script.
-5. Visit [CI](https://app.circleci.com/pipelines/github/MarquezProject/marquez?branch=main) to see the progress of the release! :rocket:
-6. Visit [sonatype](https://oss.sonatype.org) to promote _java_ artifacts
-7. Draft a [new release](https://github.com/MarquezProject/marquez/releases/new) using the release notes for `X.Y.Z` in **step 1** as the release description:
+5. Push the tag with the command supplied by the script.
+6. Visit [CI](https://app.circleci.com/pipelines/github/MarquezProject/marquez?branch=main) to see the progress of the release! :rocket:
+7. Visit [sonatype](https://oss.sonatype.org) to promote _java_ artifacts
+8. Draft a [new release](https://github.com/MarquezProject/marquez/releases/new) using the release notes for `X.Y.Z` in **step 1** as the release description:
 
    ![](./docs/assets/images/new-release.png)
 
@@ -36,5 +37,5 @@ If the proposed release receives no +1s in two days, it is not authorized and th
 Once a release is authorized, it will be initiated within two business days. Releases will not be made on a Friday unless doing so will address an important defect, an issue with project infrastructure, or a security vulnerability.
 
 ----
-SPDX-License-Identifier: Apache-2.0 
+SPDX-License-Identifier: Apache-2.0
 Copyright 2018-2023 contributors to the Marquez project.


### PR DESCRIPTION
### Problem

Closes: https://github.com/MarquezProject/marquez/issues/2483

### Solution

This PR adds a compatibility table to better communicate which version of Marquez supports a given version of OpenLineage.

![Screen Shot 2023-05-30 at 12 05 13 PM](https://github.com/MarquezProject/marquez/assets/1553185/2107583b-f5c6-42b7-ae1b-7ed14621d68d)

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)