### PR TITLE
Define `DbRetentionJob(Jdbi, DbRetentionConfig)`

### DIFF
--- a/api/src/main/java/marquez/MarquezApp.java
+++ b/api/src/main/java/marquez/MarquezApp.java
@@ -137,13 +137,7 @@ public final class MarquezApp extends Application<MarquezConfig> {
     // Add scheduled jobs to lifecycle.
     if (config.hasDbRetentionPolicy()) {
       // Add job to apply retention policy to database.
-      env.lifecycle()
-          .manage(
-              new DbRetentionJob(
-                  jdbi,
-                  config.getDbRetention().getFrequencyMins(),
-                  config.getDbRetention().getNumberOfRowsPerBatch(),
-                  config.getDbRetention().getRetentionDays()));
+      env.lifecycle().manage(new DbRetentionJob(jdbi, config.getDbRetention()));
     }
   }
 

--- a/api/src/main/java/marquez/jobs/DbRetentionConfig.java
+++ b/api/src/main/java/marquez/jobs/DbRetentionConfig.java
@@ -8,14 +8,22 @@ package marquez.jobs;
 import static marquez.db.DbRetention.DEFAULT_NUMBER_OF_ROWS_PER_BATCH;
 import static marquez.db.DbRetention.DEFAULT_RETENTION_DAYS;
 
+import javax.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.Value;
 
 /** Configuration for {@link DbRetentionJob}. */
