### PR TITLE
add pagination to datasets

### DIFF
--- a/web/src/__tests__/components/DatasetsPagination.test.tsx
+++ b/web/src/__tests__/components/DatasetsPagination.test.tsx
@@ -12,7 +12,7 @@ test.skip('DatasetsPagination Component', () => {
         expect(wrapper.exists()).toBe(true)
     })
 
-    it('should find Tooltip elements continaing IconButton elements', () => {
+    it('should find Tooltip elements containing IconButton elements', () => {
         expect(
           wrapper
             .find(Tooltip)

--- a/web/src/__tests__/components/DatasetsPagination.test.tsx
+++ b/web/src/__tests__/components/DatasetsPagination.test.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { mount } from 'enzyme'
+import Datasets from '../../routes/datasets/Datasets'
+import { Tooltip } from '@material-ui/core'
+import IconButton from '@material-ui/core/IconButton'
+
+test.skip('DatasetsPagination Component', () => {
+
+    const wrapper = mount(<Datasets />)
+
+    it('should render', () => {
+        expect(wrapper.exists()).toBe(true)
+    })
+
+    it('should find Tooltip elements continaing IconButton elements', () => {
+        expect(
+          wrapper
+            .find(Tooltip)
+        ).toContain(IconButton)
+    })
+})

--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -22,6 +22,8 @@ import React from 'react'
 import createStyles from '@material-ui/core/styles/createStyles'
 import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles'
 
+const PAGE_SIZE = 20
+
 const styles = (theme: Theme) => createStyles({
   ml2: {
     marginLeft: theme.spacing(2)
@@ -58,7 +60,7 @@ class Datasets extends React.Component<DatasetsProps, DatasetsState> {
       page: 1,
       pageIsLast: false
     }
-    this.pageSize = 20
+    // this.pageSize = 20
   }
 
   componentDidMount() {
@@ -75,13 +77,13 @@ class Datasets extends React.Component<DatasetsProps, DatasetsState> {
       prevProps.selectedNamespace !== this.props.selectedNamespace &&
       this.props.selectedNamespace
     ) {
-      this.props.fetchDatasets(this.props.selectedNamespace, this.pageSize)
+      this.props.fetchDatasets(this.props.selectedNamespace, PAGE_SIZE)
     }
 
     if (datasetsProps !== datasetsState) {
       this.setState({
         datasets: datasetsProps,
-        pageIsLast: datasetsProps.length < page * this.pageSize
+        pageIsLast: datasetsProps.length < page * PAGE_SIZE
       })
     }
   }
@@ -92,13 +94,13 @@ class Datasets extends React.Component<DatasetsProps, DatasetsState> {
 
   getDatasets() {
     const { datasets, page } = this.state
-    return datasets.slice((page - 1) * this.pageSize, this.pageSize + (page - 1) * this.pageSize)
+    return datasets.slice((page - 1) * PAGE_SIZE, PAGE_SIZE + (page - 1) * PAGE_SIZE)
   }
 
   pageNavigation() {
     const { datasets, page } = this.state
     const titlePos = datasets.length
-      ? `${this.pageSize * page - this.pageSize} - ${datasets.length}`
+      ? `${PAGE_SIZE * page - PAGE_SIZE} - ${datasets.length}`
       : `${datasets.length}`
     return `${page} (${titlePos})`
   }
@@ -110,7 +112,7 @@ class Datasets extends React.Component<DatasetsProps, DatasetsState> {
     if (this.props.selectedNamespace) {
       this.props.fetchDatasets(
         this.props.selectedNamespace,
-        this.pageSize * directionPage
+        PAGE_SIZE * directionPage
       )
     }
     this.setState({ page: directionPage })

--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -51,7 +51,6 @@ interface DatasetsState {
 type DatasetsProps = WithStyles<typeof styles> & StateProps & DispatchProps
 
 class Datasets extends React.Component<DatasetsProps, DatasetsState> {
-  pageSize: number
 
   constructor(props: DatasetsProps) {
     super(props)
@@ -64,7 +63,7 @@ class Datasets extends React.Component<DatasetsProps, DatasetsState> {
 
   componentDidMount() {
     if (this.props.selectedNamespace) {
-      this.props.fetchDatasets(this.props.selectedNamespace, this.pageSize)
+      this.props.fetchDatasets(this.props.selectedNamespace, PAGE_SIZE)
     }
   }
 

--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -60,7 +60,6 @@ class Datasets extends React.Component<DatasetsProps, DatasetsState> {
       page: 1,
       pageIsLast: false
     }
-    // this.pageSize = 20
   }
 
   componentDidMount() {
@@ -162,8 +161,6 @@ class Datasets extends React.Component<DatasetsProps, DatasetsState> {
                     </Tooltip>
                   </Box>
                 </Box>
-                
-              
                 <Table size='small'>
                   <TableHead>
                     <TableRow>

--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -96,9 +96,15 @@ class Datasets extends React.Component<DatasetsProps, DatasetsState> {
   }
 
   pageNavigation() {
-    const { datasets, page } = this.state
-    const titlePos = datasets.length
-      ? `${PAGE_SIZE * page - PAGE_SIZE} - ${datasets.length}`
+    const { datasets, page, pageIsLast } = this.state
+    const titlePos = datasets.length < PAGE_SIZE && page === 1
+      ? `1 - ${datasets.length}` 
+      : datasets.length > PAGE_SIZE && page === 1
+      ? `1 - ${PAGE_SIZE}`
+      : datasets.length && page > 1 && pageIsLast === false
+      ? `${PAGE_SIZE * page - PAGE_SIZE + 1} - ${PAGE_SIZE * page}`
+      : datasets.length && page > 1 && pageIsLast
+      ? `${PAGE_SIZE * page - PAGE_SIZE + 1} - ${datasets.length}`
       : `${datasets.length}`
     return `${page} (${titlePos})`
   }

--- a/web/src/store/actionCreators/index.ts
+++ b/web/src/store/actionCreators/index.ts
@@ -36,10 +36,11 @@ export const resetEvents = () => ({
   type: actionTypes.RESET_EVENTS
 })
 
-export const fetchDatasets = (namespace: string) => ({
+export const fetchDatasets = (namespace: string, limit: number) => ({
   type: actionTypes.FETCH_DATASETS,
   payload: {
-    namespace
+    namespace,
+    limit
   }
 })
 


### PR DESCRIPTION
### Problem

Pagination would make viewing datasets in namespaces with many datasets more manageable, as in the case of events. But currently datasets are not paginated.

### Solution

This paginates the datasets route in the same way events are paginated.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary: adds pagination to datasets

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)