### PR TITLE
ui:add HTML Tool Tip

### DIFF
--- a/web/src/components/core/tooltip/MQTooltip.tsx
+++ b/web/src/components/core/tooltip/MQTooltip.tsx
@@ -1,0 +1,29 @@
+// Copyright 2018-2023 contributors to the Marquez project
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react'
+import Tooltip from '@mui/material/Tooltip'
+import { createTheme } from '@mui/material/styles'
+import { useTheme } from '@emotion/react'
+
+interface MqToolTipProps {
+    title : string | ReactElement
+    children : ReactElement
+}
+
+//default style thing
+const MQTooltip: React.FC<MqToolTipProps> = ({ title, children }) => {
+    const theme = createTheme(useTheme())
+    return <Tooltip title={title}
+        componentsProps={{ tooltip: { sx:
+        {
+            backgroundColor: theme.palette.background.default,
+            color: theme.palette.common.white,
+            border: `1px solid ${theme.palette.common.white}`,
+            maxWidth: '600px',
+            fontSize: 14
+        }, } }}
+        >{children}</Tooltip>
+}
+
+export default MQTooltip

--- a/web/src/components/core/tooltip/MQTooltip.tsx
+++ b/web/src/components/core/tooltip/MQTooltip.tsx
@@ -1,29 +1,36 @@
 // Copyright 2018-2023 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { ReactElement } from 'react'
-import Tooltip from '@mui/material/Tooltip'
 import { createTheme } from '@mui/material/styles'
 import { useTheme } from '@emotion/react'
+import React, { ReactElement } from 'react'
+import Tooltip from '@mui/material/Tooltip'
 
 interface MqToolTipProps {
-    title : string | ReactElement
-    children : ReactElement
+  title: string | ReactElement
+  children: ReactElement
 }
 
-//default style thing
 const MQTooltip: React.FC<MqToolTipProps> = ({ title, children }) => {
-    const theme = createTheme(useTheme())
-    return <Tooltip title={title}
-        componentsProps={{ tooltip: { sx:
-        {
+  const theme = createTheme(useTheme())
+  return (
+    <Tooltip
+      title={title}
+      componentsProps={{
+        tooltip: {
+          sx: {
             backgroundColor: theme.palette.background.default,
             color: theme.palette.common.white,
             border: `1px solid ${theme.palette.common.white}`,
             maxWidth: '600px',
-            fontSize: 14
-        }, } }}
-        >{children}</Tooltip>
+            fontSize: 14,
+          },
+        },
+      }}
+    >
+      {children}
+    </Tooltip>
+  )
 }
 
 export default MQTooltip

--- a/web/src/components/lineage/components/node/Node.tsx
+++ b/web/src/components/lineage/components/node/Node.tsx
@@ -10,8 +10,8 @@ import { Link } from 'react-router-dom'
 import { MqNode } from '../../types'
 import { NodeText } from './NodeText'
 import { bindActionCreators } from 'redux'
-
 import { connect } from 'react-redux'
+import MQTooltip from '../../../core/tooltip/MQTooltip'
 import { encodeNode, isDataset, isJob } from '../../../../helpers/nodes'
 import { faCog } from '@fortawesome/free-solid-svg-icons/faCog'
 import { faDatabase } from '@fortawesome/free-solid-svg-icons/faDatabase'
@@ -43,26 +43,37 @@ const Node: React.FC<NodeProps> = ({ node, selectedNode, setSelectedNode }) => {
     return '/'
   }
 
+  const addToToolTip = (inputData: GraphNode<MqNode>) => {
+    // return react fragment
+    return <>
+      <b>{"Namespace: "}</b>{inputData.data.namespace}<br></br>
+      <b>{"Name: "}</b>{inputData.data.name}<br></br>
+      <b>{"Description: "}</b>{inputData.data.description === null ? "No Description" : inputData.data.description}<br></br>
+      </>
+  }
+
   const job = isJob(node)
   const isSelected = selectedNode === node.label
   const ariaJobLabel = 'Job'
   const ariaDatasetLabel = 'Dataset'
