### PR TITLE
Fixing the stylesheet for the date selector

### DIFF
--- a/web/src/components/core/date-picker/MqDatePicker.tsx
+++ b/web/src/components/core/date-picker/MqDatePicker.tsx
@@ -28,9 +28,8 @@ const MqDatePicker: React.FC<DatePickerProps> = ({
     <DateTimePicker
       label={label}
       sx={{
-        minWidth: '200px',
-        '.MuiFormLabel-root': {
-          transform: 'translate(14px, 0px) scale(0.75)',
+        label: {
+          left: theme.spacing(2),
         },
         '&:hover': {
           '.MuiOutlinedInput-notchedOutline': {
@@ -42,10 +41,9 @@ const MqDatePicker: React.FC<DatePickerProps> = ({
         '.MuiOutlinedInput-notchedOutline': {
           border: `2px solid ${theme.palette.common.white}`,
           borderRadius: theme.spacing(4),
-          top: '-16px',
-          left: '-6px',
           '> legend': {
-            display: 'none',
+            marginLeft: theme.spacing(2),
+            left: theme.spacing(2),
           },
         },
       }}


### PR DESCRIPTION
### Problem

The date selector got slightly out of proportion after the migration to the new version of Material. This fixes some of the margins and moves the label to be more inline with what the defaults are.

One-line summary:

The date selector now looks like:

![image](https://github.com/MarquezProject/marquez/assets/7514204/cc721237-ee6b-40b2-aa6e-1c68dfc5518b)


### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)