### PR TITLE
Chart: Dont use hardcoed postgres image for initcontainer

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -46,6 +46,15 @@ Return the proper Marquez web image name
 {{- end -}}
 
 {{/*
+Return the proper Postgresql image name for the wait-for-db initContainer
+*/}}
+{{- define "marquez.wait-for-db.image" -}}
+{{- if .Values.postgresql.enabled -}}
+  {{- include "common.images.image" (dict "imageRoot" .Values.postgresql.image "global" .Values.global) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Get the secret name
 */}}
 {{- define "marquez.secretName" -}}

--- a/chart/templates/marquez/deployment.yaml
+++ b/chart/templates/marquez/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       # This init container is for avoiding CrashLoopback errors in the Marquez container because the PostgreSQL container is not ready
       initContainers:
         - name: wait-for-db
-          image: postgres:12.1
+          image: {{ include "marquez.wait-for-db.image" . }}
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash


### PR DESCRIPTION
### Problem

The marquez deployment has a Postgresql wait-for-db init container with a hardcoded image. Due to this the `global.imageRegistry` value is not used for the "wait-for-db" init container. This creates problems for users that has to use private registries.

Closes: #ISSUE-NUMBER

### Solution

I have added a template in `chart/templates/helpers.tpl` for the postgres image that returns the value from the postgres chart, or the `global.imageRegistry` input value . The template is then included in the`chart/templates/marquez/deployment.yaml` "wait-for-db" initContainer.

One-line summary:

Use the same postgresql image value for postgres and "wait-for-db" initcontainer.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
