### PR TITLE
increase namespace length to 1024 character

### DIFF
--- a/clients/python/marquez_client/utils.py
+++ b/clients/python/marquez_client/utils.py
@@ -37,7 +37,7 @@ class Utils:
         # ['namespace_name', 'owner_name', 'source_name'] <= 64
         # ['dataset_name', 'field_name', 'job_name', 'tag_name'] <= 255
         if variable_name in ['namespace_name', 'owner_name', 'source_name']:
-            if len(variable_value) > 64:
+            if len(variable_value) > 1024:
                 raise ValueError(f"{variable_name} length is"
                                  f" {len(variable_value)}, must be <= 64")
         else:

--- a/clients/python/tests/test_utils.py
+++ b/clients/python/tests/test_utils.py
@@ -67,7 +67,7 @@ def test_check_name_length():
         Utils.check_name_length(variable_value='a'*1025,
                                 variable_name='owner_name')
     with pytest.raises(ValueError):
-        Utils.check_name_length(variable_value='a'*1025,
+        Utils.check_name_length(variable_value='a'*1026,
                                 variable_name='source_name')
     with pytest.raises(ValueError):
         Utils.check_name_length(variable_value='a'*256,

--- a/clients/python/tests/test_utils.py
+++ b/clients/python/tests/test_utils.py
@@ -64,10 +64,10 @@ def test_check_name_length():
         Utils.check_name_length(variable_value='a'*1025,
                                 variable_name='namespace_name')
     with pytest.raises(ValueError):
-        Utils.check_name_length(variable_value='a'*65,
+        Utils.check_name_length(variable_value='a'*1025,
                                 variable_name='owner_name')
     with pytest.raises(ValueError):
-        Utils.check_name_length(variable_value='a'*65,
+        Utils.check_name_length(variable_value='a'*1025,
                                 variable_name='source_name')
     with pytest.raises(ValueError):
         Utils.check_name_length(variable_value='a'*256,

--- a/clients/python/tests/test_utils.py
+++ b/clients/python/tests/test_utils.py
@@ -61,7 +61,7 @@ def test_is_none():
 
 def test_check_name_length():
     with pytest.raises(ValueError):
-        Utils.check_name_length(variable_value='a'*65,
+        Utils.check_name_length(variable_value='a'*1025,
                                 variable_name='namespace_name')
     with pytest.raises(ValueError):
         Utils.check_name_length(variable_value='a'*65,


### PR DESCRIPTION
### Problem

👋 Thanks for opening a [pull request](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#submitting-a-pull-request)! Please include a brief summary of the problem your change is trying to solve, or bug fix. If your change fixes a bug or you'd like to provide context on why you're making the change, please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) as follows:

Python client for namespace length is still at 64 when Java Marquez client length changed to 1024 character. - [marquez/common/models/NamespaceName.java](https://github.com/MarquezProject/marquez/blob/main/api/src/main/java/marquez/common/models/NamespaceName.java#L25)


Closes: #ISSUE-NUMBER

### Solution
> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary: Changed namespace length constraint to sync up with Java client


### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)