### PR TITLE
Add `namespace`, `before`, and `after` to searchAPI

### DIFF
--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -668,6 +668,33 @@ paths:
         - $ref: '#/components/parameters/filter'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/limit'
+        - name: namespace
+          in: query
+          description: Match jobs or datasets within the given namespace.
+          required: false
+          schema:
+           type: string
+           maxLength: 1024
+           example: my-namespace
+        - before:
+          name: before
+          in: query
+          description: Match jobs or datasets **before** `YYYY-MM-DD`.
+          required: false
+          schema:
+            type: string
+            pattern: YYYY-MM-DD
+            example: "2022-09-15"
+        - after:
+          name: after
+          in: query
+          description: Match jobs or datasets **after** `YYYY-MM-DD`.
+          required: false
+          schema:
+            type: string
+            pattern: YYYY-MM-DD
+            example: "2022-09-15"
+
       summary: Query all datasets and jobs
       description: Returns one or more datasets and jobs of your query.
       tags:
@@ -772,7 +799,7 @@ components:
     limit:
       name: limit
       in: query
-      description: The number of results to return from offset
+      description: The number of results to return from offset.
       required: false
       schema:
         type: integer
@@ -782,7 +809,7 @@ components:
     offset:
       name: offset
       in: query
-      description: The initial position from which to return results
+      description: The initial position from which to return results.
       required: false
       schema:
         type: integer
@@ -875,7 +902,7 @@ components:
         type: string
         format: date-time
         example: 2022-09-15T07:47:19Z
-    
+
     type:
       name: type
       in: query


### PR DESCRIPTION
### Problem

The `searchAPI` does not support filtering search results by `namespace` or `date`. See related issue #2550 

### Solution

This PR adds for  search results by `namespace` or `date` using the following query parameters:

* `namespace` - will match jobs or datasets within the given namespace.
* `before` - will match jobs or datasets **before** `YYYY-MM-DD`.
* `after` - will match jobs or datasets **after** `YYYY-MM-DD`.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)