### PR TITLE
Postgres `14`

### DIFF
--- a/.circleci/db-migration.sh
+++ b/.circleci/db-migration.sh
@@ -11,7 +11,7 @@
 # Usage: $ ./db-migration.sh
 
 # Version of PostgreSQL
-readonly POSTGRES_VERSION="12.1"
+readonly POSTGRES_VERSION="14"
 # Version of Marquez
 readonly MARQUEZ_VERSION=0.40.0
 # Build version of Marquez

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Marquez uses a _multi_-project structure and contains the following modules:
 ## Requirements
 
 * [Java 17](https://adoptium.net)
-* [PostgreSQL 12.1](https://www.postgresql.org/download)
+* [PostgreSQL 14](https://www.postgresql.org/download)
 
 > **Note:** To connect to your running PostgreSQL instance, you will need the standard [`psql`](https://www.postgresql.org/docs/9.6/app-psql.html) tool.
 

--- a/api/src/test/java/marquez/PostgresContainer.java
+++ b/api/src/test/java/marquez/PostgresContainer.java
@@ -11,7 +11,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public final class PostgresContainer extends PostgreSQLContainer<PostgresContainer> {
-  private static final DockerImageName POSTGRES = DockerImageName.parse("postgres:12.12");
+  private static final DockerImageName POSTGRES = DockerImageName.parse("postgres:14");
   private static final int JDBC = 5;
 
   private static final Map<String, PostgresContainer> containers = new HashMap<>();

--- a/api/src/test/java/marquez/db/DbTest.java
+++ b/api/src/test/java/marquez/db/DbTest.java
@@ -33,7 +33,7 @@ import org.testcontainers.utility.DockerImageName;
 @Tag("DataAccessTests")
 @Testcontainers
 class DbTest {
-  private static final DockerImageName POSTGRES_12_1 = DockerImageName.parse("postgres:12.1");
+  private static final DockerImageName POSTGRES_12_1 = DockerImageName.parse("postgres:14");
 
   @Container
   private static final PostgreSQLContainer<?> DB_CONTAINER =

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   db:
-    image: postgres:12.1
+    image: postgres:14
     container_name: marquez-db
     ports:
       - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     entrypoint: ["/opt/marquez/wait-for-it.sh", "db:5432", "--", "./entrypoint.sh"]
 
   db:
-    image: postgres:12.1
+    image: postgres:14
     container_name: marquez-db
     ports:
       - "5432:5432"


### PR DESCRIPTION
This PR bumps our recommended version of `postgres` to `14`. It's been long overdue!