### PR TITLE
upgrade openlineage java

### DIFF
--- a/api/src/test/java/marquez/api/models/ActiveRun.java
+++ b/api/src/test/java/marquez/api/models/ActiveRun.java
@@ -54,7 +54,7 @@ public class ActiveRun {
   }
 
   public void startRun() {
-    olClient.emit(ol.newRunEvent(START, newEventTime(), run, job, inputs, outputs));
+    olClient.emit(ol.newRunEvent(newEventTime(), START, run, job, inputs, outputs));
   }
 
   public void endRun() {
@@ -62,7 +62,7 @@ public class ActiveRun {
   }
 
   public void endRun(@NonNull OpenLineage.RunEvent.EventType eventType) {
-    olClient.emit(ol.newRunEvent(eventType, newEventTime(), run, job, inputs, outputs));
+    olClient.emit(ol.newRunEvent(newEventTime(), eventType, run, job, inputs, outputs));
   }
 
   private static ZonedDateTime newEventTime() {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ subprojects {
         junit5Version = '5.10.0'
         lombokVersion = '1.18.28'
         mockitoVersion = '5.4.0'
-        openlineageVersion = '0.26.0'
+        openlineageVersion = '1.4.1'
         slf4jVersion = '1.7.36'
         postgresqlVersion = '42.6.0'
     }


### PR DESCRIPTION
### Problem

Marquez uses old dependency, with vulnerabilities contained

### Solution

Upgrade the dependency.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
