### PR TITLE
Feature/add node tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased](https://github.com/MarquezProject/marquez/compare/0.39.0...HEAD)
+* Web: add node tooltip [`#2580`](https://github.com/MarquezProject/marquez/pull/2584) [@davidsharp7](https://github.com/davidsharp7)  
 
 ## [0.39.0](https://github.com/MarquezProject/marquez/compare/0.38.0...0.39.0) - 2023-08-08
 ### Added

--- a/web/src/components/lineage/components/node/Node.tsx
+++ b/web/src/components/lineage/components/node/Node.tsx
@@ -10,13 +10,16 @@ import { Link } from 'react-router-dom'
 import { MqNode } from '../../types'
 import { NodeText } from './NodeText'
 import { bindActionCreators } from 'redux'
-
 import { connect } from 'react-redux'
+
 import { encodeNode, isDataset, isJob } from '../../../../helpers/nodes'
 import { faCog } from '@fortawesome/free-solid-svg-icons/faCog'
 import { faDatabase } from '@fortawesome/free-solid-svg-icons/faDatabase'
 import { setSelectedNode } from '../../../../store/actionCreators'
+import { styled } from '@mui/material/styles'
 import { theme } from '../../../../helpers/theme'
+import Tooltip, { TooltipProps, tooltipClasses } from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
 
 const RADIUS = 14
 const ICON_SIZE = 16
@@ -43,25 +46,49 @@ const Node: React.FC<NodeProps> = ({ node, selectedNode, setSelectedNode }) => {
     return '/'
   }
 
+  // configure the tool tip
+  const HtmlTooltip = styled(({ className, ...props }: TooltipProps) => (
+    <Tooltip {...props} classes={{ popper: className }} />
+  ))(({ theme }) => ({
+    [`& .${tooltipClasses.tooltip}`]: {
+      backgroundColor: theme.palette.background.default,
+      color: theme.palette.common.white,
+      maxWidth: 400,
+      fontSize: theme.typography.pxToRem(14),
+      border: '1px solid ' + theme.palette.common.white,
+    },
+  }))
+
+  // return the object namespace/name
+  const addToToolTip = (inputString: string) => {
+    return <React.Fragment>
+      <Typography color="inherit">{inputString.split(':')[0]}</Typography>
+      <b>{"Namespace: "}</b>{inputString.split(':')[1]}<br></br>
+      <b>{"Object Name: "}</b>{inputString.split(':')[2]}<br></br>
+      </React.Fragment>
+  }
+
   const job = isJob(node)
   const isSelected = selectedNode === node.label
-  const ariaJobLabel = 'Job'
-  const ariaDatasetLabel = 'Dataset'
+  // convert the node label to  string
+  const nodeLabelToString = String(node.label)
+
   return (
     <Link to={determineLink(node)} onClick={() => node.label && setSelectedNode(node.label)}>
       {job ? (
         <g>
-          <circle
-            style={{ cursor: 'pointer' }}
-            r={RADIUS}
-            fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
-            stroke={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
-            strokeWidth={BORDER / 2}
-            cx={node.x}
-            cy={node.y}
-          />
+          <HtmlTooltip title={addToToolTip(nodeLabelToString)}>
+            <circle
+              style={{ cursor: 'pointer' }}
+              r={RADIUS}
+              fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
+              stroke={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
+              strokeWidth={BORDER / 2}
+              cx={node.x}
+              cy={node.y}
+            />
+          </HtmlTooltip>
           <FontAwesomeIcon
-            title={ariaJobLabel}
             aria-hidden={'true'}
             style={{ transformOrigin: `${node.x}px ${node.y}px` }}
             icon={faCog}
@@ -74,28 +101,31 @@ const Node: React.FC<NodeProps> = ({ node, selectedNode, setSelectedNode }) => {
         </g>
       ) : (
         <g>
-          <rect
-            style={{ cursor: 'pointer' }}
-            x={node.x - RADIUS}
-            y={node.y - RADIUS}
-            fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
-            stroke={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
-            strokeWidth={BORDER / 2}
-            width={RADIUS * 2}
-            height={RADIUS * 2}
-            rx={4}
-          />
-          <rect
-            style={{ cursor: 'pointer' }}
-            x={node.x - (RADIUS - 2)}
-            y={node.y - (RADIUS - 2)}
-            fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
-            width={(RADIUS - 2) * 2}
-            height={(RADIUS - 2) * 2}
-            rx={4}
-          />
+          <HtmlTooltip title={addToToolTip(nodeLabelToString)}>
+            <rect
+              style={{ cursor: 'pointer' }}
+              x={node.x - RADIUS}
+              y={node.y - RADIUS}
+              fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
+              stroke={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
+              strokeWidth={BORDER / 2}
+              width={RADIUS * 2}
+              height={RADIUS * 2}
+              rx={4}
+            />
+          </HtmlTooltip>
+          <HtmlTooltip title={addToToolTip(nodeLabelToString)}>
+            <rect
+              style={{ cursor: 'pointer' }}
+              x={node.x - (RADIUS - 2)}
+              y={node.y - (RADIUS - 2)}
+              fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
+              width={(RADIUS - 2) * 2}
+              height={(RADIUS - 2) * 2}
+              rx={4}
+            />
+          </HtmlTooltip>
           <FontAwesomeIcon
-            title={ariaDatasetLabel}
             aria-hidden={'true'}
             icon={faDatabase}
             width={ICON_SIZE}


### PR DESCRIPTION
### Problem

Currently the Marquez UI compresses dataset/job name under each node if they are over x characters which leads to a sub optimal user experience when browsing nodes on a graph. The current tool tip just displays if the object is a job/dataset and so is not massively helpful.

Closes: #2580

### Solution

Add an HTML tool tip which on hover over displays details about the node. Initially I would like to just update

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [x] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
