### PR TITLE
Gen new `uuid` for `etl_menus` ol events

### DIFF
--- a/docker/metadata.json
+++ b/docker/metadata.json
@@ -3,7 +3,7 @@
     "eventType": "START",
     "eventTime": "2020-02-22T22:42:42.000Z",
     "run": {
-      "runId": "d46e465b-d358-4d32-83d4-df660ff614dd",
+      "runId": "4d3b8069-69b6-4708-ade0-3275112c9f04",
       "facets": {
         "nominalTime": {
           "_producer": "https://github.com/MarquezProject/marquez/blob/main/docker/metadata.json",
@@ -84,7 +84,7 @@
     "eventType": "COMPLETE",
     "eventTime": "2020-02-22T22:45:52.000Z",
     "run": {
-      "runId": "d46e465b-d358-4d32-83d4-df660ff614dd"
+      "runId": "4d3b8069-69b6-4708-ade0-3275112c9f04"
     },
     "job": {
       "namespace": "food_delivery",


### PR DESCRIPTION
### Problem

The OL [quickstart](https://openlineage.io/getting-started) produces an invalid lineage graph if Marquez was seeded using the [`seed`](https://github.com/MarquezProject/marquez/blob/main/api/src/main/java/marquez/cli/SeedCommand.java) cmd (see related PR https://github.com/OpenLineage/docs/pull/183). That is, in the lineage graph below, the job `my-job` should **not** contain the out edge `public.menus` as an output dataset (linking the two subgraphs):

![Screenshot 2023-06-15 at 12 47 42](https://github.com/MarquezProject/marquez/assets/1553185/32e038fb-a09e-406f-8a52-2a2579dd06e8)


### Solution

Believe it or not, the invalid lineage graph is actually, valid! It's the result of a **runID** collision. That is, the OL events for  `my-job` in the quickstart uses the **runID** `d46e465b-d358-4d32-83d4-df660ff614dd`, the same **runID** `d46e465b-d358-4d32-83d4-df660ff614dd`  as job `etl_menus` in [`metadata.json`](https://github.com/MarquezProject/marquez/blob/main/docker/metadata.json). Therefore, the backend assumes the outputs have changed  for `etl_menus`. This PR generates a new **runID** `4d3b8069-69b6-4708-ade0-3275112c9f04` for `etl_menus` to render the expected lineage graph:

<img width="989" alt="Screen Shot 2023-06-15 at 2 31 36 PM" src="https://github.com/MarquezProject/marquez/assets/1553185/4b28785f-b3cc-4c50-92b7-5e3198a1777c">

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)