### PR TITLE
Migrate Docker Compose cmd in `up` to V2

### DIFF
--- a/docker/up.sh
+++ b/docker/up.sh
@@ -142,5 +142,5 @@ if [[ "${NO_VOLUMES}" = "false" ]]; then
 fi
 
 # Run docker compose cmd with overrides
-DOCKER_SCAN_SUGGEST=false API_PORT=${API_PORT} API_ADMIN_PORT=${API_ADMIN_PORT} WEB_PORT=${WEB_PORT} TAG=${TAG} \
-  docker-compose --log-level ERROR $compose_files up $ARGS
+DOCKER_SCAN_SUGGEST="false" API_PORT=${API_PORT} API_ADMIN_PORT=${API_ADMIN_PORT} WEB_PORT=${WEB_PORT} TAG=${TAG} \
+  docker --log-level ERROR compose $compose_files up $ARGS


### PR DESCRIPTION
### Problem

Docker Compose version 1 has been at EOL since this past June. Our docker compose `up` command in docker/up.sh is technically not compatible with version 2, even if Docker Desktop for Mac (or Docker for MacOS in general?) permits the incorrect format. On at least one Linux distro, however, the command fails to execute when version 2 is installed. Error output mentions only MIME-type issues, which is confusing and unhelpful, making the issue hard to diagnose. New users on Linux can potentially be blocked by this.

### Solution

This upgrades the `up` command in docker/up.sh to version 2. This should be sufficient to migrate the project.

Closes: https://github.com/MarquezProject/marquez/issues/2643

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary: upgrades docker/up.sh to Docker Compose V2

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
