### PR TITLE
UI: expand the node name on hover and focus

### DIFF
--- a/web/src/components/lineage/components/node/Node.tsx
+++ b/web/src/components/lineage/components/node/Node.tsx
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 import * as Redux from 'redux'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -33,90 +33,102 @@ interface OwnProps {
 
 type NodeProps = DispatchProps & OwnProps
 
-class Node extends React.Component<NodeProps> {
-  determineLink = (node: GraphNode<MqNode>) => {
-    if (isJob(node)) {
-      return `/lineage/${encodeNode('JOB', node.data.namespace, node.data.name)}`
-    } else if (isDataset(node)) {
-      return `/lineage/${encodeNode('DATASET', node.data.namespace, node.data.name)}`
-    }
-    return '/'
+const determineLink = (node: GraphNode<MqNode>) => {
+  if (isJob(node)) {
+    return `/lineage/${encodeNode('JOB', node.data.namespace, node.data.name)}`
+  } else if (isDataset(node)) {
+    return `/lineage/${encodeNode('DATASET', node.data.namespace, node.data.name)}`
+  }
+  return '/'
+}
+
+const Node: React.FC<NodeProps> = ({ node, selectedNode, setSelectedNode }) => {
+  const job = isJob(node)
+  const isSelected = selectedNode === node.label
+  const ariaJobLabel = 'Job'
+  const ariaDatasetLabel = 'Dataset'
+  let showFullNodeLabelTimeout = 0
+
+  const [showFullNodeLabel, setShowFullNodeLabel] = useState(false)
+
+  useEffect(() => clearTimeout(showFullNodeLabelTimeout), [])
+
+  const delayedSetShowFullNodeLabel = (delayMs = 1500) => {
+    showFullNodeLabelTimeout = window.setTimeout(() => {
+      setShowFullNodeLabel(true)
+    }, delayMs)
   }
 
-  render() {
-    const { node, selectedNode } = this.props
-    const job = isJob(node)
-    const isSelected = selectedNode === node.label
-    const ariaJobLabel = 'Job'
-    const ariaDatasetLabel = 'Dataset'
-    return (
-      <Link
-        to={this.determineLink(node)}
-        onClick={() => node.label && this.props.setSelectedNode(node.label)}
-      >
-        {job ? (
-          <g>
-            {/* { console.log(job.latestRun)} */}
-            {/* {console.log(runStateToNodeColor(job.latestRun))} */}
-            <circle
-              style={{ cursor: 'pointer' }}
-              r={RADIUS}
-              fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
-              stroke={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
-              strokeWidth={BORDER / 2}
-              cx={node.x}
-              cy={node.y}
-            />
-            <FontAwesomeIcon
-              title={ariaJobLabel}
-              aria-hidden={'true'}
-              style={{ transformOrigin: `${node.x}px ${node.y}px` }}
-              icon={faCog}
-              width={ICON_SIZE}
-              height={ICON_SIZE}
-              x={node.x - ICON_SIZE / 2}
-              y={node.y - ICON_SIZE / 2}
-              color={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
-            />
-          </g>
-        ) : (
-          <g>
-            <rect
-              style={{ cursor: 'pointer' }}
-              x={node.x - RADIUS}
-              y={node.y - RADIUS}
-              fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
-              stroke={isSelected ? theme.palette.primary.main: theme.palette.secondary.main}
-              strokeWidth={BORDER / 2}
-              width={RADIUS * 2}
-              height={RADIUS * 2}
-              rx={4}
-            />
-            <rect
-              style={{ cursor: 'pointer' }}
-              x={node.x - (RADIUS - 2)}
-              y={node.y - (RADIUS - 2)}
-              fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
-              width={(RADIUS - 2) * 2}
-              height={(RADIUS - 2) * 2}
-              rx={4}
-            />
-            <FontAwesomeIcon
-              title={ariaDatasetLabel}
-              aria-hidden={'true'}
-              icon={faDatabase}
-              width={ICON_SIZE}
-              height={ICON_SIZE}
-              x={node.x - ICON_SIZE / 2}
-              y={node.y - ICON_SIZE / 2}
-              color={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
-            />
-          </g>
-        )}
-        <NodeText node={node} />
-      </Link>
-    )
-  }
+  return (
+    <Link
+      to={determineLink(node)}
+      onClick={() => node.label && setSelectedNode(node.label)}
+      onMouseEnter={() => delayedSetShowFullNodeLabel()}
+      onMouseLeave={() => setShowFullNodeLabel(false)}
+      onFocus={() => delayedSetShowFullNodeLabel()}
+    >
+      {job ? (
+        <g>
+          {/* {console.log(job.latestRun)} */}
+          {/* {console.log(runStateToNodeColor(job.latestRun))} */}
+          <circle
+            style={{ cursor: 'pointer' }}
+            r={RADIUS}
+            fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
+            stroke={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
+            strokeWidth={BORDER / 2}
+            cx={node.x}
+            cy={node.y}
+          />
+          <FontAwesomeIcon
+            title={ariaJobLabel}
+            aria-hidden={'true'}
+            style={{ transformOrigin: `${node.x}px ${node.y}px` }}
+            icon={faCog}
+            width={ICON_SIZE}
+            height={ICON_SIZE}
+            x={node.x - ICON_SIZE / 2}
+            y={node.y - ICON_SIZE / 2}
+            color={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
+          />
+        </g>
+      ) : (
+        <g>
+          <rect
+            style={{ cursor: 'pointer' }}
+            x={node.x - RADIUS}
+            y={node.y - RADIUS}
+            fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
+            stroke={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
+            strokeWidth={BORDER / 2}
+            width={RADIUS * 2}
+            height={RADIUS * 2}
+            rx={4}
+          />
+          <rect
+            style={{ cursor: 'pointer' }}
+            x={node.x - (RADIUS - 2)}
+            y={node.y - (RADIUS - 2)}
+            fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
+            width={(RADIUS - 2) * 2}
+            height={(RADIUS - 2) * 2}
+            rx={4}
+          />
+          <FontAwesomeIcon
+            title={ariaDatasetLabel}
+            aria-hidden={'true'}
+            icon={faDatabase}
+            width={ICON_SIZE}
+            height={ICON_SIZE}
+            x={node.x - ICON_SIZE / 2}
+            y={node.y - ICON_SIZE / 2}
+            color={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
+          />
+        </g>
+      )}
+      <NodeText node={node} showFullNodeLabel={showFullNodeLabel} />
+    </Link>
+  )
 }
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch) =>

--- a/web/src/components/lineage/components/node/Node.tsx
+++ b/web/src/components/lineage/components/node/Node.tsx
@@ -69,8 +69,8 @@ const Node: React.FC<NodeProps> = ({ node, selectedNode, setSelectedNode }) => {
       to={determineLink(node)}
       onClick={() => node.label && setSelectedNode(node.label)}
       onMouseEnter={() => delayedSetShowFullNodeLabel()}
-      onMouseLeave={() => handleMouseLeave()}
       onFocus={() => delayedSetShowFullNodeLabel()}
+      onMouseLeave={() => handleMouseLeave()}
       onBlur={() => handleMouseLeave()}
     >
       {job ? (

--- a/web/src/components/lineage/components/node/Node.tsx
+++ b/web/src/components/lineage/components/node/Node.tsx
@@ -53,10 +53,15 @@ const Node: React.FC<NodeProps> = ({ node, selectedNode, setSelectedNode }) => {
 
   useEffect(() => clearTimeout(showFullNodeLabelTimeout), [])
 
-  const delayedSetShowFullNodeLabel = (delayMs = 1500) => {
+  const delayedSetShowFullNodeLabel = (delayMs = 400) => {
     showFullNodeLabelTimeout = window.setTimeout(() => {
       setShowFullNodeLabel(true)
     }, delayMs)
+  }
+
+  const handleMouseLeave = () => {
+    setShowFullNodeLabel(false)
+    clearTimeout(showFullNodeLabelTimeout)
   }
 
   return (
@@ -64,8 +69,9 @@ const Node: React.FC<NodeProps> = ({ node, selectedNode, setSelectedNode }) => {
       to={determineLink(node)}
       onClick={() => node.label && setSelectedNode(node.label)}
       onMouseEnter={() => delayedSetShowFullNodeLabel()}
-      onMouseLeave={() => setShowFullNodeLabel(false)}
+      onMouseLeave={() => handleMouseLeave()}
       onFocus={() => delayedSetShowFullNodeLabel()}
+      onBlur={() => handleMouseLeave()}
     >
       {job ? (
         <g>

--- a/web/src/components/lineage/components/node/NodeText.tsx
+++ b/web/src/components/lineage/components/node/NodeText.tsx
@@ -8,13 +8,14 @@ import React from 'react'
 
 type NodeTextProps = {
   node: GraphNode<MqNode>
+  showFullNodeLabel: boolean
 }
 
 const TEXT_BOTTOM_SPACING = theme.spacing(3)
 const MAX_CHARACTERS = 20
 const LEADING_AND_TRAILING_CHARACTERS = 10
 
-export function NodeText({ node }: NodeTextProps) {
+export function NodeText({ node, showFullNodeLabel }: NodeTextProps) {
   return (
     <text
       x={node.x}
@@ -23,7 +24,7 @@ export function NodeText({ node }: NodeTextProps) {
       textAnchor='middle'
       fill={'white'}
     >
-      {node.data.name.length > MAX_CHARACTERS
+      {node.data.name.length > MAX_CHARACTERS && !showFullNodeLabel
         ? `${node.data.name.substring(
             0,
             LEADING_AND_TRAILING_CHARACTERS


### PR DESCRIPTION
### Problem

Currently the only way to see the full label of the node is to select it as the main node. Which can be especially annoying when using the new graph depth / full graph toggle config options. 

Closes: n/a

### Solution

This PR adds a mouse-enter and focus listener to the node and expands the node name when hovered or focused

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary: Expands the node labels in the UI on hover/focus

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)