### PR TITLE
Fix Unix epoch time display in case of null `endedAt` value

### DIFF
--- a/web/src/components/jobs/Runs.tsx
+++ b/web/src/components/jobs/Runs.tsx
@@ -96,7 +96,7 @@ const Runs: FunctionComponent<RunsProps> = (props) => {
         </TableHead>
         <TableBody>
           {runs.map((run) => {
-            return (
+            return ( run.durationMs > 0 ?
               <TableRow
                 key={run.id}
                 sx={{
@@ -119,7 +119,30 @@ const Runs: FunctionComponent<RunsProps> = (props) => {
                 <TableCell align='left'>{formatUpdatedAt(run.startedAt)}</TableCell>
                 <TableCell align='left'>{formatUpdatedAt(run.endedAt)}</TableCell>
                 <TableCell align='left'>{stopWatchDuration(run.durationMs)}</TableCell>
-              </TableRow>
+              </TableRow> :
+              <TableRow
+              key={run.id}
+              sx={{
+                cursor: 'pointer',
+                transition: theme.transitions.create(['background-color']),
+                '&:hover': {
+                  backgroundColor: alpha(theme.palette.common.white, 0.1),
+                },
+              }}
+              onClick={() => handleClick(run)}
+            >
+              <TableCell align='left'>{run.id}</TableCell>
+              <TableCell align='left'>
+                <Box display={'flex'} alignItems={'center'}>
+                  <RunStatus run={run} />
+                  <MqText>{run.state}</MqText>
+                </Box>
+              </TableCell>
+              <TableCell align='left'>{formatUpdatedAt(run.createdAt)}</TableCell>
+              <TableCell align='left'>{formatUpdatedAt(run.startedAt)}</TableCell>
+              <TableCell align='left'>N/A</TableCell>
+              <TableCell align='left'>{stopWatchDuration(run.durationMs)}</TableCell>
+            </TableRow>
             )
           })}
         </TableBody>


### PR DESCRIPTION
### Problem

In the case of a fresh instance of Marquez (e.g., a new user experimenting with a quickstart), using cURL to post a start event by itself causes the `runs` component to display the Unix epoch time in the ENDED AT column.

### Solution

This makes displaying the `endedAt` value conditional on there being a `durationMs` value greater than 0. Otherwise, it will display 'N/A'.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary: Fixes Unix epoch time display in case of null `endedAt` value.

Closes: https://github.com/MarquezProject/marquez/issues/2646

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)

![Screenshot 2023-10-10 at 17 21 40](https://github.com/MarquezProject/marquez/assets/68482867/ce2ee6fd-0db0-4915-8e9b-d52dd3f2eb0a)