### PR TITLE
Added Copy Button for Lineage ID

### DIFF
--- a/web/src/components/core/copy/MqCopy.tsx
+++ b/web/src/components/core/copy/MqCopy.tsx
@@ -1,0 +1,49 @@
+// Copyright 2018-2023 contributors to the Marquez project
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import IconButton from '@mui/material/IconButton'
+import { Tooltip, Snackbar } from '@mui/material'
+
+interface MqCopyProps {
+    string: string
+}
+
+const MqEmpty: React.FC<MqCopyProps> = ({ string }) => {
+    const [open, setOpen] = React.useState(false)
+    const handleClose = (event: React.SyntheticEvent | Event, reason?: string) => {
+        if (reason === 'clickaway') {
+            return
+        }
+
+        setOpen(false)
+    }
+    return (
+        <>
+            <Tooltip title='Copy'>
+                <IconButton
+                    onClick={(event) => {
+                        event.stopPropagation()
+                        navigator.clipboard.writeText(string)
+                        setOpen(true)
+                    }}
+                    aria-label='copy'
+                    size={'small'}
+                    color={'primary'}
+                >
+                    <ContentCopyIcon fontSize={'small'} />
+                </IconButton>
+            </Tooltip>
+            <Snackbar
+                open={open}
+                autoHideDuration={2000}
+                onClose={handleClose}
+                message={`Copied ${string}`}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+            />
+        </>
+    )
+}
+
+export default MqEmpty

--- a/web/src/components/core/copy/MqCopy.tsx
+++ b/web/src/components/core/copy/MqCopy.tsx
@@ -1,49 +1,49 @@
 // Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react'
+import { Snackbar, Tooltip } from '@mui/material'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import IconButton from '@mui/material/IconButton'
-import { Tooltip, Snackbar } from '@mui/material'
+import React from 'react'
 
 interface MqCopyProps {
-    string: string
+  string: string
 }
 
 const MqEmpty: React.FC<MqCopyProps> = ({ string }) => {
-    const [open, setOpen] = React.useState(false)
-    const handleClose = (event: React.SyntheticEvent | Event, reason?: string) => {
-        if (reason === 'clickaway') {
-            return
-        }
-
-        setOpen(false)
+  const [open, setOpen] = React.useState(false)
+  const handleClose = (event: React.SyntheticEvent | Event, reason?: string) => {
+    if (reason === 'clickaway') {
+      return
     }
-    return (
-        <>
-            <Tooltip title='Copy'>
-                <IconButton
-                    onClick={(event) => {
-                        event.stopPropagation()
-                        navigator.clipboard.writeText(string)
-                        setOpen(true)
-                    }}
-                    aria-label='copy'
-                    size={'small'}
-                    color={'primary'}
-                >
-                    <ContentCopyIcon fontSize={'small'} />
-                </IconButton>
-            </Tooltip>
-            <Snackbar
-                open={open}
-                autoHideDuration={2000}
-                onClose={handleClose}
-                message={`Copied ${string}`}
-                anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-            />
-        </>
-    )
+
+    setOpen(false)
+  }
+  return (
+    <>
+      <Tooltip title='Copy'>
+        <IconButton
+          onClick={(event) => {
+            event.stopPropagation()
+            navigator.clipboard.writeText(string)
+            setOpen(true)
+          }}
+          aria-label='copy'
+          size={'small'}
+          color={'primary'}
+        >
+          <ContentCopyIcon fontSize={'small'} />
+        </IconButton>
+      </Tooltip>
+      <Snackbar
+        open={open}
+        autoHideDuration={2000}
+        onClose={handleClose}
+        message={`Copied ${string}`}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      />
+    </>
+  )
 }
 
 export default MqEmpty

--- a/web/src/routes/events/Events.tsx
+++ b/web/src/routes/events/Events.tsx
@@ -37,6 +37,7 @@ import MqStatus from '../../components/core/status/MqStatus'
 import MqText from '../../components/core/text/MqText'
 import React, { useEffect, useRef } from 'react'
 import moment from 'moment'
+import MqCopy from '../../components/core/copy/MqCopy'
 
 interface StateProps {
   events: Event[]
@@ -248,7 +249,10 @@ const Events: React.FC<EventsProps> = ({
                           }}
                         >
                           <TableCell align='left'>
-                            <MqText font={'mono'}>{event.run.runId}</MqText>
+                            <Box display={"flex"} alignItems={"center"}>
+                              <MqText font={'mono'}>{event.run.runId}</MqText>
+                              <MqCopy string={event.run.runId}/>
+                            </Box>
                           </TableCell>
                           <TableCell align='left'>
                             <MqStatus


### PR DESCRIPTION
### Problem
This PR adds a copy button to the ID's on the Events page.

<img width="1480" alt="Screenshot 2023-08-10 at 4 08 09 PM" src="https://github.com/MarquezProject/marquez/assets/70288484/94bab5dd-aea8-4425-a439-03614096bce8">

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
