### PR TITLE
Amend indentation in OpenAPI spec

### DIFF
--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -1919,22 +1919,24 @@ components:
         eventTime: 2019-05-09T19:49:24.201361Z
         run: {runId: d46e465b-d358-4d32-83d4-df660ff614dd}
         job: {namespace: my-namespace,name: my-job}
-        outputs: [{
-          namespace: my-namespace,
-          name: my-output,
-          facets: {
-            schema: {
-              _producer: "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
-              _schemaURL: "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
-              fields: [
-                {name: a, type: INTEGER},
-                {name: b, type: TIMESTAMP},
-                {name: c, type: INTEGER},
-                {name: d, type: INTEGER}
-              ]
+        outputs: [
+          {
+            namespace: my-namespace,
+            name: my-output,
+            facets: {
+              schema: {
+                _producer: "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+                _schemaURL: "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+                fields: [
+                  { name: a, type: INTEGER },
+                  { name: b, type: TIMESTAMP },
+                  { name: c, type: INTEGER },
+                  { name: d, type: INTEGER }
+                ]
+              }
             }
           }
-        }]
+        ]
         producer: "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client"
 
     SearchResultList:


### PR DESCRIPTION
### Problem

I'm referencing the Marquez OpenAPI spec in a Backstage component, via a URL like <https://raw.githubusercontent.com/MarquezProject/marquez/0.41.0/spec/openapi.yml>. Backstage uses a very strict (fussy?) YAML parser which has taken exception to the way a particular JSON block is formed:

```
YAMLParseError: Flow map in block collection must be sufficiently indented and end with a } at line 1910, column 9
```

### Solution

This PR amends the indentation so the aforementioned parser will accept and render the spec.

An alternative would be to convert this chunk of the spec to full YAML, rather than inline JSON - happy to do that instead if it's preferred.

One-line summary:  
Amend indentation in OpenAPI spec

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