-public final class DbRetentionConfig {
+@Value
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DbRetentionConfig {
   public static final int DEFAULT_FREQUENCY_MINS = 15;
 
-  @Getter @Setter private int frequencyMins = DEFAULT_FREQUENCY_MINS;
-  @Getter @Setter private int numberOfRowsPerBatch = DEFAULT_NUMBER_OF_ROWS_PER_BATCH;
-  @Getter @Setter private int retentionDays = DEFAULT_RETENTION_DAYS;
+  @Builder.Default @Getter @Positive int frequencyMins = DEFAULT_FREQUENCY_MINS;
+  @Builder.Default @Getter @Positive int numberOfRowsPerBatch = DEFAULT_NUMBER_OF_ROWS_PER_BATCH;
+  @Builder.Default @Getter @Positive int retentionDays = DEFAULT_RETENTION_DAYS;
 }

--- a/api/src/main/java/marquez/jobs/DbRetentionConfig.java
+++ b/api/src/main/java/marquez/jobs/DbRetentionConfig.java
@@ -16,10 +16,10 @@ import lombok.NoArgsConstructor;
 import lombok.Value;
 
 /** Configuration for {@link DbRetentionJob}. */
-@Value
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Value
 public class DbRetentionConfig {
   public static final int DEFAULT_FREQUENCY_MINS = 15;
 

--- a/api/src/main/java/marquez/jobs/DbRetentionJob.java
+++ b/api/src/main/java/marquez/jobs/DbRetentionJob.java
@@ -5,8 +5,6 @@
 
 package marquez.jobs;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.util.concurrent.AbstractScheduledService;
 import io.dropwizard.lifecycle.Managed;
 import java.time.Duration;
@@ -43,21 +41,17 @@ public class DbRetentionJob extends AbstractScheduledService implements Managed 
    * of {@code retentionDays}.
    */
   public DbRetentionJob(
-      @NonNull final Jdbi jdbi,
-      final int frequencyMins,
-      final int numberOfRowsPerBatch,
-      final int retentionDays) {
-    checkArgument(frequencyMins > 0, "'frequencyMins' must be > 0");
-    checkArgument(numberOfRowsPerBatch > 0, "'numberOfRowsPerBatch' must be > 0");
-    checkArgument(retentionDays > 0, "'retentionDays' must be > 0");
-    this.numberOfRowsPerBatch = numberOfRowsPerBatch;
-    this.retentionDays = retentionDays;
+      @NonNull final Jdbi jdbi, @NonNull final DbRetentionConfig dbRetentionConfig) {
+    this.numberOfRowsPerBatch = dbRetentionConfig.getNumberOfRowsPerBatch();
+    this.retentionDays = dbRetentionConfig.getRetentionDays();
 
+    // Open connection.
     this.jdbi = jdbi;
 
     // Define fixed schedule with no delay.
     this.fixedRateScheduler =
-        Scheduler.newFixedRateSchedule(NO_DELAY, Duration.ofMinutes(frequencyMins));
+        Scheduler.newFixedRateSchedule(
+            NO_DELAY, Duration.ofMinutes(dbRetentionConfig.getFrequencyMins()));
   }
 
   @Override

--- a/api/src/test/java/marquez/jobs/DbRetentionConfigTest.java
+++ b/api/src/test/java/marquez/jobs/DbRetentionConfigTest.java
@@ -1,0 +1,105 @@
+package marquez.jobs;
+
+import static marquez.db.DbRetention.DEFAULT_NUMBER_OF_ROWS_PER_BATCH;
+import static marquez.db.DbRetention.DEFAULT_RETENTION_DAYS;
+import static marquez.jobs.DbRetentionConfig.DEFAULT_FREQUENCY_MINS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+/** The test suite for {@link DbRetentionConfig}. */
+public class DbRetentionConfigTest {
+  private static final Validator VALIDATOR =
+      Validation.buildDefaultValidatorFactory().getValidator();
+
+  @Test
+  public void testNewDbRetentionConfig_withDefaultsOnly() {
+    final DbRetentionConfig configWithDefaults = new DbRetentionConfig();
+
+    assertThat(configWithDefaults.getFrequencyMins()).isEqualTo(DEFAULT_FREQUENCY_MINS);
+    assertThat(configWithDefaults.getNumberOfRowsPerBatch())
+        .isEqualTo(DEFAULT_NUMBER_OF_ROWS_PER_BATCH);
+    assertThat(configWithDefaults.getRetentionDays()).isEqualTo(DEFAULT_RETENTION_DAYS);
+  }
+
+  @Test
+  public void testNewDbRetentionConfig_overrideFrequencyMins() {
+    final int frequencyMinsOverride = 5;
+    final DbRetentionConfig configWithFrequencyMinsOverride =
+        DbRetentionConfig.builder().frequencyMins(frequencyMinsOverride).build();
+
+    assertThat(configWithFrequencyMinsOverride.getFrequencyMins()).isEqualTo(frequencyMinsOverride);
+    assertThat(configWithFrequencyMinsOverride.getNumberOfRowsPerBatch())
+        .isEqualTo(DEFAULT_NUMBER_OF_ROWS_PER_BATCH);
+    assertThat(configWithFrequencyMinsOverride.getRetentionDays())
+        .isEqualTo(DEFAULT_RETENTION_DAYS);
+  }
+
+  @Test
+  public void testNewDbRetentionConfig_overrideNumberOfRowsPerBatch() {
+    final int numberOfRowsPerBatchOverride = 25;
+    final DbRetentionConfig configWithNumberOfRowsPerBatchOverride =
+        DbRetentionConfig.builder().numberOfRowsPerBatch(numberOfRowsPerBatchOverride).build();
+
+    assertThat(configWithNumberOfRowsPerBatchOverride.getFrequencyMins())
+        .isEqualTo(DEFAULT_FREQUENCY_MINS);
+    assertThat(configWithNumberOfRowsPerBatchOverride.getNumberOfRowsPerBatch())
+        .isEqualTo(numberOfRowsPerBatchOverride);
+    assertThat(configWithNumberOfRowsPerBatchOverride.getRetentionDays())
+        .isEqualTo(DEFAULT_RETENTION_DAYS);
+  }
+
+  @Test
+  public void testNewDbRetentionConfig_overrideRetentionDays() {
+    final int retentionDaysOverride = 14;
+    final DbRetentionConfig configWithNumberOfRowsPerBatchOverride =
+        DbRetentionConfig.builder().retentionDays(retentionDaysOverride).build();
+
+    assertThat(configWithNumberOfRowsPerBatchOverride.getFrequencyMins())
+        .isEqualTo(DEFAULT_FREQUENCY_MINS);
+    assertThat(configWithNumberOfRowsPerBatchOverride.getNumberOfRowsPerBatch())
+        .isEqualTo(DEFAULT_NUMBER_OF_ROWS_PER_BATCH);
+    assertThat(configWithNumberOfRowsPerBatchOverride.getRetentionDays())
+        .isEqualTo(retentionDaysOverride);
+  }
+
+  @Test
+  public void testNewDbRetentionConfig_negativeFrequencyMins() {
+    final int negativeFrequencyMins = -5;
+
+    final DbRetentionConfig configWithNegativeFrequencyMins =
+        DbRetentionConfig.builder().frequencyMins(negativeFrequencyMins).build();
+
+    final Set<ConstraintViolation<DbRetentionConfig>> violations =
+        VALIDATOR.validate(configWithNegativeFrequencyMins);
+    assertThat(violations).hasSize(1);
+  }
+
+  @Test
+  public void testNewDbRetentionConfig_negativeNumberOfRowsPerBatch() {
+    final int negativeNumberOfRowsPerBatch = -25;
+
+    final DbRetentionConfig configWithNegativeNumberOfRowsPerBatch =
+        DbRetentionConfig.builder().numberOfRowsPerBatch(negativeNumberOfRowsPerBatch).build();
+
+    final Set<ConstraintViolation<DbRetentionConfig>> violations =
+        VALIDATOR.validate(configWithNegativeNumberOfRowsPerBatch);
+    assertThat(violations).hasSize(1);
+  }
+
+  @Test
+  public void testNewDbRetentionConfig_negativeRetentionDays() {
+    final int negativeRetentionDays = -14;
+
+    final DbRetentionConfig configWithNegativeRetentionDays =
+        DbRetentionConfig.builder().retentionDays(negativeRetentionDays).build();
+
+    final Set<ConstraintViolation<DbRetentionConfig>> violations =
+        VALIDATOR.validate(configWithNegativeRetentionDays);
+    assertThat(violations).hasSize(1);
+  }
+}

--- a/api/src/test/java/marquez/jobs/DbRetentionConfigTest.java
+++ b/api/src/test/java/marquez/jobs/DbRetentionConfigTest.java
@@ -32,6 +32,11 @@ public class DbRetentionConfigTest {
     final DbRetentionConfig configWithFrequencyMinsOverride =
         DbRetentionConfig.builder().frequencyMins(frequencyMinsOverride).build();
 
+    // No constraint violations.
+    final Set<ConstraintViolation<DbRetentionConfig>> violations =
+        VALIDATOR.validate(configWithFrequencyMinsOverride);
+    assertThat(violations).isEmpty();
+
     assertThat(configWithFrequencyMinsOverride.getFrequencyMins()).isEqualTo(frequencyMinsOverride);
     assertThat(configWithFrequencyMinsOverride.getNumberOfRowsPerBatch())
         .isEqualTo(DEFAULT_NUMBER_OF_ROWS_PER_BATCH);
@@ -44,6 +49,11 @@ public class DbRetentionConfigTest {
     final int numberOfRowsPerBatchOverride = 25;
     final DbRetentionConfig configWithNumberOfRowsPerBatchOverride =
         DbRetentionConfig.builder().numberOfRowsPerBatch(numberOfRowsPerBatchOverride).build();
+
+    // No constraint violations.
+    final Set<ConstraintViolation<DbRetentionConfig>> violations =
+        VALIDATOR.validate(configWithNumberOfRowsPerBatchOverride);
+    assertThat(violations).isEmpty();
 
     assertThat(configWithNumberOfRowsPerBatchOverride.getFrequencyMins())
         .isEqualTo(DEFAULT_FREQUENCY_MINS);
@@ -58,6 +68,11 @@ public class DbRetentionConfigTest {
     final int retentionDaysOverride = 14;
     final DbRetentionConfig configWithNumberOfRowsPerBatchOverride =
         DbRetentionConfig.builder().retentionDays(retentionDaysOverride).build();
+
+    // No constraint violations.
+    final Set<ConstraintViolation<DbRetentionConfig>> violations =
+        VALIDATOR.validate(configWithNumberOfRowsPerBatchOverride);
+    assertThat(violations).isEmpty();
 
     assertThat(configWithNumberOfRowsPerBatchOverride.getFrequencyMins())
         .isEqualTo(DEFAULT_FREQUENCY_MINS);

--- a/api/src/test/java/marquez/jobs/DbRetentionConfigTest.java
+++ b/api/src/test/java/marquez/jobs/DbRetentionConfigTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package marquez.jobs;
 
 import static marquez.db.DbRetention.DEFAULT_NUMBER_OF_ROWS_PER_BATCH;


### PR DESCRIPTION
### Problem

Validate `DbRetentionConfig` properties internally within class. That is, when instantiating a new `DbRetentionConfig` object, the caller should expect all config values to be valid, contain a reasonable default (if not set), and be immutable. The caller should not be expected to validate the properties externally from the class.

### Solution

Add `@Positive` to `DbRetentionConfig` instance variables with accompanying test suite.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)