### PR TITLE
[Bug] fix pagination in jobs route

### DIFF
--- a/web/src/routes/jobs/Jobs.tsx
+++ b/web/src/routes/jobs/Jobs.tsx
@@ -34,10 +34,14 @@ import React from 'react'
 
 interface StateProps {
   jobs: Job[]
-  totalCount: number
   isJobsInit: boolean
   isJobsLoading: boolean
   selectedNamespace: Nullable<string>
+  totalCount: number
+}
+
+interface JobsState {
+  page: number
 }
 
 interface DispatchProps {
@@ -58,15 +62,16 @@ const Jobs: React.FC<JobsProps> = ({
   fetchJobs,
   resetJobs,
 }) => {
-  const theme = createTheme(useTheme())
-
-  const [state, setState] = React.useState({
+  const defaultState = {
     page: 0,
-  })
-
+  }
+  const [state, setState] = React.useState<JobsState>(defaultState)
+  
+  const theme = createTheme(useTheme())
+  
   React.useEffect(() => {
     if (selectedNamespace) {
-      fetchJobs(selectedNamespace, PAGE_SIZE, state.page)
+      fetchJobs(selectedNamespace, PAGE_SIZE, state.page * PAGE_SIZE)
     }
   }, [selectedNamespace, state.page])
 
@@ -167,43 +172,43 @@ const Jobs: React.FC<JobsProps> = ({
                   })}
                 </TableBody>
               </Table>
-            </>
+			  <Box display={'flex'} justifyContent={'flex-end'} alignItems={'center'} mb={2}>
+				<MqText subdued>
+				  <>
+					{PAGE_SIZE * state.page + 1} -{' '}
+					{Math.min(PAGE_SIZE * (state.page + 1), totalCount)} of {totalCount}
+				  </>
+				</MqText>
+				<Tooltip title={i18next.t('events_route.previous_page')}>
+				  <span>
+					<IconButton
+					  sx={{
+						marginLeft: theme.spacing(2),
+					  }}
+					  color='primary'
+					  disabled={state.page === 0}
+					  onClick={() => handleClickPage('prev')}
+					  size='large'
+					>
+					  <ChevronLeftRounded />
+					</IconButton>
+				  </span>
+				</Tooltip>
+				<Tooltip title={i18next.t('events_route.next_page')}>
+				  <span>
+					<IconButton
+					  color='primary'
+					  onClick={() => handleClickPage('next')}
+					  size='large'
+					  disabled={state.page === Math.ceil(totalCount / PAGE_SIZE) - 1}
+					>
+					  <ChevronRightRounded />
+					</IconButton>
+				  </span>
+				</Tooltip>
+			  </Box>
+			</>
           )}
-          <Box display={'flex'} justifyContent={'flex-end'} alignItems={'center'} mb={2}>
-            <MqText subdued>
-              <>
-                {PAGE_SIZE * state.page + 1} - {Math.min(PAGE_SIZE * (state.page + 1), totalCount)}{' '}
-                of {totalCount}
-              </>
-            </MqText>
-            <Tooltip title={i18next.t('events_route.previous_page')}>
-              <span>
-                <IconButton
-                  sx={{
-                    marginLeft: theme.spacing(2),
-                  }}
-                  color='primary'
-                  disabled={state.page === 0}
-                  onClick={() => handleClickPage('prev')}
-                  size='large'
-                >
-                  <ChevronLeftRounded />
-                </IconButton>
-              </span>
-            </Tooltip>
-            <Tooltip title={i18next.t('events_route.next_page')}>
-              <span>
-                <IconButton
-                  color='primary'
-                  onClick={() => handleClickPage('next')}
-                  size='large'
-                  disabled={state.page === Math.ceil(totalCount / PAGE_SIZE) - 1}
-                >
-                  <ChevronRightRounded />
-                </IconButton>
-              </span>
-            </Tooltip>
-          </Box>
         </>
       </MqScreenLoad>
     </Container>
@@ -211,11 +216,11 @@ const Jobs: React.FC<JobsProps> = ({
 }
 
 const mapStateToProps = (state: IState) => ({
-  isJobsInit: state.jobs.init,
   jobs: state.jobs.result,
-  totalCount: state.jobs.totalCount,
+  isJobsInit: state.jobs.init,
   isJobsLoading: state.jobs.isLoading,
   selectedNamespace: state.namespaces.selectedNamespace,
+  totalCount: state.jobs.totalCount,
 })
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch) =>


### PR DESCRIPTION
### Problem

Unlike in the case of datasets, for jobs, page navigation is displayed whether or not there are jobs/pages in the namespace. The page total  advances while the total job count remains zero.

### Solution

This hides pagination when there are no jobs.

One-line summary: hides job pagination in the case of no jobs.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)

![Screenshot from 2023-10-21 18-02-39](https://github.com/MarquezProject/marquez/assets/68482867/3741594d-475d-4502-b36c-8812fc3994e9)
![Screenshot from 2023-10-21 08-40-33](https://github.com/MarquezProject/marquez/assets/68482867/78b9da54-5e95-49a1-a4a2-43aabe001d57)