+
   return (
     <Link to={determineLink(node)} onClick={() => node.label && setSelectedNode(node.label)}>
+      <MQTooltip title={addToToolTip(node)}>
       {job ? (
         <g>
-          <circle
-            style={{ cursor: 'pointer' }}
-            r={RADIUS}
-            fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
-            stroke={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
-            strokeWidth={BORDER / 2}
-            cx={node.x}
-            cy={node.y}
-          />
+            <circle
+              style={{ cursor: 'pointer' }}
+              r={RADIUS}
+              fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
+              stroke={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
+              strokeWidth={BORDER / 2}
+              cx={node.x}
+              cy={node.y}
+            />
           <FontAwesomeIcon
-            title={ariaJobLabel}
             aria-hidden={'true'}
+            title={ariaJobLabel}
             style={{ transformOrigin: `${node.x}px ${node.y}px` }}
             icon={faCog}
             width={ICON_SIZE}
@@ -74,29 +85,29 @@ const Node: React.FC<NodeProps> = ({ node, selectedNode, setSelectedNode }) => {
         </g>
       ) : (
         <g>
-          <rect
-            style={{ cursor: 'pointer' }}
-            x={node.x - RADIUS}
-            y={node.y - RADIUS}
-            fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
-            stroke={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
-            strokeWidth={BORDER / 2}
-            width={RADIUS * 2}
-            height={RADIUS * 2}
-            rx={4}
-          />
-          <rect
-            style={{ cursor: 'pointer' }}
-            x={node.x - (RADIUS - 2)}
-            y={node.y - (RADIUS - 2)}
-            fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
-            width={(RADIUS - 2) * 2}
-            height={(RADIUS - 2) * 2}
-            rx={4}
-          />
+            <rect
+              style={{ cursor: 'pointer' }}
+              x={node.x - RADIUS}
+              y={node.y - RADIUS}
+              fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
+              stroke={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
+              strokeWidth={BORDER / 2}
+              width={RADIUS * 2}
+              height={RADIUS * 2}
+              rx={4}
+            />
+            <rect
+              style={{ cursor: 'pointer' }}
+              x={node.x - (RADIUS - 2)}
+              y={node.y - (RADIUS - 2)}
+              fill={isSelected ? theme.palette.secondary.main : theme.palette.common.white}
+              width={(RADIUS - 2) * 2}
+              height={(RADIUS - 2) * 2}
+              rx={4}
+            />
           <FontAwesomeIcon
-            title={ariaDatasetLabel}
             aria-hidden={'true'}
+            title={ariaDatasetLabel}
             icon={faDatabase}
             width={ICON_SIZE}
             height={ICON_SIZE}
@@ -106,6 +117,7 @@ const Node: React.FC<NodeProps> = ({ node, selectedNode, setSelectedNode }) => {
           />
         </g>
       )}
+       </MQTooltip>
       <NodeText node={node} />
     </Link>
   )

--- a/web/src/components/lineage/components/node/Node.tsx
+++ b/web/src/components/lineage/components/node/Node.tsx
@@ -11,12 +11,12 @@ import { MqNode } from '../../types'
 import { NodeText } from './NodeText'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
-import MQTooltip from '../../../core/tooltip/MQTooltip'
 import { encodeNode, isDataset, isJob } from '../../../../helpers/nodes'
 import { faCog } from '@fortawesome/free-solid-svg-icons/faCog'
 import { faDatabase } from '@fortawesome/free-solid-svg-icons/faDatabase'
 import { setSelectedNode } from '../../../../store/actionCreators'
 import { theme } from '../../../../helpers/theme'
+import MQTooltip from '../../../core/tooltip/MQTooltip'
 
 const RADIUS = 14
 const ICON_SIZE = 16
@@ -44,12 +44,19 @@ const Node: React.FC<NodeProps> = ({ node, selectedNode, setSelectedNode }) => {
   }
 
   const addToToolTip = (inputData: GraphNode<MqNode>) => {
-    // return react fragment
-    return <>
-      <b>{"Namespace: "}</b>{inputData.data.namespace}<br></br>
-      <b>{"Name: "}</b>{inputData.data.name}<br></br>
-      <b>{"Description: "}</b>{inputData.data.description === null ? "No Description" : inputData.data.description}<br></br>
+    return (
+      <>
+        <b>{'Namespace: '}</b>
+        {inputData.data.namespace}
+        <br></br>
+        <b>{'Name: '}</b>
+        {inputData.data.name}
+        <br></br>
+        <b>{'Description: '}</b>
+        {inputData.data.description === null ? 'No Description' : inputData.data.description}
+        <br></br>
       </>
+    )
   }
 
   const job = isJob(node)
@@ -60,8 +67,8 @@ const Node: React.FC<NodeProps> = ({ node, selectedNode, setSelectedNode }) => {
   return (
     <Link to={determineLink(node)} onClick={() => node.label && setSelectedNode(node.label)}>
       <MQTooltip title={addToToolTip(node)}>
-      {job ? (
-        <g>
+        {job ? (
+          <g>
             <circle
               style={{ cursor: 'pointer' }}
               r={RADIUS}
@@ -71,20 +78,20 @@ const Node: React.FC<NodeProps> = ({ node, selectedNode, setSelectedNode }) => {
               cx={node.x}
               cy={node.y}
             />
-          <FontAwesomeIcon
-            aria-hidden={'true'}
-            title={ariaJobLabel}
-            style={{ transformOrigin: `${node.x}px ${node.y}px` }}
-            icon={faCog}
-            width={ICON_SIZE}
-            height={ICON_SIZE}
-            x={node.x - ICON_SIZE / 2}
-            y={node.y - ICON_SIZE / 2}
-            color={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
-          />
-        </g>
-      ) : (
-        <g>
+            <FontAwesomeIcon
+              aria-hidden={'true'}
+              title={ariaJobLabel}
+              style={{ transformOrigin: `${node.x}px ${node.y}px` }}
+              icon={faCog}
+              width={ICON_SIZE}
+              height={ICON_SIZE}
+              x={node.x - ICON_SIZE / 2}
+              y={node.y - ICON_SIZE / 2}
+              color={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
+            />
+          </g>
+        ) : (
+          <g>
             <rect
               style={{ cursor: 'pointer' }}
               x={node.x - RADIUS}
@@ -105,19 +112,19 @@ const Node: React.FC<NodeProps> = ({ node, selectedNode, setSelectedNode }) => {
               height={(RADIUS - 2) * 2}
               rx={4}
             />
-          <FontAwesomeIcon
-            aria-hidden={'true'}
-            title={ariaDatasetLabel}
-            icon={faDatabase}
-            width={ICON_SIZE}
-            height={ICON_SIZE}
-            x={node.x - ICON_SIZE / 2}
-            y={node.y - ICON_SIZE / 2}
-            color={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
-          />
-        </g>
-      )}
-       </MQTooltip>
+            <FontAwesomeIcon
+              aria-hidden={'true'}
+              title={ariaDatasetLabel}
+              icon={faDatabase}
+              width={ICON_SIZE}
+              height={ICON_SIZE}
+              x={node.x - ICON_SIZE / 2}
+              y={node.y - ICON_SIZE / 2}
+              color={isSelected ? theme.palette.primary.main : theme.palette.secondary.main}
+            />
+          </g>
+        )}
+      </MQTooltip>
       <NodeText node={node} />
     </Link>
   )


### PR DESCRIPTION
### Problem

Currently the Marquez UI compresses dataset/job name under each node if they are over x characters which leads to a sub optimal user experience when browsing nodes on a graph. The current tool tip just displays if the object is a job/dataset and so is not massively helpful.

Closes: #2580

### Solution

![image](https://github.com/MarquezProject/marquez/assets/34074888/8f71b90d-2d8f-4c60-b04c-8562b5b283d7)

One-line summary:

Add Tool tip to display basic node details.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [x] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
