### PR TITLE
Fix headers in docs/v2/netlify.toml.

### DIFF
--- a/docs/v2/netlify.toml
+++ b/docs/v2/netlify.toml
@@ -2,5 +2,5 @@
   for = "/*"
   [headers.values]
     X-Frame-Options = "DENY"
-    Content-Security-Policy = "frame-ancestors https://fonts.googleapis.com"
+    Content-Security-Policy = "frame-ancestors none; link https://fonts.googleapis.com"
     X-Content-Type-Options = "nosniff"


### PR DESCRIPTION
### Problem

The initial attempt to add security headers with a netlify.toml improved site security significantly, but according to Mozilla Observatory there is still an issue with the Content Security Policy. As a result, the site receives a B-, which is better than the D it was receiving before but not great.

### Solution

This revises the CSP header to disallow `frame-ancestors` and change the directive for imported fonts to a link.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary: fixes csp header in netlify.toml.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
