### PR TITLE
Ability to decode static metadata events 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
 * Web: handle lineage graph cycles on the client [`#2506`](https://github.com/MarquezProject/marquez/pull/2506) [@jlukenoff](https://github.com/jlukenoff)  
     *Fixes a bug where we blow the stack on the client-side if the user selects a node that is part of a cycle in the graph.*
 
+### Added
+
+* Ability to decode static metadata events [`#2495`](https://github.com/MarquezProject/marquez/pull/2495) [@pawel-big-lebowski]( https://github.com/pawel-big-lebowski)  
+  *Adds the ability to distinguish on a bakend static metadata events introduced based on the [proposal](https://github.com/OpenLineage/OpenLineage/blob/main/proposals/1837/static_lineage.md).*
+
+
 ## [0.34.0](https://github.com/MarquezProject/marquez/compare/0.33.0...0.34.0) - 2023-05-18
 
 ### Fixed

--- a/api/src/main/java/marquez/service/models/BaseEvent.java
+++ b/api/src/main/java/marquez/service/models/BaseEvent.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.service.models;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+
+@JsonTypeIdResolver(EventTypeResolver.class)
+@JsonTypeInfo(
+    use = Id.CUSTOM,
+    include = As.EXISTING_PROPERTY,
+    property = "schemaURL",
+    defaultImpl = LineageEvent.class,
+    visible = true)
+public class BaseEvent extends BaseJsonModel {}

--- a/api/src/main/java/marquez/service/models/DatasetEvent.java
+++ b/api/src/main/java/marquez/service/models/DatasetEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.service.models;
+
+import java.net.URI;
+import java.time.ZonedDateTime;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+@Valid
+@ToString
+public class DatasetEvent extends BaseEvent {
+  @NotNull private ZonedDateTime eventTime;
+  @Valid private LineageEvent.Dataset dataset;
+  @Valid @NotNull private String producer;
+  @Valid @NotNull private URI schemaURL;
+}

--- a/api/src/main/java/marquez/service/models/EventTypeResolver.java
+++ b/api/src/main/java/marquez/service/models/EventTypeResolver.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.service.models;
+
+import static marquez.service.models.EventTypeResolver.EventSchemaURL.LINEAGE_EVENT;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import java.io.IOException;
+import java.util.Arrays;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class EventTypeResolver extends TypeIdResolverBase {
+
+  @AllArgsConstructor
+  public enum EventSchemaURL {
+    LINEAGE_EVENT(
+        "https://openlineage.io/spec/2-0-0/OpenLineage.json#/definitions/RunEvent",
+        LineageEvent.class),
+    DATASET_EVENT(
+        "https://openlineage.io/spec/2-0-0/OpenLineage.json#/definitions/DatasetEvent",
+        DatasetEvent.class),
+    JOB_EVENT(
+        "https://openlineage.io/spec/2-0-0/OpenLineage.json#/definitions/JobEvent", JobEvent.class);
+
+    @Getter private String schemaURL;
+
+    public String getName() {
+      int lastSlash = schemaURL.lastIndexOf('/');
+      return schemaURL.substring(lastSlash, schemaURL.length());
+    }
+
+    @Getter private Class<?> subType;
+  }
+
+  private JavaType superType;
+
+  @Override
+  public void init(JavaType baseType) {
+    superType = baseType;
+  }
+
+  @Override
+  public String idFromValue(Object value) {
+    return null;
+  }
+
+  @Override
+  public String idFromValueAndType(Object value, Class<?> suggestedType) {
+    return null;
+  }
+
+  @Override
+  public JavaType typeFromId(DatabindContext context, String id) throws IOException {
+    if (id == null) {
+      return context.constructSpecializedType(superType, LINEAGE_EVENT.subType);
+    }
+
+    int lastSlash = id.lastIndexOf('/');
+
+    if (lastSlash < 0) {
+      return context.constructSpecializedType(superType, LINEAGE_EVENT.subType);
+    }
+
+    String type = id.substring(lastSlash, id.length());
+
+    Class<?> subType =
+        Arrays.stream(EventSchemaURL.values())
+            .filter(s -> s.getName().equals(type))
+            .findAny()
+            .map(EventSchemaURL::getSubType)
+            .orElse(LINEAGE_EVENT.subType);
+
+    return context.constructSpecializedType(superType, subType);
+  }
+
+  @Override
+  public Id getMechanism() {
+    return null;
+  }
+}

--- a/api/src/main/java/marquez/service/models/JobEvent.java
+++ b/api/src/main/java/marquez/service/models/JobEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.service.models;
+
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+@Valid
+@ToString
+public class JobEvent extends BaseEvent {
+  @NotNull private ZonedDateTime eventTime;
+  @Valid @NotNull private LineageEvent.Job job;
+  @Valid private List<LineageEvent.Dataset> inputs;
+  @Valid private List<LineageEvent.Dataset> outputs;
+  @Valid @NotNull private String producer;
+  @Valid @NotNull private URI schemaURL;
+}

--- a/api/src/main/java/marquez/service/models/LineageEvent.java
+++ b/api/src/main/java/marquez/service/models/LineageEvent.java
@@ -38,7 +38,7 @@ import lombok.ToString;
 @Getter
 @Valid
 @ToString
-public class LineageEvent extends BaseJsonModel {
+public class LineageEvent extends BaseEvent {
 
   private String eventType;
 
@@ -48,6 +48,7 @@ public class LineageEvent extends BaseJsonModel {
   @Valid private List<Dataset> inputs;
   @Valid private List<Dataset> outputs;
   @Valid @NotNull private String producer;
+  @Valid private URI schemaURL;
 
   @AllArgsConstructor
   @NoArgsConstructor

--- a/api/src/test/java/marquez/DatasetIntegrationTest.java
+++ b/api/src/test/java/marquez/DatasetIntegrationTest.java
@@ -365,14 +365,17 @@ public class DatasetIntegrationTest extends BaseIntegrationTest {
     String namespace = "namespace";
     String name = "table";
     LineageEvent event =
-        new LineageEvent(
-            "COMPLETE",
-            Instant.now().atZone(ZoneId.systemDefault()),
-            new LineageEvent.Run(UUID.randomUUID().toString(), null),
-            new LineageEvent.Job("namespace", "job_name", null),
-            List.of(new LineageEvent.Dataset(namespace, name, LineageTestUtils.newDatasetFacet())),
-            Collections.emptyList(),
-            "the_producer");
+        LineageEvent.builder()
+            .eventType("COMPLETE")
+            .eventTime(Instant.now().atZone(ZoneId.systemDefault()))
+            .run(new LineageEvent.Run(UUID.randomUUID().toString(), null))
+            .job(new LineageEvent.Job("namespace", "job_name", null))
+            .inputs(
+                List.of(
+                    new LineageEvent.Dataset(namespace, name, LineageTestUtils.newDatasetFacet())))
+            .outputs(Collections.emptyList())
+            .producer("the_producer")
+            .build();
 
     final CompletableFuture<Integer> resp = sendEvent(event);
     assertThat(resp.join()).isEqualTo(201);
@@ -388,14 +391,17 @@ public class DatasetIntegrationTest extends BaseIntegrationTest {
     String namespace = "namespace";
     String name = "anotherTable";
     LineageEvent event =
-        new LineageEvent(
-            "COMPLETE",
-            Instant.now().atZone(ZoneId.systemDefault()),
-            new LineageEvent.Run(UUID.randomUUID().toString(), null),
-            new LineageEvent.Job("namespace", "job_name", null),
-            List.of(new LineageEvent.Dataset(namespace, name, LineageTestUtils.newDatasetFacet())),
-            Collections.emptyList(),
-            "the_producer");
+        LineageEvent.builder()
+            .eventType("COMPLETE")
+            .eventTime(Instant.now().atZone(ZoneId.systemDefault()))
+            .run(new LineageEvent.Run(UUID.randomUUID().toString(), null))
+            .job(new LineageEvent.Job("namespace", "job_name", null))
+            .inputs(
+                List.of(
+                    new LineageEvent.Dataset(namespace, name, LineageTestUtils.newDatasetFacet())))
+            .outputs(Collections.emptyList())
+            .producer("the_producer")
+            .build();
 
     CompletableFuture<Integer> resp = sendEvent(event);
     assertThat(resp.join()).isEqualTo(201);
@@ -414,14 +420,15 @@ public class DatasetIntegrationTest extends BaseIntegrationTest {
   @Test
   public void testApp_getDatasetContainsColumnLineage() {
     LineageEvent event =
-        new LineageEvent(
-            "COMPLETE",
-            Instant.now().atZone(ZoneId.systemDefault()),
-            new LineageEvent.Run(UUID.randomUUID().toString(), null),
-            new LineageEvent.Job("namespace", "job_name", null),
-            List.of(getDatasetA()),
-            List.of(getDatasetB()),
-            "the_producer");
+        LineageEvent.builder()
+            .eventType("COMPLETE")
+            .eventTime(Instant.now().atZone(ZoneId.systemDefault()))
+            .run(new LineageEvent.Run(UUID.randomUUID().toString(), null))
+            .job(new LineageEvent.Job("namespace", "job_name", null))
+            .inputs(List.of(getDatasetA()))
+            .outputs(List.of(getDatasetB()))
+            .producer("the_producer")
+            .build();
 
     CompletableFuture<Integer> resp =
         this.sendLineage(Utils.toJson(event))
@@ -457,14 +464,17 @@ public class DatasetIntegrationTest extends BaseIntegrationTest {
     String namespace = "namespace";
     String name = "table";
     LineageEvent event =
-        new LineageEvent(
-            "COMPLETE",
-            Instant.now().atZone(ZoneId.systemDefault()),
-            new LineageEvent.Run(UUID.randomUUID().toString(), null),
-            new LineageEvent.Job("namespace", "job_name", null),
-            List.of(new LineageEvent.Dataset(namespace, name, LineageTestUtils.newDatasetFacet())),
-            Collections.emptyList(),
-            "the_producer");
+        LineageEvent.builder()
+            .eventType("COMPLETE")
+            .eventTime(Instant.now().atZone(ZoneId.systemDefault()))
+            .run(new LineageEvent.Run(UUID.randomUUID().toString(), null))
+            .job(new LineageEvent.Job("namespace", "job_name", null))
+            .inputs(
+                List.of(
+                    new LineageEvent.Dataset(namespace, name, LineageTestUtils.newDatasetFacet())))
+            .outputs(Collections.emptyList())
+            .producer("the_producer")
+            .build();
 
     final CompletableFuture<Integer> resp = sendEvent(event);
     assertThat(resp.join()).isEqualTo(201);
@@ -481,27 +491,32 @@ public class DatasetIntegrationTest extends BaseIntegrationTest {
     String name = "table";
 
     LineageEvent firstEvent =
-        new LineageEvent(
-            "COMPLETE",
-            Instant.now().atZone(ZoneId.systemDefault()),
-            new LineageEvent.Run(UUID.randomUUID().toString(), null),
-            new LineageEvent.Job(namespaceName, "job_name", null),
-            List.of(
-                new LineageEvent.Dataset(namespaceName, name, LineageTestUtils.newDatasetFacet())),
-            Collections.emptyList(),
-            "the_producer");
+        LineageEvent.builder()
+            .eventType("COMPLETE")
+            .eventTime(Instant.now().atZone(ZoneId.systemDefault()))
+            .run(new LineageEvent.Run(UUID.randomUUID().toString(), null))
+            .job(new LineageEvent.Job(namespaceName, "job_name", null))
+            .inputs(
+                List.of(
+                    new LineageEvent.Dataset(
+                        namespaceName, name, LineageTestUtils.newDatasetFacet())))
+            .outputs(Collections.emptyList())
+            .producer("the_producer")
+            .build();
 
     LineageEvent secondEvent =
-        new LineageEvent(
-            "COMPLETE",
-            Instant.now().atZone(ZoneId.systemDefault()),
-            new LineageEvent.Run(UUID.randomUUID().toString(), null),
-            new LineageEvent.Job(namespaceName, "second_job_name", null),
-            List.of(
-                new LineageEvent.Dataset(
-                    namespaceName, name + "2", LineageTestUtils.newDatasetFacet())),
-            Collections.emptyList(),
-            "the_producer");
+        LineageEvent.builder()
+            .eventType("COMPLETE")
+            .eventTime(Instant.now().atZone(ZoneId.systemDefault()))
+            .run(new LineageEvent.Run(UUID.randomUUID().toString(), null))
+            .job(new LineageEvent.Job(namespaceName, "second_job_name", null))
+            .inputs(
+                List.of(
+                    new LineageEvent.Dataset(
+                        namespaceName, name + "2", LineageTestUtils.newDatasetFacet())))
+            .outputs(Collections.emptyList())
+            .producer("the_producer")
+            .build();
 
     CompletableFuture<Integer> resp = sendEvent(firstEvent);
     assertThat(resp.join()).isEqualTo(201);
@@ -529,15 +544,18 @@ public class DatasetIntegrationTest extends BaseIntegrationTest {
     assertThat(jobs).hasSize(0);
 
     LineageEvent eventThatWillUndeleteNamespace =
-        new LineageEvent(
-            "COMPLETE",
-            Instant.now().atZone(ZoneId.systemDefault()),
-            new LineageEvent.Run(UUID.randomUUID().toString(), null),
-            new LineageEvent.Job(namespaceName, "job_name", null),
-            List.of(
-                new LineageEvent.Dataset(namespaceName, name, LineageTestUtils.newDatasetFacet())),
-            Collections.emptyList(),
-            "the_producer");
+        LineageEvent.builder()
+            .eventType("COMPLETE")
+            .eventTime(Instant.now().atZone(ZoneId.systemDefault()))
+            .run(new LineageEvent.Run(UUID.randomUUID().toString(), null))
+            .job(new LineageEvent.Job(namespaceName, "job_name", null))
+            .inputs(
+                List.of(
+                    new LineageEvent.Dataset(
+                        namespaceName, name, LineageTestUtils.newDatasetFacet())))
+            .outputs(Collections.emptyList())
+            .producer("the_producer")
+            .build();
 
     resp = sendEvent(eventThatWillUndeleteNamespace);
     assertThat(resp.join()).isEqualTo(201);

--- a/api/src/test/java/marquez/db/BackfillTestUtils.java
+++ b/api/src/test/java/marquez/db/BackfillTestUtils.java
@@ -83,20 +83,23 @@ public class BackfillTestUtils {
                         new RunLink(runId),
                         new JobLink(NAMESPACE, parentJobName)));
     LineageEvent event =
-        new LineageEvent(
-            COMPLETE,
-            Instant.now().atZone(LOCAL_ZONE),
-            new Run(
-                runUuid.toString(),
-                new RunFacet(
-                    nominalTimeRunFacet,
-                    parentRun.orElse(null),
-                    ImmutableMap.of("airflow_version", ImmutableMap.of("version", "abc")))),
-            new LineageEvent.Job(
-                NAMESPACE, jobName, new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP)),
-            Collections.emptyList(),
-            Collections.emptyList(),
-            PRODUCER_URL.toString());
+        LineageEvent.builder()
+            .eventType(COMPLETE)
+            .eventTime(Instant.now().atZone(LOCAL_ZONE))
+            .run(
+                new Run(
+                    runUuid.toString(),
+                    new RunFacet(
+                        nominalTimeRunFacet,
+                        parentRun.orElse(null),
+                        ImmutableMap.of("airflow_version", ImmutableMap.of("version", "abc")))))
+            .job(
+                new LineageEvent.Job(
+                    NAMESPACE, jobName, new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP)))
+            .inputs(Collections.emptyList())
+            .outputs(Collections.emptyList())
+            .producer(PRODUCER_URL.toString())
+            .build();
     PGobject eventJson = new PGobject();
     eventJson.setType("json");
     eventJson.setValue(Utils.getMapper().writeValueAsString(event));

--- a/api/src/test/java/marquez/db/LineageTestUtils.java
+++ b/api/src/test/java/marquez/db/LineageTestUtils.java
@@ -122,14 +122,17 @@ public class LineageTestUtils {
 
     UUID runId = UUID.randomUUID();
     LineageEvent event =
-        new LineageEvent(
-            status,
-            Instant.now().atZone(LOCAL_ZONE),
-            new Run(runId.toString(), new RunFacet(nominalTimeRunFacet, parentRunFacet, runFacets)),
-            new Job(NAMESPACE, jobName, jobFacet),
-            inputs,
-            outputs,
-            PRODUCER_URL.toString());
+        LineageEvent.builder()
+            .eventType(status)
+            .eventTime(Instant.now().atZone(LOCAL_ZONE))
+            .run(
+                new Run(
+                    runId.toString(), new RunFacet(nominalTimeRunFacet, parentRunFacet, runFacets)))
+            .job(new Job(NAMESPACE, jobName, jobFacet))
+            .inputs(inputs)
+            .outputs(outputs)
+            .producer(PRODUCER_URL.toString())
+            .build();
     // emulate an OpenLineage RunEvent
     event
         .getProperties()

--- a/api/src/test/java/marquez/service/models/EventTypeResolverTest.java
+++ b/api/src/test/java/marquez/service/models/EventTypeResolverTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.service.models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class EventTypeResolverTest {
+
+  EventTypeResolver resolver = new EventTypeResolver();
+  ObjectMapper mapper = new ObjectMapper();
+  DatabindContext databindContext = mock(DatabindContext.class);
+  JavaType superType = mapper.constructType(BaseEvent.class);
+
+  @BeforeEach
+  public void setup() {
+    resolver.init(superType);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testTypeFromIdForRunEvent() {
+    JavaType runEventType = mapper.constructType(LineageEvent.class);
+    when(databindContext.constructSpecializedType(superType, LineageEvent.class))
+        .thenReturn(runEventType);
+
+    assertThat(
+            resolver.typeFromId(
+                databindContext,
+                "https://openlineage.io/spec/2-0-0/OpenLineage.json#/definitions/RunEvent"))
+        .isEqualTo(runEventType);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testTypeFromIdForDatasetEvent() {
+    JavaType datasetEventType = mapper.constructType(DatasetEvent.class);
+    when(databindContext.constructSpecializedType(superType, DatasetEvent.class))
+        .thenReturn(datasetEventType);
+
+    assertThat(
+            resolver.typeFromId(
+                databindContext,
+                "https://openlineage.io/spec/2-5-0/OpenLineage.json#/definitions/DatasetEvent"))
+        .isEqualTo(datasetEventType);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testTypeFromIdForJobEvent() {
+    JavaType jobEventType = mapper.constructType(JobEvent.class);
+    when(databindContext.constructSpecializedType(superType, JobEvent.class))
+        .thenReturn(jobEventType);
+
+    assertThat(
+            resolver.typeFromId(
+                databindContext,
+                "https://openlineage.io/spec/2-0-0/OpenLineage.json#/definitions/JobEvent"))
+        .isEqualTo(jobEventType);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testTypeFromIdForUnknownEvent() {
+    JavaType runEventType = mapper.constructType(LineageEvent.class);
+    when(databindContext.constructSpecializedType(superType, LineageEvent.class))
+        .thenReturn(runEventType);
+
+    assertThat(resolver.typeFromId(databindContext, "unknown type")).isEqualTo(runEventType);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testTypeFromIdForNullId() {
+    JavaType runEventType = mapper.constructType(LineageEvent.class);
+    when(databindContext.constructSpecializedType(superType, LineageEvent.class))
+        .thenReturn(runEventType);
+
+    assertThat(resolver.typeFromId(databindContext, null)).isEqualTo(runEventType);
+  }
+}

--- a/api/src/test/java/marquez/service/models/LineageEventTest.java
+++ b/api/src/test/java/marquez/service/models/LineageEventTest.java
@@ -57,7 +57,8 @@ public class LineageEventTest {
     URL expectedResource = Resources.getResource(inputFile);
     ObjectMapper objectMapper = Utils.newObjectMapper();
     RunEvent expectedEvent = objectMapper.readValue(expectedResource, RunEvent.class);
-    LineageEvent lineageEvent = objectMapper.readValue(expectedResource, LineageEvent.class);
+    LineageEvent lineageEvent =
+        (LineageEvent) objectMapper.readValue(expectedResource, BaseEvent.class);
     RunEvent converted =
         objectMapper.readValue(objectMapper.writeValueAsString(lineageEvent), RunEvent.class);
     assertThat(converted)
@@ -75,7 +76,7 @@ public class LineageEventTest {
 
   public void testSerialization(ObjectMapper mapper, String expectedFile) throws IOException {
     URL expectedResource = Resources.getResource(expectedFile);
-    LineageEvent deserialized = mapper.readValue(expectedResource, LineageEvent.class);
+    LineageEvent deserialized = (LineageEvent) mapper.readValue(expectedResource, BaseEvent.class);
     String serialized = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(deserialized);
 
     JsonNode expectedNode = mapper.readTree(expectedResource);

--- a/api/src/test/resources/open_lineage/event_dataset_event.json
+++ b/api/src/test/resources/open_lineage/event_dataset_event.json
@@ -1,0 +1,22 @@
+{
+  "eventTime": "2020-12-28T19:52:00.001+10:00",
+  "dataset": {
+    "namespace": "my-dataset-namespace",
+    "name": "my-dataset-name",
+    "facets": {
+      "schema": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "fields": [
+          {
+            "name": "col_a",
+            "type": "VARCHAR",
+            "description": "string"
+          }
+        ]
+      }
+    }
+  },
+  "producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+  "schemaURL": "https://openlineage.io/spec/2-8-9/OpenLineage.json#/definitions/DatasetEvent"
+}

--- a/api/src/test/resources/open_lineage/event_job_event.json
+++ b/api/src/test/resources/open_lineage/event_job_event.json
@@ -1,0 +1,22 @@
+{
+  "eventType": "COMPLETE",
+  "eventTime": "2020-12-28T19:52:00.001+10:00",
+  "job": {
+    "namespace": "my-scheduler-namespace",
+    "name": "myjob"
+  },
+  "inputs": [
+    {
+      "namespace": "my-datasource-namespace",
+      "name": "instance.schema.input-1"
+    }
+  ],
+  "outputs": [
+    {
+      "namespace": "my-datasource-namespace",
+      "name": "instance.schema.output-1"
+    }
+  ],
+  "producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+  "schemaURL": "https://openlineage.io/spec/1-0-1/OpenLineage.json#/definitions/JobEvent"
+}

--- a/api/src/test/resources/open_lineage/event_without_schema_url.json
+++ b/api/src/test/resources/open_lineage/event_without_schema_url.json
@@ -1,0 +1,28 @@
+{
+  "eventType": "COMPLETE",
+  "eventTime": "2020-12-28T19:52:00.001+10:00",
+  "run": {
+    "runId": "41fb5137-f0fd-4ee5-ba5c-56f8571d1bd7"
+  },
+  "job": {
+    "namespace": "my-scheduler-namespace",
+    "name": "myjob"
+  },
+  "inputs": [
+    {
+      "namespace": "my-datasource-namespace",
+      "name": "instance.schema.input-1"
+    },
+    {
+      "namespace": "my-datasource-namespace",
+      "name": "instance.schema.input-2"
+    }
+  ],
+  "outputs": [
+    {
+      "namespace": "my-datasource-namespace",
+      "name": "instance.schema.output-1"
+    }
+  ],
+  "producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client"
+}

--- a/clients/java/src/main/java/marquez/client/models/LineageEvent.java
+++ b/clients/java/src/main/java/marquez/client/models/LineageEvent.java
@@ -20,4 +20,12 @@ public class LineageEvent {
   List<Object> inputs;
   List<Object> outputs;
   URI producer;
+  URI schemaURL;
+
+  public URI getSchemaURL() {
+    if (schemaURL == null) {
+      return URI.create("https://openlineage.io/spec/2-0-0/OpenLineage.json#/definitions/RunEvent");
+    }
+    return schemaURL;
+  }
 }

--- a/clients/java/src/test/java/marquez/client/MarquezClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezClientTest.java
@@ -188,7 +188,8 @@ public class MarquezClientTest {
           Collections.emptyMap(),
           Collections.emptyList(),
           Collections.emptyList(),
-          URI.create("http://localhost:8080"));
+          URI.create("http://localhost:8080"),
+          URI.create("https://openlineage.io/spec/2-0-0/OpenLineage.json#/definitions/RunEvent"));
 
   // STREAM DATASET
   private static final DatasetId STREAM_ID = newDatasetIdWith(NAMESPACE_NAME);

--- a/clients/java/src/test/java/marquez/client/models/LineageEventTest.java
+++ b/clients/java/src/test/java/marquez/client/models/LineageEventTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.client.models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class LineageEventTest {
+
+  public static final URI VALID_SCHEMA_URL =
+      URI.create("https://openlineage.io/spec/2-5-0/OpenLineage.json#/definitions/RunEvent");
+
+  @Test
+  public void testGetSchemaURL() {
+    assertThat(createlLineageEventWith(VALID_SCHEMA_URL).getSchemaURL())
+        .isEqualTo(VALID_SCHEMA_URL);
+  }
+
+  @Test
+  public void testGetSchemaURLWhenNull() {
+    assertThat(createlLineageEventWith(null).getSchemaURL())
+        .isEqualTo(
+            URI.create("https://openlineage.io/spec/2-0-0/OpenLineage.json#/definitions/RunEvent"));
+  }
+
+  private LineageEvent createlLineageEventWith(URI schemaURL) {
+    return new LineageEvent(
+        "START",
+        ZonedDateTime.now(ZoneId.of("UTC")),
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        URI.create("http://localhost:8080"),
+        schemaURL);
+  }
+}


### PR DESCRIPTION
### Problem

Static metadata events (known also as runless) where presented within in the proposal:
https://github.com/OpenLineage/OpenLineage/blob/main/proposals/1837/static_lineage.md

and is being introduced to Openlineage specification within the PR: https://github.com/OpenLineage/OpenLineage/pull/1880

Of course, we would like to implement it within Marquez. We would like to achieve this ultimate goal gradually and this PR contains the first step.

The changes introduced within the PR: 
 * Don't affect the way `RunEvent` events are being collected. Events are saved into database and http status code `201 (created)` is returned. 
 * `DatasetEvent` and `JobEvent` are distinguished by `schemaURL` property. If distinction cannot be made, events are treated the default way, as `RunEvent`.
 *   `DatasetEvent` and `JobEvent`events are deserialised by standard Jackso library `DatasetEvent`/`JobEvent` classes. The response returns in such cases `200 OK` http status code but **DOES NOT SAVE** data to database (this will be introduced later). The great benefit of that is that it is a good integration test and a demo of of how to do events' distinction on the server side. 

Relates to: #1868

### Solution

 * EventTypeResolver is introduced which decodes incoming `/create` requests to `LineageEvent`, `DatasetEvent` or `JobEvent` based on the `schemaURL` field.
 * Nothing changes for `RunEvents`.
 * In case of `DatasetEvent` or `JobEvent`, they get deserialised and distinguished, however no operation on database is performed. 

One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)