### PR TITLE
Revert URL encoding when fetching lineage

### DIFF
--- a/web/src/__tests__/requests/lineage.test.ts
+++ b/web/src/__tests__/requests/lineage.test.ts
@@ -1,0 +1,22 @@
+// Copyright 2018-2023 contributors to the Marquez project
+// SPDX-License-Identifier: Apache-2.0
+
+import { generateNodeId } from '../../helpers/nodes'
+import * as requestUtils from '../../store/requests'
+import { getLineage } from '../../store/requests/lineage'
+
+describe('getLineage function', () => {
+  let spy: jest.SpyInstance<Promise<any>, [string, requestUtils.IParams, string]>
+  let testResult: Promise<any>
+
+  beforeEach(() => {
+    spy = jest.spyOn(requestUtils, 'genericFetchWrapper').mockImplementation(() => {})
+    testResult = getLineage('JOB', 'foo', 'bar', 0)
+  })
+
+  it('does not url-encode query params', () => {
+    const expectedNodeId = generateNodeId('JOB', 'foo', 'bar')
+    const actualParamString = spy.mock.lastCall[0].split('?')
+    expect(actualParamString.pop()!.split('&')).toContain(`nodeId=${expectedNodeId}`)
+  })
+})

--- a/web/src/store/requests/index.ts
+++ b/web/src/store/requests/index.ts
@@ -8,7 +8,7 @@ export const genericErrorMessageConstructor = (functionName: string, error: APIE
   throw `${functionName} responded with error code ${code}: ${message}.  Here are the details: ${details}`
 }
 
-interface IParams {
+export interface IParams {
   method: HttpMethod
   body?: string
 }

--- a/web/src/store/requests/lineage.ts
+++ b/web/src/store/requests/lineage.ts
@@ -13,6 +13,7 @@ export const getLineage = async (
   depth: number
 ) => {
   const nodeId = generateNodeId(nodeType, namespace, name)
+  // Node ID cannot be URL encoded
   const url = `${API_URL}/lineage/?nodeId=${nodeId}&depth=${depth}`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchLineage')
 }

--- a/web/src/store/requests/lineage.ts
+++ b/web/src/store/requests/lineage.ts
@@ -12,10 +12,7 @@ export const getLineage = async (
   name: string,
   depth: number
 ) => {
-  const params = new URLSearchParams({
-    nodeId: generateNodeId(nodeType, namespace, name),
-    depth: depth.toString()
-  })
-  const url = `${API_URL}/lineage/?${params.toString()}`
+  const nodeId = generateNodeId(nodeType, namespace, name)
+  const url = `${API_URL}/lineage/?nodeId=${nodeId}&depth=${depth}`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchLineage')
 }


### PR DESCRIPTION
### Problem

When I converted this to use the URLSearchParams in #2525, we started inadvertently url-encoding the node id, which causes problems if the node id contains special characters. 

### Solution

This reverts node ID from being URL encoded and allows the backend to successfully return the lineage details even when the node ID contains special characters.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)