### PR TITLE
Add `namespace`, `before` and `after` to SearchDao

### DIFF
--- a/api/src/main/java/marquez/db/SearchDao.java
+++ b/api/src/main/java/marquez/db/SearchDao.java
@@ -5,17 +5,45 @@
 
 package marquez.db;
 
+import java.time.Instant;
 import java.util.List;
+import javax.annotation.Nullable;
 import marquez.api.models.SearchFilter;
 import marquez.api.models.SearchResult;
 import marquez.api.models.SearchSort;
 import marquez.db.mappers.SearchResultMapper;
+import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 
 /** The DAO for {@link SearchResult}. */
 @RegisterRowMapper(SearchResultMapper.class)
-public interface SearchDao {
+public interface SearchDao extends SqlObject {
+
+  default List<SearchResult> search(String query, SearchFilter filter, SearchSort sort, int limit) {
+    return search(query, filter, sort, limit, null, null, null);
+  }
+
+  default List<SearchResult> search(
+      String query, SearchFilter filter, SearchSort sort, int limit, String namespace) {
+    return search(query, filter, sort, limit, namespace, null, null);
+  }
+
+  default List<SearchResult> search(
+      String query, SearchFilter filter, SearchSort sort, int limit, Instant before) {
+    return search(query, filter, sort, limit, null, before, null);
+  }
+
+  default List<SearchResult> search(
+      String query,
+      SearchFilter filter,
+      SearchSort sort,
+      int limit,
+      Instant before,
+      Instant after) {
+    return search(query, filter, sort, limit, null, before, after);
+  }
+
   /**
    * Returns all datasets and jobs that match the provided query; matching of datasets and jobs are
    * string based and case-insensitive.
@@ -24,26 +52,41 @@ public interface SearchDao {
    * @param filter The filter to apply to the query result.
    * @param sort The sort to apply to the query result.
    * @param limit The limit to apply to the query result.
+   * @param namespace Match jobs or datasets within the given namespace.
+   * @param before Match jobs or datasets before YYYY-MM-DD.
+   * @param after Match jobs or datasets after YYYY-MM-DD.
    * @return A {@link SearchResult} object.
    */
   @SqlQuery(
       """
-      SELECT type, name, updated_at, namespace_name
-      FROM (
-        SELECT 'DATASET' AS type, d.name, d.updated_at, d.namespace_name
-          FROM datasets_view AS d
-         WHERE  d.name ilike '%' || :query || '%'
-         UNION
-        SELECT DISTINCT ON (j.namespace_name, j.name)\s
-          'JOB' AS type, j.name, j.updated_at, j.namespace_name
-          FROM (SELECT namespace_name, name, unnest(COALESCE(aliases, Array[NULL]::varchar[])) AS alias, updated_at\s
-                 FROM jobs_view WHERE symlink_target_uuid IS NULL
-                 ORDER BY updated_at DESC) AS j
-         WHERE  j.name ilike '%' || :query || '%'
-         OR j.alias ilike '%' || :query || '%'
-      ) AS results
-      WHERE type = :filter OR CAST(:filter AS TEXT) IS NULL
-      ORDER BY :sort
-      LIMIT :limit""")
-  List<SearchResult> search(String query, SearchFilter filter, SearchSort sort, int limit);
+          SELECT type, name, updated_at, namespace_name
+                FROM (
+                  SELECT 'DATASET' AS type, d.name, d.updated_at, d.namespace_name
+                    FROM datasets_view AS d
+                   WHERE (d.namespace_name = :namespace OR CAST(:namespace AS TEXT) IS NULL)
+                     AND (d.updated_at < :before OR CAST(:before AS TEXT) IS NULL)
+                     AND (d.updated_at > :after OR CAST(:after AS TEXT) IS NULL)
+                     AND (d.name ILIKE '%' || :query || '%')
+                   UNION
+                  SELECT DISTINCT ON (j.namespace_name, j.name)
+                    'JOB' AS type, j.name, j.updated_at, j.namespace_name
+                    FROM (SELECT namespace_name, name, UNNEST(COALESCE(aliases, Array[NULL]::varchar[])) AS alias, updated_at
+                           FROM jobs_view WHERE symlink_target_uuid IS NULL
+                           ORDER BY updated_at DESC) AS j
+                   WHERE (j.namespace_name = :namespace OR CAST(:namespace AS TEXT) IS NULL)
+                     AND (j.updated_at < :before OR CAST(:before AS TEXT) IS NULL)
+                     AND (j.updated_at > :after OR CAST(:after AS TEXT) IS NULL)
+                     AND (j.name ILIKE '%' || :query || '%' OR j.alias ILIKE '%' || :query || '%')
+                ) AS results
+                  WHERE type = :filter OR CAST(:filter AS TEXT) IS NULL
+                  ORDER BY :sort
+                  LIMIT :limit""")
+  List<SearchResult> search(
+      String query,
+      SearchFilter filter,
+      SearchSort sort,
+      int limit,
+      @Nullable String namespace,
+      @Nullable Instant before,
+      @Nullable Instant after);
 }


### PR DESCRIPTION
### Problem

As of 0.37.0, Marquez Search API does not support filtering search results by namespace or date.

Relates to #2550 

### Solution

This PR is a follow-up to #2553, consisting of the Dao change necessary to support:
* `namespace` - match jobs or datasets within the given namespace.
* `before` - match jobs or datasets before YYYY-MM-DD.
* `after` - match jobs or datasets after YYYY-MM-DD.

The API change itself is part of a separate PR to come.

### Checklist

- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained