### PR TITLE
Add log for when retention job starts

### DIFF
--- a/api/src/main/java/marquez/jobs/DbRetentionJob.java
+++ b/api/src/main/java/marquez/jobs/DbRetentionJob.java
@@ -27,6 +27,9 @@ public class DbRetentionJob extends AbstractScheduledService implements Managed 
   private static final Duration NO_DELAY = Duration.ofMinutes(0);
 
   /* The number of rows deleted per batch. */
+  private final int frequencyMins;
+
+  /* The number of rows deleted per batch. */
   private final int numberOfRowsPerBatch;
 
   /* The retention days. */
@@ -61,8 +64,12 @@ public class DbRetentionJob extends AbstractScheduledService implements Managed 
 
   @Override
   public void start() throws Exception {
-    log.info("Starting db retention job...");
     startAsync().awaitRunning();
+    log.info(
+        "Started db retention job with retention policy of '{}' days, "
+            + "scheduled to be applied every '{}' mins.",
+        retentionDays,
+        frequencyMins);
   }
 
   @Override

--- a/api/src/main/java/marquez/jobs/DbRetentionJob.java
+++ b/api/src/main/java/marquez/jobs/DbRetentionJob.java
@@ -26,7 +26,7 @@ import org.jdbi.v3.core.Jdbi;
 public class DbRetentionJob extends AbstractScheduledService implements Managed {
   private static final Duration NO_DELAY = Duration.ofMinutes(0);
 
-  /* The number of rows deleted per batch. */
+  /* The retention policy frequency. */
   private final int frequencyMins;
 
   /* The number of rows deleted per batch. */
@@ -45,10 +45,11 @@ public class DbRetentionJob extends AbstractScheduledService implements Managed 
    */
   public DbRetentionJob(
       @NonNull final Jdbi jdbi, @NonNull final DbRetentionConfig dbRetentionConfig) {
+    this.frequencyMins = dbRetentionConfig.getFrequencyMins();
     this.numberOfRowsPerBatch = dbRetentionConfig.getNumberOfRowsPerBatch();
     this.retentionDays = dbRetentionConfig.getRetentionDays();
 
-    // Open connection.
+    // Connection to database retention policy will be applied.
     this.jdbi = jdbi;
 
     // Define fixed schedule with no delay.


### PR DESCRIPTION
### Problem

Let's add a log event when the `DbRetentionJob` starts. The log will display:

* Retention policy
* Run frequency

### Solution

```
INFO  [2023-07-25 13:47:10,615] marquez.jobs.DbRetentionJob: Started db retention job with retention policy of '7' days, scheduled to be applied every '1' mins.
```

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)