### PR TITLE
add available column level tags

### DIFF
--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -51,13 +51,7 @@ const formatColumnTags = (tags: string[]) => {
           key={tag}
           label={tag}
           size="small"
-          style={
-            index < tags.length - 1
-              ? {
-                  marginRight: theme.spacing(1),
-                }
-              : {}
-          }
+          style={{display: 'inline', marginRight: index < tags.length - 1 ? theme.spacing(1) : 0}}
         />
       ))}
     </>

--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -44,19 +44,24 @@ type DatasetInfoProps = {
 
 const formatColumnTags = (tags: string[]) => {
   const theme = createTheme(useTheme())
-  return <>{tags.map((tag, index) => (
-    <span
-      key={tag}
-      style={
-        index < tags.length - 1
-          ? {
-            marginRight: theme.spacing(1),
+  return (
+    <>
+      {tags.map((tag, index) => (
+        <Chip
+          key={tag}
+          label={tag}
+          size="small"
+          style={
+            index < tags.length - 1
+              ? {
+                  marginRight: theme.spacing(1),
+                }
+              : {}
           }
-          : {}
-      }>
-      <Chip size='small' label={tag} />
-    </span>
-  ))}</>
+        />
+      ))}
+    </>
+  )
 }
 
 const DatasetInfo: FunctionComponent<DatasetInfoProps> = (props) => {

--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -14,6 +14,9 @@ import MqJsonView from '../core/json-view/MqJsonView'
 import MqText from '../core/text/MqText'
 import React, { FunctionComponent, useEffect } from 'react'
 import RunStatus from '../jobs/RunStatus'
+import { Chip } from '@mui/material'
+import { createTheme } from '@mui/material/styles'
+import { useTheme } from '@emotion/react'
 
 export interface DispatchProps {
   fetchJobFacets: typeof fetchJobFacets
@@ -38,6 +41,23 @@ type DatasetInfoProps = {
   run?: Run
 } & JobFacetsProps &
   DispatchProps
+
+const formatColumnTags = (tags: string[]) => {
+  const theme = createTheme(useTheme())
+  return <>{tags.map((tag, index) => (
+    <span
+      key={tag}
+      style={
+        index < tags.length - 1
+          ? {
+            marginRight: theme.spacing(1),
+          }
+          : {}
+      }>
+      <Chip size='small' label={tag} />
+    </span>
+  ))}</>
+}
 
 const DatasetInfo: FunctionComponent<DatasetInfoProps> = (props) => {
   const { datasetFields, facets, run, jobFacets, fetchJobFacets, resetFacets } = props
@@ -82,6 +102,11 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = (props) => {
                   {i18next.t('dataset_info_columns.description')}
                 </MqText>
               </TableCell>
+              <TableCell align='left'>
+                <MqText subheading inline>
+                {i18next.t('dataset_info_columns.tags')}
+                </MqText>
+              </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -91,6 +116,7 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = (props) => {
                   <TableCell align='left'>{field.name}</TableCell>
                   <TableCell align='left'>{field.type}</TableCell>
                   <TableCell align='left'>{field.description || 'no description'}</TableCell>
+                  <TableCell align='left'>{formatColumnTags(field.tags)}</TableCell>
                 </TableRow>
               )
             })}

--- a/web/src/i18n/config.ts
+++ b/web/src/i18n/config.ts
@@ -118,7 +118,8 @@ i18next
           dataset_info_columns: {
             name: 'NAME',
             type: 'TYPE',
-            description: 'DESCRIPTION'
+            description: 'DESCRIPTION',
+            tags: 'TAGS'
           },
           dataset_versions_columns: {
             version: 'VERSION',
@@ -244,7 +245,8 @@ i18next
           dataset_info_columns: {
             name: 'NOM',
             type: 'TAPER',
-            description: 'DESCRIPTION'
+            description: 'DESCRIPTION',
+            tags: 'MOTS CLÉS'
           },
           dataset_versions_columns: {
             version: 'VERSION',
@@ -371,7 +373,8 @@ i18next
           dataset_info_columns: {
             name: 'NOMBRE',
             type: 'ESCRIBE',
-            description: 'DESCRIPCIÓN'
+            description: 'DESCRIPCIÓN',
+            tags: 'ETIQUETAS'
           },
           dataset_versions_columns: {
             version: 'VERSIÓN',
@@ -498,7 +501,8 @@ i18next
           dataset_info_columns: {
             name: 'NAZWA',
             type: 'RODZAJ',
-            description: 'OPIS'
+            description: 'OPIS',
+            tags: 'TAGI'
           },
           dataset_versions_columns: {
             version: 'WERSJA',


### PR DESCRIPTION
### Problem

Currently any dataset columns with tags are not displayed in the dataset information pane. The data is available in the field.tags var.

Closes: #2605

### Solution

add a new column called "tags" to the dataset column view and add the tags associated with the dataset column.

<img width="1191" alt="Screenshot 2023-09-06 at 05 53 39" src="https://github.com/MarquezProject/marquez/assets/34074888/ff520a95-8b89-4fd2-9e04-1e58fbbe537f">




One-line summary:

add a new column called "tags" to the dataset column view and add the tags associated with the dataset column.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [x] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
