### PR TITLE
Update Slack invite links

### DIFF
--- a/CODE_QUALITY_AND_SECURITY.md
+++ b/CODE_QUALITY_AND_SECURITY.md
@@ -26,7 +26,7 @@ The specific security and analysis methodologies that we employ include but are 
 
 For more information about our approach to quality and security, feel free to reach out to the Marquez development team:
 
-- Slack: [Marquezproject.slack.com](http://bit.ly/Marquez_invite)
+- Slack: [Marquezproject.slack.com](http://bit.ly/Mqz_invite)
 - Twitter: [@MarquezProject](https://twitter.com/MarquezProject)
 
 ----

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 We're excited you're interested in contributing to Marquez! We'd love your help, and there are plenty of ways to contribute:
 
 * Give the repo a star
-* Join our [slack](http://bit.ly/Marquez_invite) channel and leave us feedback or help with answering questions from the community
+* Join our [slack](http://bit.ly/Mqz_invite) channel and leave us feedback or help with answering questions from the community
 * Fix or [report](https://github.com/MarquezProject/marquez/issues/new) a bug
 * Fix or improve documentation
 * For newcomers, pick up a ["good first issue"](https://github.com/MarquezProject/marquez/labels/good%20first%20issue), then send a pull request our way (see the [resources](#resources) section below for helpful links to get started)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -100,7 +100,7 @@ Or a meeting may be at an organization's offices that are required to maintain a
 
 ## Marquez on Slack
 
-Marquez uses [a Slack community](https://bit.ly/Marquez_invite) to provide an ongoing dialogue between members.
+Marquez uses [a Slack community](https://bit.ly/Mqz_invite) to provide an ongoing dialogue between members.
 This creates a recorded discussion of design decisions and discussions that complement the project meetings.
 
 Follow the link above and register with the Slack service using your email address.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Marquez is an open source **metadata service** for the **collection**, **aggrega
 [![CircleCI](https://circleci.com/gh/MarquezProject/marquez/tree/main.svg?style=shield)](https://circleci.com/gh/MarquezProject/marquez/tree/main)
 [![codecov](https://codecov.io/gh/MarquezProject/marquez/branch/main/graph/badge.svg)](https://codecov.io/gh/MarquezProject/marquez/branch/main)
 [![status](https://img.shields.io/badge/status-active-brightgreen.svg)](#status)
-[![Slack](https://img.shields.io/badge/slack-chat-blue.svg)](https://bit.ly/Marquez_invite)
+[![Slack](https://img.shields.io/badge/slack-chat-blue.svg)](https://bit.ly/Mqz_invite)
 [![license](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](https://raw.githubusercontent.com/MarquezProject/marquez/main/LICENSE)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 [![maven](https://img.shields.io/maven-central/v/io.github.marquezproject/marquez-api.svg)](https://search.maven.org/search?q=g:io.github.marquezproject)
@@ -160,7 +160,7 @@ Marquez listens on port `8080` for all API calls and port `8081` for the admin i
 
 * Website: https://marquezproject.ai
 * Source: https://github.com/MarquezProject/marquez
-* Chat: [MarquezProject Slack](https://bit.ly/Marquez_invite)
+* Chat: [MarquezProject Slack](https://bit.ly/Mqz_invite)
 * Twitter: [@MarquezProject](https://twitter.com/MarquezProject)
 
 ## Contributing

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -111,7 +111,7 @@ In this simple example, we showed you how to write sample lineage metadata to a 
 
 ## Feedback
 
-What did you think of this guide? You can reach out to us on [slack](http://bit.ly/Marquez_invite) and leave us feedback, or [open a pull request](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#submitting-a-pull-request) with your suggestions!
+What did you think of this guide? You can reach out to us on [slack](http://bit.ly/Mqz_invite) and leave us feedback, or [open a pull request](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#submitting-a-pull-request) with your suggestions!
 
 ----
 SPDX-License-Identifier: Apache-2.0

--- a/docs/v2/blog/2021-07-14-using-marquez-api/index.mdx
+++ b/docs/v2/blog/2021-07-14-using-marquez-api/index.mdx
@@ -550,7 +550,7 @@ For a list of all the available queries and more information about the API, see 
 
 Interested in contributing to the project? Read our guide for new contributors: https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md.
 
-Join us on Slack: http://bit.ly/MarquezSlack.
+Join us on Slack: http://bit.ly/Mqz_invite.
 
 
 

--- a/docs/v2/docusaurus.config.js
+++ b/docs/v2/docusaurus.config.js
@@ -133,7 +133,7 @@ const config = {
                         items: [
                             {
                                 label: 'Slack',
-                                href: 'https://bit.ly/Marquez_invite',
+                                href: 'https://bit.ly/Mqz_invite',
                             },
                             {
                                 label: 'YouTube',

--- a/docs/v2/src/pages/index.tsx
+++ b/docs/v2/src/pages/index.tsx
@@ -33,7 +33,7 @@ function HomepageHeader() {
                             </Link>
                             <Link
                                 className="button button--secondary button--md margin-left--md"
-                                href="https://bit.ly/Marquez_invite">
+                                href="https://bit.ly/Mqz_invite">
                                 Slack
                             </Link>
                         </div>

--- a/examples/airflow/airflow.md
+++ b/examples/airflow/airflow.md
@@ -309,4 +309,4 @@ _Congrats_! You successfully step through a troubleshooting scenario of a failin
 
 # Feedback
 
-What did you think of this example? You can reach out to us on [slack](http://bit.ly/Marquez_invite) and leave us feedback, or [open a pull request](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#submitting-a-pull-request) with your suggestions!
+What did you think of this example? You can reach out to us on [slack](http://bit.ly/Mqz_invite) and leave us feedback, or [open a pull request](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#submitting-a-pull-request) with your suggestions!


### PR DESCRIPTION
### Problem

The Slack invite link expired.

### Solution

Closes: https://github.com/MarquezProject/marquez/issues/2674

One-line summary: Updates the Slack invite link where it appears in the repo and docs.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
