### PR TITLE
add ARIA labels to input fields

### DIFF
--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -103,7 +103,7 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = props => {
           <Box mb={1}>
             <MqText subheading>{i18next.t('dataset_info.facets_subhead')}</MqText>
           </Box>
-          <MqJsonView data={facets} searchable={true} placeholder='Search' />
+          <MqJsonView data={facets} searchable={true} aria-label={i18next.t('dataset_info.facets_subhead_aria')} aria-required='True' placeholder='Search' />
         </Box>
       )}
       {run && (

--- a/web/src/components/jobs/RunInfo.tsx
+++ b/web/src/components/jobs/RunInfo.tsx
@@ -64,7 +64,13 @@ const RunInfo: FunctionComponent<RunInfoProps> = props => {
           <Box mb={1}>
             <MqText subheading>{i18next.t('jobs.runinfo_subhead')}</MqText>
           </Box>
-          <MqJsonView data={run.facets} searchable={true} placeholder='Search' />
+          <MqJsonView 
+            data={run.facets} 
+            searchable={true} 
+            aria-label={i18next.t('jobs.facets_subhead_aria')} 
+            aria-required='true' 
+            placeholder='Search' 
+          />
         </Box>
       )}
     </Box>

--- a/web/src/components/search/SearchPlaceholder.tsx
+++ b/web/src/components/search/SearchPlaceholder.tsx
@@ -30,18 +30,17 @@ const SearchPlaceholder: React.FC<WithStyles<typeof styles>> = ({ classes }) => 
   return (
     <Box className={classes.root}>
       <Box display={'inline'}>
-        <MqText disabled inline aria-label={i18next.t('search.search_aria')} aria-required='true'>
-          {' '}
+        <MqText disabled inline font={'mono'} aria-label={i18next.t('search.search_aria')} aria-required='true'>
           {i18next.t('search.search')}
-        </MqText>{' '}
+        </MqText>
         <MqText bold inline font={'mono'} color={theme.palette.common.white}>
           {' '}
           {i18next.t('search.jobs')}
-        </MqText>{' '}
-        <MqText disabled inline>
+        </MqText>
+        <MqText disabled inline font={'mono'}>
           {' '}
           {i18next.t('search.and')}
-        </MqText>{' '}
+        </MqText>
         <MqText bold inline font={'mono'} color={theme.palette.common.white}>
           {' '}
           {i18next.t('search.datasets')}

--- a/web/src/components/search/SearchPlaceholder.tsx
+++ b/web/src/components/search/SearchPlaceholder.tsx
@@ -30,7 +30,7 @@ const SearchPlaceholder: React.FC<WithStyles<typeof styles>> = ({ classes }) => 
   return (
     <Box className={classes.root}>
       <Box display={'inline'}>
-        <MqText disabled inline>
+        <MqText disabled inline aria-label={i18next.t('search.search_aria')} aria-required='true'>
           {' '}
           {i18next.t('search.search')}
         </MqText>{' '}

--- a/web/src/i18n/config.ts
+++ b/web/src/i18n/config.ts
@@ -32,12 +32,14 @@ i18next
             empty_title: 'No Run Information Available',
             empty_body: 'Try adding some runs for this job.',
             runinfo_subhead: 'FACETS',
+            facets_subhead_aria: 'Search',
             runs_subhead: 'FACETS',
             dialog_delete: 'DELETE',
             dialog_confirmation_title: 'Are you sure?'
           },
           search: {
             search: 'Search',
+            search_aria: 'Search jobs and datasets',
             jobs: 'Jobs',
             and: 'and',
             datasets: 'Datasets'
@@ -59,6 +61,7 @@ i18next
             empty_title: 'No Fields',
             empty_body: 'Try adding dataset fields.',
             facets_subhead: 'FACETS',
+            facets_subhead_aria: 'Search',
             run_subhead: 'Created by Run',
             duration: 'Duration'
           },
@@ -144,11 +147,13 @@ i18next
             empty_body: "Essayez d'ajouter quelques exécutions pour ce travail.",
             runinfo_subhead: 'FACETTES',
             runs_subhead: 'FACETTES',
+            facets_subhead_aria: 'Recherche',
             dialog_delete: 'EFFACER',
             dialog_confirmation_title: 'Êtes-vous sûr?'
           },
           search: {
             search: 'Recherche',
+            search_aria: 'Recherchez des emplois et des ensembles de données',
             jobs: "d'Emplois",
             and: 'et',
             datasets: 'Jeux de Données'
@@ -170,6 +175,7 @@ i18next
             empty_title: 'Aucun jeu de données trouvé',
             empty_body: "Essayez d'ajouter des champs de jeu de données.",
             facets_subhead: 'FACETTES',
+            facets_subhead_aria: 'Recherche',
             run_subhead: 'Créé par Run',
             duration: 'Durée'
           },
@@ -258,11 +264,13 @@ i18next
             empty_body: 'Intente agregar algunas ejecuciones para este trabajo.',
             runinfo_subhead: 'FACETAS',
             runs_subhead: 'FACETAS',
+            facets_subhead_aria: 'Buscar',
             dialog_delete: 'ELIMINAR',
             dialog_confirmation_title: 'Estás seguro?'
           },
           search: {
             search: 'Buscar',
+            search_aria: 'Buscar trabajos y conjuntos de datos',
             jobs: 'Trabajos',
             and: 'y',
             datasets: 'Conjuntos de Datos'
@@ -284,6 +292,7 @@ i18next
             empty_title: 'No se encontraron conjuntos de datos',
             empty_body: 'Intente agregar campos de conjuntos de datos.',
             facets_subhead: 'FACETAS',
+            facets_subhead_aria: 'Buscar',
             run_subhead: 'Creado por Ejecutar',
             duration: 'Duración'
           },
@@ -372,11 +381,13 @@ i18next
             empty_body: 'Spróbuj dodać kilka przebiegów dla tego zadania.',
             runinfo_subhead: 'ASPECTY',
             runs_subhead: 'ASPECTY',
+            facets_subhead_aria: 'Wyszukiwanie',
             dialog_delete: 'USUNĄĆ',
             dialog_confirmation_title: 'Jesteś pewny?'
           },
           search: {
             search: 'Wyszukiwanie',
+            search_aria: 'Wyszukiwanie zadań i zbiorów danych',
             jobs: 'Zadania',
             and: 'i',
             datasets: 'Zbiory Danych'
@@ -398,6 +409,7 @@ i18next
             empty_title: 'Nie znaleziono zbiorów danych',
             empty_body: 'Spróbuj dodać pola zbiory danych.',
             facets_subhead: 'ASPECTY',
+            facets_subhead_aria: 'Wyszukiwanie',
             run_subhead: 'Stworzony przez Run',
             duration: 'Czas trwania'
           },


### PR DESCRIPTION
### Problem

Input fields in the Web UI are missing ARIA labels, which the OSSF Silver Badge requires to meet a11y standards.

### Solution

This adds ARIA properties to the Web UI's `input` and `text` components used for user input and configures i18next to support the text in them. All have been tested with a screen reader and found to work as expected.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary: adds i18next-compliant ARIA labels to input fields

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)