### PR TITLE
Remove usage of `current_job_context_uuid` column

### DIFF
--- a/api/src/main/java/marquez/db/JobDao.java
+++ b/api/src/main/java/marquez/db/JobDao.java
@@ -283,7 +283,6 @@ public interface JobDao extends BaseDao {
       namespace_name,
       name,
       description,
-      current_job_context_uuid,
       current_location,
       current_inputs,
       symlink_target_uuid,
@@ -297,7 +296,6 @@ public interface JobDao extends BaseDao {
       :namespaceName,
       :name,
       :description,
-      null,
       :location,
       :inputs,
       :symlinkTargetId,
@@ -332,7 +330,6 @@ public interface JobDao extends BaseDao {
       namespace_name,
       name,
       description,
-      current_job_context_uuid,
       current_location,
       current_inputs,
       symlink_target_uuid
@@ -346,7 +343,6 @@ public interface JobDao extends BaseDao {
       :namespaceName,
       :name,
       :description,
-      null,
       :location,
       :inputs,
       :symlinkTargetId

--- a/api/src/main/java/marquez/db/migrations/V44_3_BackfillJobsWithParents.java
+++ b/api/src/main/java/marquez/db/migrations/V44_3_BackfillJobsWithParents.java
@@ -51,10 +51,10 @@ public class V44_3_BackfillJobsWithParents implements JavaMigration {
   public static final String INSERT_NEW_JOB_WITH_PARENT =
       """
       INSERT INTO jobs(uuid, type, created_at, updated_at, namespace_uuid, name, description,
-        current_version_uuid, namespace_name, current_job_context_uuid, current_location, current_inputs,
+        current_version_uuid, namespace_name, current_location, current_inputs,
         parent_job_uuid)
       SELECT :uuid, type, created_at, updated_at, namespace_uuid, name, description, current_version_uuid,
-        namespace_name, current_job_context_uuid, current_location, current_inputs, :parent_job_uuid
+        namespace_name, current_location, current_inputs, :parent_job_uuid
         FROM jobs
         WHERE uuid=:job_uuid
         ON CONFLICT (name, namespace_name, parent_job_uuid) DO NOTHING

--- a/api/src/main/resources/marquez/db/migration/R__1_Jobs_view_and_rewrite_function.sql
+++ b/api/src/main/resources/marquez/db/migration/R__1_Jobs_view_and_rewrite_function.sql
@@ -52,7 +52,7 @@ BEGIN
            NEW.description,
            NEW.current_version_uuid,
            NEW.namespace_name,
-           NEW.current_job_context_uuid,
+           NULL,
            NEW.current_location,
            NEW.current_inputs,
            NEW.symlink_target_uuid,
@@ -67,7 +67,6 @@ BEGIN
                             END,
                       type                     = EXCLUDED.type,
                       description              = EXCLUDED.description,
-                      current_job_context_uuid = EXCLUDED.current_job_context_uuid,
                       current_location         = EXCLUDED.current_location,
                       current_inputs           = EXCLUDED.current_inputs,
                       -- update the symlink target if null. otherwise, keep the old value

--- a/api/src/test/java/marquez/db/BackfillTestUtils.java
+++ b/api/src/test/java/marquez/db/BackfillTestUtils.java
@@ -122,8 +122,8 @@ public class BackfillTestUtils {
         h -> {
           return h.createQuery(
                   """
-                  INSERT INTO jobs (uuid, type, created_at, updated_at, namespace_uuid, name, namespace_name, current_job_context_uuid, current_inputs)
-                  VALUES (:uuid, :type, :now, :now, :namespaceUuid, :name, :namespaceName, null, :currentInputs)
+                  INSERT INTO jobs (uuid, type, created_at, updated_at, namespace_uuid, name, namespace_name, current_inputs)
+                  VALUES (:uuid, :type, :now, :now, :namespaceUuid, :name, :namespaceName, :currentInputs)
                   RETURNING uuid
                   """)
               .bind("uuid", UUID.randomUUID())


### PR DESCRIPTION
This PR removes the usage of `job_context_uuid` (and `current_job_context_uuid`). We will follow up with a PR to drop the column now scheduled to be release in `0.43.0`.