### PR TITLE
Perf/improve jobdao query

### DIFF
--- a/api/src/main/java/marquez/db/JobDao.java
+++ b/api/src/main/java/marquez/db/JobDao.java
@@ -129,50 +129,50 @@ public interface JobDao extends BaseDao {
     AS (
       SELECT
         *
-      FROM 
+      FROM
         jobs_view AS j
-      WHERE 
+      WHERE
         j.namespace_name = :namespaceName
       ORDER BY
         j.name
-      LIMIT 
+      LIMIT
         :limit
-      OFFSET 
+      OFFSET
         :offset
     ),
     job_versions_temp AS (
-      SELECT 
+      SELECT
         *
-      FROM 
+      FROM
         job_versions AS j
-      WHERE 
+      WHERE
         j.namespace_name = :namespaceName
     ),
     facets_temp AS (
-    SELECT 
+    SELECT
       run_uuid,
         JSON_AGG(e.facet) AS facets
     FROM (
-        SELECT 
+        SELECT
           jf.run_uuid,
             jf.facet
-        FROM 
+        FROM
           job_facets_view AS jf
-        INNER JOIN job_versions_temp jv2 
+        INNER JOIN job_versions_temp jv2
           ON jv2.latest_run_uuid = jf.run_uuid
-        INNER JOIN jobs_view_page j2 
+        INNER JOIN jobs_view_page j2
           ON j2.current_version_uuid = jv2.uuid
-        ORDER BY 
+        ORDER BY
           lineage_event_time ASC
         ) e
     GROUP BY e.run_uuid
     )
-    SELECT 
+    SELECT
       j.*,
       f.facets
-    FROM 
+    FROM
       jobs_view_page AS j
-    LEFT OUTER JOIN job_versions_temp AS jv 
+    LEFT OUTER JOIN job_versions_temp AS jv
       ON jv.uuid = j.current_version_uuid
     LEFT OUTER JOIN facets_temp AS f
       ON f.run_uuid = jv.latest_run_uuid

--- a/api/src/main/java/marquez/db/JobDao.java
+++ b/api/src/main/java/marquez/db/JobDao.java
@@ -125,23 +125,59 @@ public interface JobDao extends BaseDao {
 
   @SqlQuery(
       """
-    SELECT j.*, f.facets
-      FROM jobs_view AS j
-      LEFT OUTER JOIN job_versions AS jv ON jv.uuid = j.current_version_uuid
-    LEFT OUTER JOIN (
-      SELECT run_uuid, JSON_AGG(e.facet) AS facets
-      FROM (
-        SELECT jf.run_uuid, jf.facet
-        FROM job_facets_view AS jf
-        INNER JOIN job_versions jv2 ON jv2.latest_run_uuid=jf.run_uuid
-        INNER JOIN jobs_view j2 ON j2.current_version_uuid=jv2.uuid
-        WHERE j2.namespace_name=:namespaceName
-        ORDER BY lineage_event_time ASC
-      ) e
-      GROUP BY e.run_uuid
-    ) f ON f.run_uuid=jv.latest_run_uuid
-    WHERE j.namespace_name = :namespaceName
-    ORDER BY j.name LIMIT :limit OFFSET :offset
+    WITH jobs_view_page
+    AS (
+      SELECT
+        *
+      FROM 
+        jobs_view AS j
+      WHERE 
+        j.namespace_name = :namespaceName
+      ORDER BY
+        j.name
+      LIMIT 
+        :limit
+      OFFSET 
+        :offset
+    ),
+    job_versions_temp AS (
+      SELECT 
+        *
+      FROM 
+        job_versions AS j
+      WHERE 
+        j.namespace_name = :namespaceName
+    ),
+    facets_temp AS (
+    SELECT 
+      run_uuid,
+        JSON_AGG(e.facet) AS facets
+    FROM (
+        SELECT 
+          jf.run_uuid,
+            jf.facet
+        FROM 
+          job_facets_view AS jf
+        INNER JOIN job_versions_temp jv2 
+          ON jv2.latest_run_uuid = jf.run_uuid
+        INNER JOIN jobs_view_page j2 
+          ON j2.current_version_uuid = jv2.uuid
+        ORDER BY 
+          lineage_event_time ASC
+        ) e
+    GROUP BY e.run_uuid
+    )
+    SELECT 
+      j.*,
+      f.facets
+    FROM 
+      jobs_view_page AS j
+    LEFT OUTER JOIN job_versions_temp AS jv 
+      ON jv.uuid = j.current_version_uuid
+    LEFT OUTER JOIN facets_temp AS f
+      ON f.run_uuid = jv.latest_run_uuid
+    ORDER BY
+        j.name
   """)
   List<Job> findAll(String namespaceName, int limit, int offset);
 


### PR DESCRIPTION
### Problem

Hello, 

While working with Marquez, I noticed a significant performance bottleneck with a specific SQL query in the `JobDao.java` file. For the namespaceName "MyNameSpace", the query was originally taking 17 seconds to execute with a limit of 100, and 12 seconds with a limit of 25. Given that this query runs every time the Marquez web UI is accessed, this presented a major user experience challenge.
`db.t4g.medium (vCPU: 2, RAM: 4 GB)`

See : https://github.com/MarquezProject/marquez/issues/2608

### Solution

To address this, I've revised the query. The optimized query makes use of Common Table Expressions to fetch the required data more efficiently and *before the join*. Here's the optimized query:

```sql
    WITH jobs_view_page
    AS (
      SELECT
        *
      FROM 
        jobs_view AS j
      WHERE 
        j.namespace_name = :namespaceName
      ORDER BY
        j.name
      LIMIT 
        :limit
      OFFSET 
        :offset
    ),
    job_versions_temp AS (
      SELECT 
        *
      FROM 
        job_versions AS j
      WHERE 
        j.namespace_name = :namespaceName
    ),
    facets_temp AS (
    SELECT 
      run_uuid,
        JSON_AGG(e.facet) AS facets
    FROM (
        SELECT 
          jf.run_uuid,
            jf.facet
        FROM 
          job_facets_view AS jf
        INNER JOIN job_versions_temp jv2 
          ON jv2.latest_run_uuid = jf.run_uuid
        INNER JOIN jobs_view_page j2 
          ON j2.current_version_uuid = jv2.uuid
        ORDER BY 
          lineage_event_time ASC
        ) e
    GROUP BY e.run_uuid
    )
    SELECT 
      j.*,
      f.facets
    FROM 
      jobs_view_page AS j
    LEFT OUTER JOIN job_versions_temp AS jv 
      ON jv.uuid = j.current_version_uuid
    LEFT OUTER JOIN facets_temp AS f
      ON f.run_uuid = jv.latest_run_uuid
    ORDER BY
        j.name
```

On the same cluster `db.t4g.medium (vCPU: 2, RAM: 4 GB)`, the optimization reduced the execution time from 17 seconds with `limit=100` to a mere 300ms. For `limit=25`, it dropped from 12 seconds to under 100ms. 

Furthermore, I believe there's potential for even more optimization. If `job_facets_view` included the column `namespace_name`, it might allow for further refinements.

One-line summary: Optimized a critical SQL query in `JobDao.java`, resulting in a significant reduction in execution time.

### Checklist

- [x] I've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) on my work.
- [x] My changes are accompanied by tests (_if relevant_).
- [x] The change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained.
- [ ] I've updated the relevant documentation (_if necessary_).
- [ ] I've included a one-line summary of my change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] I've versioned my `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_).
- [x] I've included the appropriate [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_).