### PR TITLE
tolerate null transformation attrs in ColumnLineageInputField

### DIFF
--- a/api/src/main/java/marquez/service/models/ColumnLineageInputField.java
+++ b/api/src/main/java/marquez/service/models/ColumnLineageInputField.java
@@ -19,6 +19,6 @@ public class ColumnLineageInputField {
   @NotNull private String namespace;
   @NotNull private String dataset;
   @NotNull private String field;
-  @NotNull private String transformationDescription;
-  @NotNull private String transformationType;
+  private String transformationDescription;
+  private String transformationType;
 }

--- a/clients/java/src/main/java/marquez/client/models/ColumnLineageInputField.java
+++ b/clients/java/src/main/java/marquez/client/models/ColumnLineageInputField.java
@@ -19,6 +19,6 @@ public class ColumnLineageInputField {
   @NonNull private String namespace;
   @NonNull private String dataset;
   @NonNull private String field;
-  @NonNull String transformationDescription;
-  @NonNull String transformationType;
+  private String transformationDescription;
+  private String transformationType;
 }

--- a/clients/java/src/test/java/marquez/client/models/ColumnLineageInputFieldTest.java
+++ b/clients/java/src/test/java/marquez/client/models/ColumnLineageInputFieldTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.client.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+@org.junit.jupiter.api.Tag("UnitTests")
+public class ColumnLineageInputFieldTest {
+  @Test
+  void testToleratesNullTransformationTypeAndDescription() {
+    ColumnLineageInputField field = new ColumnLineageInputField("ns", "ds", "field", null, null);
+
+    assertEquals("ns", field.getNamespace());
+    assertEquals("ds", field.getDataset());
+    assertEquals("field", field.getField());
+    assertNull(field.getTransformationDescription());
+    assertNull(field.getTransformationType());
+  }
+}


### PR DESCRIPTION
### Problem

The `transformationType` and `transformationDescription` attributes for column-level lineage are optional at the database level and can be safely omitted when pushing in lineage events.

However, because they're marked as non-nullable in the Java client's representation, an exception is thrown when deserialising a response from the column lineage endpoint (thanks to Lombok-generated `Objects.requireNonNull` in the constructor).

### Solution

Remove the `@NonNull` annotation from the client class and the `@NotNull` from the model class. Add a test that would fail without this change. Validated by running the stack locally.

One-line summary:  
tolerate null transformation attrs in field model

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [x] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
