### PR TITLE
Add `publish-snapshot` CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,15 @@ jobs:
       - run: ./.circleci/get-docker-compose.sh
       - run: ./.circleci/db-migration.sh
 
+  publish-snapshot:
+    working_directory: ~/marquez
+    machine:
+      image: ubuntu-2004:current
+    steps:
+      - checkout
+      - run: ./.circleci/get-jdk17.sh
+      - run: ./.circleci/publish.sh # *SNAPSHOT.jar
+
   release-java:
     working_directory: ~/marquez
     machine:
@@ -179,11 +188,7 @@ jobs:
     steps:
       - checkout
       - run: ./.circleci/get-jdk17.sh
-      - run: |
-          # Get, then decode the GPG private key used to sign *.jar
-          export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
-          # Publish *.jar
-          ./gradlew publish
+      - run: ./.circleci/publish.sh # *.jar
 
   release-python:
     working_directory: ~/marquez
@@ -225,6 +230,16 @@ workflows:
       - migrate-db:
           requires:
             - build-api
+      - publish-snapshot:
+          filters:
+            branches:
+              only: main
+          context: release
+          requires:
+            - build-image-api
+            - load-test-api
+            - migrate-db
+
   release:
     jobs:
       - build-client-python:

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -126,7 +126,9 @@ publishing {
 
     repositories {
         maven {
-            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
+            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             credentials {
                 username = System.getenv('SONATYPE_NEXUS_USERNAME')
                 password = System.getenv('SONATYPE_NEXUS_PASSWORD')

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ subprojects {
         assertjVersion = '3.24.2'
         dropwizardVersion = '2.1.7'
         jacocoVersion = '0.8.10'
-        junit5Version = '5.9.3'
+        junit5Version = '5.10.0'
         lombokVersion = '1.18.28'
         mockitoVersion = '5.4.0'
         openlineageVersion = '0.26.0'


### PR DESCRIPTION
### Problem

It'd be useful to the community to publish a snapshot for `marquez-api`.

### Solution

One-line summary: Adds `publish-snapshot` CI job to publish a snapshot for `marquez-api`.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
