### PR TITLE
UI/add datagrid

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,6 +18,7 @@
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.2",
         "@mui/system": "^5.13.2",
+        "@mui/x-data-grid": "^6.13.0",
         "@mui/x-date-pickers": "^6.5.0",
         "@types/jest": "^29.5.2",
         "@types/react-router-dom": "^5.3.3",
@@ -2127,15 +2128,20 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
+      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/@babel/template": {
       "version": "7.22.5",
@@ -3422,11 +3428,11 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.14.3",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.3.tgz",
-      "integrity": "sha512-gZ6Etw+ppO43GYc1HFZSLjwd4DoZoa+RrYTD25wQLfzcSoPjVoC/zZqA2Lkq0zjgwGBQOSxKZI6jfp9uXR+kgw==",
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.8.tgz",
+      "integrity": "sha512-1Ls2FfyY2yVSz9NEqedh3J8JAbbZAnUWkOWLE2f4/Hc4T5UWHMfzBLLrCqExfqyfyU+uXYJPGeNIsky6f8Gh5Q==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
+        "@babel/runtime": "^7.22.10",
         "@types/prop-types": "^15.7.5",
         "@types/react-is": "^18.2.1",
         "prop-types": "^15.8.1",
@@ -3441,6 +3447,31 @@
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@mui/x-data-grid": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-6.13.0.tgz",
+      "integrity": "sha512-HRZGPdE+unZEiygcMqLsKOJ1F7iaTrhGQXGdlFLLniwfYMzVmJgZQXYCCeOIkCQqF28rQniF+4PbRhmFERdqSQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.15",
+        "@mui/utils": "^5.14.7",
+        "clsx": "^2.0.0",
+        "prop-types": "^15.8.1",
+        "reselect": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.4.1",
+        "@mui/system": "^5.4.1",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@mui/x-date-pickers": {
@@ -18327,6 +18358,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.3",

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.2",
     "@mui/system": "^5.13.2",
+    "@mui/x-data-grid": "^6.13.0",
     "@mui/x-date-pickers": "^6.5.0",
     "@types/jest": "^29.5.2",
     "@types/react-router-dom": "^5.3.3",

