### PR TITLE
provide simple implementation of one-level lineage optimized for parent jobs

### DIFF
--- a/api/src/main/java/marquez/api/OpenLineageResource.java
+++ b/api/src/main/java/marquez/api/OpenLineageResource.java
@@ -111,6 +111,22 @@ public class OpenLineageResource extends BaseResource {
   @ResponseMetered
   @ExceptionMetered
   @GET
+  @Consumes(APPLICATION_JSON)
+  @Produces(APPLICATION_JSON)
+  @Path("/lineage/direct")
+  public Response getSimpleLineage(
+      @QueryParam("parentJobNodeId") @NotNull NodeId parentJobNodeId) {
+    if (!parentJobNodeId.isJobType()) {
+      throw new IllegalArgumentException("Only job expected, got " + parentJobNodeId.getValue());
+    }
+    throwIfNotExists(parentJobNodeId);
+    return Response.ok(lineageService.parentDirectLineage(parentJobNodeId.asJobId())).build();
+  }
+
+  @Timed
+  @ResponseMetered
+  @ExceptionMetered
+  @GET
   @Path("/events/lineage")
   @Produces(APPLICATION_JSON)
   public Response getLineageEvents(

--- a/api/src/main/java/marquez/db/Columns.java
+++ b/api/src/main/java/marquez/db/Columns.java
@@ -183,7 +183,7 @@ public final class Columns {
   public static String stringOrThrow(final ResultSet results, final String column)
       throws SQLException {
     if (results.getObject(column) == null) {
-      throw new IllegalArgumentException();
+      throw new IllegalArgumentException("no column found for " + column);
     }
     return results.getString(column);
   }

--- a/api/src/main/java/marquez/db/mappers/SimpleLineageEdgeMapper.java
+++ b/api/src/main/java/marquez/db/mappers/SimpleLineageEdgeMapper.java
@@ -1,0 +1,36 @@
+package marquez.db.mappers;
+
+import static marquez.db.Columns.stringOrNull;
+import static marquez.db.Columns.stringOrThrow;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import lombok.NonNull;
+import marquez.common.models.DatasetId;
+import marquez.common.models.DatasetName;
+import marquez.common.models.JobId;
+import marquez.common.models.JobName;
+import marquez.common.models.NamespaceName;
+import marquez.db.LineageDao.SimpleLineageEdge;
+
+public final class SimpleLineageEdgeMapper implements RowMapper<SimpleLineageEdge> {
+  @Override
+  public SimpleLineageEdge map(@NonNull ResultSet results, @NonNull StatementContext context)
+      throws SQLException {
+    JobId job1 = JobId.of(NamespaceName.of(stringOrThrow(results, "job_namespace")), JobName.of(stringOrThrow(results, "job_name")));
+    String io1 = stringOrNull(results, "io1");
+    String ds_namespace = stringOrNull(results, "ds_namespace");
+    DatasetId ds = ds_namespace == null ? null : new DatasetId(NamespaceName.of(ds_namespace), DatasetName.of(stringOrNull(results, "ds_name")));
+    String io2 = stringOrNull(results, "io2");
+    String job2_namespace = stringOrNull(results, "job2_namespace");
+    JobId job2 = job2_namespace == null ? null : JobId.of(NamespaceName.of(job2_namespace), JobName.of(stringOrThrow(results, "job2_name")));
+    String job2parent_namespace = stringOrNull(results, "job2_parent_namespace");
+    JobId job2parent = job2parent_namespace == null ? null : JobId.of(NamespaceName.of(job2parent_namespace), JobName.of(stringOrThrow(results, "job2_parent_name")));
+    return new  SimpleLineageEdge(job1, io1, ds, io2, job2, job2parent);
+  }
+}
+

--- a/api/src/main/java/marquez/service/LineageService.java
+++ b/api/src/main/java/marquez/service/LineageService.java
@@ -5,10 +5,12 @@
 
 package marquez.service;
 
-import com.google.common.base.Functions;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Maps;
+import static java.util.stream.Collectors.filtering;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -21,6 +23,12 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import com.google.common.base.Functions;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Maps;
+
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import marquez.common.models.DatasetId;
@@ -41,11 +49,71 @@ import marquez.service.models.Run;
 
 @Slf4j
 public class LineageService extends DelegatingLineageDao {
+
+  public record JobWithParent(JobId job, JobId parent) {
+  }
+
+  public record DatasetLineage(DatasetId dataset, Collection<JobWithParent> consumers, Collection<JobWithParent> producers) {
+  }
+
+  public record ChildLineage(JobId job, Collection<DatasetLineage> inputs, Collection<DatasetLineage> outputs) {
+  }
+
+  public record ParentLineage(JobId parent, Collection<ChildLineage> children) {
+  }
+
   private final JobDao jobDao;
 
   public LineageService(LineageDao delegate, JobDao jobDao) {
     super(delegate);
     this.jobDao = jobDao;
+  }
+
+  /**
+   * This method is specialized for returning one level of lineage from a parent job.
+   * It finds all the children of the provided parent node
+   * It then finds the input and output datasets those children write to.
+   * It finally returns the other jobs consuming or producing those datasets (and their parent).
+   * @param parentJobId the parent job
+   * @return 1 level of lineage for all the children jobs of the given parent
+   */
+  public ParentLineage parentDirectLineage(JobId parentJobId) {
+    log.debug("Attempting to get lineage for parent job '{}'", parentJobId);
+
+    Collection<SimpleLineageEdge> directLineageFromParent =
+        getDirectLineageFromParent(parentJobId.getNamespace().getValue(), parentJobId.getName().getValue());
+
+
+    Map<JobId, Map<String, Map<DatasetId, Map<String, List<JobWithParent>>>>> grouped =
+        directLineageFromParent.stream().collect(
+        groupingBy(SimpleLineageEdge::job1,
+            filtering(e -> e.direction() != null,
+            groupingBy(SimpleLineageEdge::direction,
+                filtering(e -> e.dataset() != null,
+                groupingBy(SimpleLineageEdge::dataset,
+                    filtering(e -> e.direction2() != null,
+                    groupingBy(SimpleLineageEdge::direction2,
+                        mapping(e -> new JobWithParent(e.job2(), e.job2parent()),
+                        toList())))))))));
+
+    List<ChildLineage> children = grouped.entrySet().stream().map(
+        e -> new ChildLineage(
+              e.getKey(),
+              toDatasetLineages(e.getValue().get("INPUT")),
+              toDatasetLineages(e.getValue().get("OUTPUT"))
+            )
+      ).collect(toList());
+    return new ParentLineage(parentJobId, children);
+  }
+
+  private Collection<DatasetLineage> toDatasetLineages(Map<DatasetId, Map<String, List<JobWithParent>>> datasets) {
+    return datasets == null ? null : datasets.entrySet().stream().map(
+        e -> new DatasetLineage(
+              e.getKey(),
+              e.getValue().get("INPUT"),
+              e.getValue().get("OUTPUT")
+            )
+      ).collect(toList());
   }
 
   // TODO make input parameters easily extendable if adding more options like 'withJobFacets'

--- a/api/src/main/java/marquez/service/models/EventTypeResolver.java
+++ b/api/src/main/java/marquez/service/models/EventTypeResolver.java
@@ -79,6 +79,7 @@ public class EventTypeResolver extends TypeIdResolverBase {
             .filter(s -> s.getName().equals(type))
             .findAny()
             .map(EventSchemaURL::getSubType)
+            .map(p -> (Class)p)
             .orElse(LINEAGE_EVENT.subType);
 
     return context.constructSpecializedType(superType, subType);

--- a/api/src/test/java/marquez/OpenLineageIntegrationTest.java
+++ b/api/src/test/java/marquez/OpenLineageIntegrationTest.java
@@ -10,23 +10,13 @@ import static marquez.db.LineageTestUtils.SCHEMA_URL;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
-import com.google.common.collect.ImmutableMap;
-import io.dropwizard.util.Resources;
-import io.openlineage.client.OpenLineage;
-import io.openlineage.client.OpenLineage.RunEvent;
-import io.openlineage.client.OpenLineage.RunEvent.EventType;
-import io.openlineage.client.OpenLineage.RunFacet;
-import io.openlineage.client.OpenLineage.RunFacetsBuilder;
 import java.io.IOException;
 import java.net.URI;
+import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.Charset;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -43,6 +33,32 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.jdbi.v3.core.Jdbi;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableMap;
+
+import io.dropwizard.util.Resources;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.client.OpenLineage.RunEvent.EventType;
+import io.openlineage.client.OpenLineage.RunFacet;
+import io.openlineage.client.OpenLineage.RunFacetsBuilder;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import marquez.api.JdbiUtils;
@@ -54,19 +70,12 @@ import marquez.client.models.JobId;
 import marquez.client.models.LineageEvent;
 import marquez.client.models.Run;
 import marquez.common.Utils;
+import marquez.common.models.JobName;
+import marquez.common.models.NamespaceName;
 import marquez.db.LineageTestUtils;
 import marquez.service.models.DatasetEvent;
 import marquez.service.models.JobEvent;
-import org.assertj.core.api.InstanceOfAssertFactories;
-import org.jdbi.v3.core.Jdbi;
-import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.slf4j.LoggerFactory;
+import marquez.service.models.NodeId;
 
 @org.junit.jupiter.api.Tag("IntegrationTests")
 @Slf4j
@@ -316,6 +325,29 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
         .hasFieldOrPropertyWithValue("parentJobName", null);
     List<Run> runsList = client.listRuns(NAMESPACE_NAME, dagName);
     assertThat(runsList).isNotEmpty().hasSize(1);
+
+
+
+    marquez.common.models.JobId jobId = new marquez.common.models.JobId(NamespaceName.of(NAMESPACE_NAME), JobName.of(dagName));
+    String nodeId = NodeId.of(jobId).getValue();
+    HttpRequest request =
+        HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl + "/api/v1/lineage/direct?parentJobNodeId=" + nodeId))
+        .header("Content-Type", "application/json")
+        .GET()
+        .build();
+
+    HttpResponse<String> resp;
+    try {
+      resp = http2.send(request, BodyHandlers.ofString());
+
+      assertEquals(200, resp.statusCode(), resp.body());
+      assertTrue(resp.body().contains("task1"), resp.body());
+      assertTrue(resp.body().contains("task2"), resp.body());
+    } catch (IOException | InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
   }
 
   @Test
@@ -390,6 +422,26 @@ public class OpenLineageIntegrationTest extends BaseIntegrationTest {
         .hasFieldOrPropertyWithValue("parentJobName", null);
     List<Run> runsList = client.listRuns(NAMESPACE_NAME, dagName);
     assertThat(runsList).isNotEmpty().hasSize(1);
+
+    marquez.common.models.JobId jobId = new marquez.common.models.JobId(NamespaceName.of(NAMESPACE_NAME), JobName.of(dagName));
+    String nodeId = NodeId.of(jobId).getValue();
+    HttpRequest request =
+        HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl + "/api/v1/lineage/direct?parentJobNodeId=" + nodeId))
+        .header("Content-Type", "application/json")
+        .GET()
+        .build();
+
+    HttpResponse<String> resp;
+    try {
+      resp = http2.send(request, BodyHandlers.ofString());
+
+      assertEquals(200, resp.statusCode(), resp.body());
+      assertTrue(resp.body().contains("task1"), resp.body());
+      assertTrue(resp.body().contains("task2"), resp.body());
+    } catch (IOException | InterruptedException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Test

--- a/api/src/test/java/marquez/db/LineageDaoTest.java
+++ b/api/src/test/java/marquez/db/LineageDaoTest.java
@@ -165,6 +165,9 @@ public class LineageDaoTest {
           .containsAll(
               expected.getOutput().map(ds -> ds.getDatasetRow().getUuid()).stream()::iterator);
     }
+
+
+    lineageDao.getDirectLineageFromParent("foo", "bar");
   }
 
   @Test


### PR DESCRIPTION
### Problem

The main lineage graph API focuses on individual jobs and is not easy to use when one wants coverage of a all the children of a parent job.

### Solution

This new endpoint provides a non-recursive one level of lineage for all the children of a given parent job.
This will facilitate for example if someone wants to retrieve all the lineage of a given Airflow DAG.
It will return all its children (tasks) and all the datasets they consume or produce as well as the other tasks and DAGs producing and consuming them.

Example:
GET /api/v1/lineage/simple?nodeId=job:default:order_analysis
```
{
  "parent": {
    "namespace": "default",
    "name": "order_analysis"
  },
  "children": [
    {
      "job": {
        "namespace": "default",
        "name": "order_analysis.find_popular_products"
      },
      "inputs": [
        {
          "dataset": {
            "namespace": "postgres://host.docker.internal:5435",
            "name": "postgres.public.orders"
          },
          "consumers": null,
          "producers": [
            {
               "job": {
                "namespace": "default",
                "name": "order_analysis.import_orders"
               },
               "parent": {
                  "namespace": "default", 
                  "name": "order_analysis"
               }
            }
          ]
        }
      ],
     "outputs": [
         ...   
      ]
    ),
    ...
  ]
}
```

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
