### PR TITLE
fix: correct example syntax for java client readme

### DIFF
--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -25,7 +25,7 @@ implementation 'io.github.marquezproject:marquez-java:0.39.0
 ### Reading Metadata
 ```java
 // Connect to http://localhost:5000
-MarquezClient client = MarquezClient().builder()
+MarquezClient client = MarquezClient.builder()
   .baseUrl("http://localhost:5000")
   .build()
 


### PR DESCRIPTION
### Problem

Errant parens in the example code makes it invalid - `builder` is a static method.

### Solution

Remove the parens so the example is correct and matches the later one in the file.

One-line summary:  
Correct example syntax for Java client README

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)