### PR TITLE
feat: change dataQualityAssertions type to DATASET

### DIFF
--- a/api/src/main/java/marquez/db/DatasetFacetsDao.java
+++ b/api/src/main/java/marquez/db/DatasetFacetsDao.java
@@ -40,7 +40,7 @@ public interface DatasetFacetsDao {
     COLUMN_LINEAGE(Type.DATASET, "columnLineage"),
     OWNERSHIP(Type.DATASET, "ownership"),
     DATA_QUALITY_METRICS(Type.INPUT, "dataQualityMetrics"),
-    DATA_QUALITY_ASSERTIONS(Type.INPUT, "dataQualityAssertions"),
+    DATA_QUALITY_ASSERTIONS(Type.DATASET, "dataQualityAssertions"),
     OUTPUT_STATISTICS(Type.OUTPUT, "outputStatistics");
 
     final Type type;

--- a/api/src/main/java/marquez/db/migrations/V56_1__FacetViews.java
+++ b/api/src/main/java/marquez/db/migrations/V56_1__FacetViews.java
@@ -62,8 +62,8 @@ public class V56_1__FacetViews implements JavaMigration {
                 df.event_type::VARCHAR(64) AS lineage_event_type,
                 (
                     CASE
-                    WHEN lower(facet_name) IN ('documentation', 'schema', 'datasource', 'description', 'lifecyclestatechange', 'version', 'columnlineage', 'ownership') then 'DATASET'
-                    WHEN lower(facet_name) IN ('dataqualitymetrics', 'dataqualityassertions') then 'INPUT'
+                    WHEN lower(facet_name) IN ('documentation', 'schema', 'datasource', 'description', 'lifecyclestatechange', 'version', 'columnlineage', 'ownership', 'dataqualityassertions') then 'DATASET'
+                    WHEN lower(facet_name) IN ('dataqualitymetrics') then 'INPUT'
                     WHEN lower(facet_name) = 'outputstatistics' then 'OUTPUT'
                     ELSE 'UNKNOWN'
                     END

--- a/api/src/test/java/marquez/db/DatasetFacetsDaoTest.java
+++ b/api/src/test/java/marquez/db/DatasetFacetsDaoTest.java
@@ -263,7 +263,7 @@ public class DatasetFacetsDaoTest {
         .hasFieldOrPropertyWithValue("runUuid", lineageRow.getRun().getUuid())
         .hasFieldOrPropertyWithValue("lineageEventTime", lineageRow.getRun().getCreatedAt())
         .hasFieldOrPropertyWithValue("lineageEventType", "COMPLETE")
-        .hasFieldOrPropertyWithValue("type", DatasetFacetsDao.Type.INPUT);
+        .hasFieldOrPropertyWithValue("type", DatasetFacetsDao.Type.DATASET);
 
     assertThat(facet.facet().toString()).isEqualTo("{\"dataQualityAssertions\": \"m2\"}");
   }

--- a/api/src/test/java/marquez/db/migrations/V57_1__BackfillFacetsTest.java
+++ b/api/src/test/java/marquez/db/migrations/V57_1__BackfillFacetsTest.java
@@ -108,7 +108,7 @@ public class V57_1__BackfillFacetsTest {
       assertThat(getDatasetFacetType(inputDatasetFacets, "version")).isEqualTo(DATASET);
       assertThat(getDatasetFacetType(inputDatasetFacets, "ownership")).isEqualTo(DATASET);
       assertThat(getDatasetFacetType(inputDatasetFacets, "dataQualityMetrics")).isEqualTo(INPUT);
-      assertThat(getDatasetFacetType(inputDatasetFacets, "dataQualityAssertions")).isEqualTo(INPUT);
+      assertThat(getDatasetFacetType(inputDatasetFacets, "dataQualityAssertions")).isEqualTo(DATASET);
       assertThat(getDatasetFacetType(inputDatasetFacets, "custom-input")).isEqualTo(UNKNOWN);
 
       assertThat(


### PR DESCRIPTION
### Problem

Closes: #2503 

### Solution

As a quick fix to display the dataQualityAssertion again in the Marquez UI, I propose changing the dataset facet type of the dataQualityAssertion to DATASET

One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)