--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -131,8 +131,7 @@ const Datasets: React.FC<DatasetsProps> = ({
     {
       field: 'name',
       headerName: i18next.t('datasets_route.name_col'),
-      renderCell: (params) => {
-        return <MqText
+      renderCell: (params) => (<MqText
           link
           linkTo={`/lineage/${encodeNode(
             'DATASET',
@@ -141,33 +140,31 @@ const Datasets: React.FC<DatasetsProps> = ({
           )}`}
         >
           {params.row.name}
-        </MqText>
-      },
-      width: 400
+      </MqText>),
+      flex: 2,
+      editable: false,
     },
-    { field: 'namespace', headerName: i18next.t('datasets_route.namespace_col'), width: 200 },
-    { field: 'sourceName', headerName: i18next.t('datasets_route.source_col'), width: 200 },
+    { field: 'namespace', headerName: i18next.t('datasets_route.namespace_col'), flex: 1, editable: false, },
+    { field: 'sourceName', headerName: i18next.t('datasets_route.source_col'), flex: 1, editable: false, },
     {
       field: 'updatedAt',
       headerName: i18next.t('datasets_route.updated_col'),
-      renderCell: (params) => {
-        return <MqText>{formatUpdatedAt(params.row.updatedAt)}</MqText>
-      },
-      width: 200
+      renderCell: (params) => (<MqText>{formatUpdatedAt(params.row.updatedAt)}</MqText>),
+      flex: 1,
+      editable: false,
     },
     {
       field: 'facets',
       headerName: i18next.t('datasets_route.status_col'),
-      renderCell: (params) => {
-        return (datasetFacetsStatus(params.row.facets) ? (
+      renderCell: (params) => (datasetFacetsStatus(params.row.facets) ? (
           <>
             <MqStatus color={datasetFacetsStatus(params.row.facets)} />
           </>
         ) : (
           <MqText>N/A</MqText>
-        ))
-      },
-      width: 200
+      )),
+      flex: 1,
+      editable: false,
     }
   ]
 

--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -23,7 +23,7 @@ import IconButton from '@mui/material/IconButton'
 import MqEmpty from '../../components/core/empty/MqEmpty'
 import MqStatus from '../../components/core/status/MqStatus'
 import MqText from '../../components/core/text/MqText'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { DataGrid, GridColDef } from '@mui/x-data-grid'
 
 interface StateProps {
@@ -173,6 +173,12 @@ const Datasets: React.FC<DatasetsProps> = ({
     page: 0,
   });
 
+  useEffect(() => {
+    if (selectedNamespace) {
+      fetchDatasets(selectedNamespace, PAGE_SIZE * paginationModel?.page + 1)
+    }
+    setState({ ...state, page: paginationModel?.page + 1 })
+  }, [paginationModel?.page])
 
   return (
     <Container maxWidth={'lg'} disableGutters>

--- a/web/src/routes/jobs/Jobs.tsx
+++ b/web/src/routes/jobs/Jobs.tsx
@@ -18,6 +18,7 @@ import MqEmpty from '../../components/core/empty/MqEmpty'
 import MqStatus from '../../components/core/status/MqStatus'
 import MqText from '../../components/core/text/MqText'
 import React from 'react'
+import { DataGrid, GridColDef } from '@mui/x-data-grid'
 
 interface StateProps {
   jobs: Job[]
@@ -69,6 +70,51 @@ const Jobs: React.FC<JobsProps> = ({
   }, [])
 
   const i18next = require('i18next')
+
+  const columns: GridColDef[] = [
+    {
+      field: 'name',
+      headerName: i18next.t('jobs_route.name_col'),
+      renderCell: (params) => (<MqText
+        link
+        linkTo={`/lineage/${encodeNode('JOB', params.row.namespace, params.row.name)}`}
+      >
+        {params.row.name}
+      </MqText>),
+      flex: 2,
+      editable: false
+    },
+    { field: 'namespace', headerName: i18next.t('jobs_route.namespace_col'), flex: 1, editable: false },
+    {
+      field: 'updatedAt',
+      headerName: i18next.t('jobs_route.updated_col'),
+      renderCell: (params) => (<MqText>{formatUpdatedAt(params.row.updatedAt)}</MqText>),
+      flex: 1,
+      editable: false
+    },
+    {
+      field: 'latestRun',
+      headerName: i18next.t('jobs_route.latest_run_col'),
+      renderCell: (params) => (<MqText>
+        {params.row.latestRun && params.row.latestRun.durationMs
+          ? stopWatchDuration(params.row.latestRun.durationMs)
+          : 'N/A'}
+      </MqText>),
+      flex: 1,
+      editable: false
+    },
+    {
+      field: 'runState',
+      headerName: i18next.t('jobs_route.latest_run_state_col'),
+      renderCell: (params) => (<MqStatus
+        color={params.row.latestRun && runStateColor(params.row.latestRun.state || 'NEW')}
+        label={params.row.latestRun && params.row.latestRun.state ? params.row.latestRun.state : 'N/A'}
+      />),
+      flex: 1,
+      editable: false,
+    },
+  ]
+
   return (
     <Container maxWidth={'lg'} disableGutters>
       <MqScreenLoad loading={isJobsLoading || !isJobsInit}>
@@ -84,64 +130,12 @@ const Jobs: React.FC<JobsProps> = ({
               <Box p={2}>
                 <MqText heading>{i18next.t('jobs_route.heading')}</MqText>
               </Box>
-              <Table size='small'>
-                <TableHead>
-                  <TableRow>
-                    <TableCell key={i18next.t('jobs_route.name_col')} align='left'>
-                      <MqText subheading>{i18next.t('datasets_route.name_col')}</MqText>
-                    </TableCell>
-                    <TableCell key={i18next.t('jobs_route.namespace_col')} align='left'>
-                      <MqText subheading>{i18next.t('datasets_route.namespace_col')}</MqText>
-                    </TableCell>
-                    <TableCell key={i18next.t('jobs_route.updated_col')} align='left'>
-                      <MqText subheading>{i18next.t('datasets_route.updated_col')}</MqText>
-                    </TableCell>
-                    <TableCell key={i18next.t('jobs_route.latest_run_col')} align='left'>
-                      <MqText subheading>{i18next.t('jobs_route.latest_run_col')}</MqText>
-                    </TableCell>
-                    <TableCell key={i18next.t('jobs_route.latest_run_state_col')} align='left'>
-                      <MqText subheading>{i18next.t('jobs_route.latest_run_state_col')}</MqText>
-                    </TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {jobs.map((job) => {
-                    return (
-                      <TableRow key={job.name}>
-                        <TableCell align='left'>
-                          <MqText
-                            link
-                            linkTo={`/lineage/${encodeNode('JOB', job.namespace, job.name)}`}
-                          >
-                            {job.name}
-                          </MqText>
-                        </TableCell>
-                        <TableCell align='left'>
-                          <MqText>{job.namespace}</MqText>
-                        </TableCell>
-                        <TableCell align='left'>
-                          <MqText>{formatUpdatedAt(job.updatedAt)}</MqText>
-                        </TableCell>
-                        <TableCell align='left'>
-                          <MqText>
-                            {job.latestRun && job.latestRun.durationMs
-                              ? stopWatchDuration(job.latestRun.durationMs)
-                              : 'N/A'}
-                          </MqText>
-                        </TableCell>
-                        <TableCell key={i18next.t('jobs_route.latest_run_col')} align='left'>
-                          <MqStatus
-                            color={job.latestRun && runStateColor(job.latestRun.state || 'NEW')}
-                            label={
-                              job.latestRun && job.latestRun.state ? job.latestRun.state : 'N/A'
-                            }
-                          />
-                        </TableCell>
-                      </TableRow>
-                    )
-                  })}
-                </TableBody>
-              </Table>
+                <DataGrid
+                  rows={jobs}
+                  columns={columns}
+                  getRowId={(row) => JSON.stringify(row.id)}
+                  disableRowSelectionOnClick
+                />
             </>
           )}
         </>


### PR DESCRIPTION
### Problem

Currently jobs and datasets are display in table. This integration limite the possibility to filter / order the data.

Closes: n/a

### Solution

We can now use mui DataGrid, so I replace the table by DataGrid on Job and Dataset page.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
