### PR TITLE
Support streaming jobs in Marquez

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   *Save into Marquez model datasets sent via `DatasetEvent` event type
 * API: support `JobEvent` [`#2661`](https://github.com/MarquezProject/marquez/pull/2661) [@pawel-big-lebowski]( https://github.com/pawel-big-lebowski)
   *Save into Marquez model jobs and datasets sent via `JobEvent` event type.
+* API: support streaming jobs [`#2682`](https://github.com/MarquezProject/marquez/pull/2682) [@pawel-big-lebowski]( https://github.com/pawel-big-lebowski)
+  *Creates job version and reference rows at the beginning of the job instead of on complete. Updates job version within the run if anything changes.
 
 ## [0.42.0](https://github.com/MarquezProject/marquez/compare/0.41.0...0.42.0) - 2023-10-17
 ### Added

--- a/api/src/main/java/marquez/common/Utils.java
+++ b/api/src/main/java/marquez/common/Utils.java
@@ -57,6 +57,9 @@ import marquez.common.models.Version;
 import marquez.service.models.DatasetMeta;
 import marquez.service.models.DbTableMeta;
 import marquez.service.models.LineageEvent;
+import marquez.service.models.LineageEvent.Job;
+import marquez.service.models.LineageEvent.JobFacet;
+import marquez.service.models.LineageEvent.JobTypeJobFacet;
 import marquez.service.models.LineageEvent.ParentRunFacet;
 import marquez.service.models.StreamMeta;
 import org.apache.commons.lang3.tuple.Triple;
@@ -311,6 +314,21 @@ public final class Utils {
             .runId(runId)
             .build();
     return newDatasetVersionFor(data);
+  }
+
+  /**
+   * Verifies if a job is a streaming job.
+   *
+   * @param job
+   * @return
+   */
+  public static boolean isStreamingJob(Job job) {
+    return Optional.ofNullable(job)
+        .map(Job::getFacets)
+        .map(JobFacet::getJobType)
+        .map(JobTypeJobFacet::getProcessingType)
+        .filter(type -> type.equalsIgnoreCase("STREAMING"))
+        .isPresent();
   }
 
   /**

--- a/api/src/main/java/marquez/common/Utils.java
+++ b/api/src/main/java/marquez/common/Utils.java
@@ -57,9 +57,6 @@ import marquez.common.models.Version;
 import marquez.service.models.DatasetMeta;
 import marquez.service.models.DbTableMeta;
 import marquez.service.models.LineageEvent;
-import marquez.service.models.LineageEvent.Job;
-import marquez.service.models.LineageEvent.JobFacet;
-import marquez.service.models.LineageEvent.JobTypeJobFacet;
 import marquez.service.models.LineageEvent.ParentRunFacet;
 import marquez.service.models.StreamMeta;
 import org.apache.commons.lang3.tuple.Triple;
@@ -314,21 +311,6 @@ public final class Utils {
             .runId(runId)
             .build();
     return newDatasetVersionFor(data);
-  }
-
-  /**
-   * Verifies if a job is a streaming job.
-   *
-   * @param job
-   * @return
-   */
-  public static boolean isStreamingJob(Job job) {
-    return Optional.ofNullable(job)
-        .map(Job::getFacets)
-        .map(JobFacet::getJobType)
-        .map(JobTypeJobFacet::getProcessingType)
-        .filter(type -> type.equalsIgnoreCase("STREAMING"))
-        .isPresent();
   }
 
   /**

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -27,7 +27,6 @@ import marquez.common.Utils;
 import marquez.common.models.DatasetId;
 import marquez.common.models.DatasetName;
 import marquez.common.models.DatasetType;
-import marquez.common.models.JobType;
 import marquez.common.models.NamespaceName;
 import marquez.common.models.RunState;
 import marquez.common.models.SourceType;
@@ -169,7 +168,7 @@ public interface OpenLineageDao extends BaseDao {
     UpdateLineageRow updateLineageRow = updateBaseMarquezModel(event, mapper);
     RunState runState = getRunState(event.getEventType());
 
-    if (Utils.isStreamingJob(event.getJob())) {
+    if (event.getJob() != null && event.getJob().isStreamingJob()) {
       updateMarquezOnStreamingJob(event, updateLineageRow, runState);
     } else if (event.getEventType() != null && runState.isDone()) {
       updateMarquezOnComplete(event, updateLineageRow, runState);
@@ -564,7 +563,7 @@ public interface OpenLineageDao extends BaseDao {
                 jobDao.upsertJob(
                     UUID.randomUUID(),
                     parent.getUuid(),
-                    getJobType(job),
+                    job.type(),
                     now,
                     namespace.getUuid(),
                     namespace.getName(),
@@ -577,7 +576,7 @@ public interface OpenLineageDao extends BaseDao {
             () ->
                 jobDao.upsertJob(
                     UUID.randomUUID(),
-                    getJobType(job),
+                    job.type(),
                     now,
                     namespace.getUuid(),
                     namespace.getName(),
@@ -685,7 +684,7 @@ public interface OpenLineageDao extends BaseDao {
         createJobDao()
             .upsertJob(
                 UUID.randomUUID(),
-                getJobType(job),
+                job.type(),
                 now,
                 namespace.getUuid(),
                 namespace.getName(),
@@ -817,10 +816,6 @@ public interface OpenLineageDao extends BaseDao {
 
   default String formatNamespaceName(String namespace) {
     return namespace.replaceAll("[^a-z:/A-Z0-9\\-_.@+]", "_");
-  }
-
-  default JobType getJobType(Job job) {
-    return Utils.isStreamingJob(job) ? JobType.STREAM : JobType.BATCH;
   }
 
   default DatasetRecord upsertLineageDataset(

--- a/api/src/main/java/marquez/service/OpenLineageService.java
+++ b/api/src/main/java/marquez/service/OpenLineageService.java
@@ -144,13 +144,8 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
                   if (event.getEventType() != null) {
                     boolean isStreaming =
                         Optional.ofNullable(event.getJob())
-                            .map(j -> j.getFacets())
-                            .map(f -> f.getJobType())
-                            .map(p -> p.getProcessingType())
-                            .filter(t -> t.equalsIgnoreCase("STREAMING"))
-                            .stream()
-                            .findAny()
-                            .isPresent();
+                            .map(j -> j.isStreamingJob())
+                            .orElse(false);
                     if (event.getEventType().equalsIgnoreCase("COMPLETE") || isStreaming) {
                       buildJobOutputUpdate(update).ifPresent(runService::notify);
                     }

--- a/api/src/main/java/marquez/service/OpenLineageService.java
+++ b/api/src/main/java/marquez/service/OpenLineageService.java
@@ -142,7 +142,16 @@ public class OpenLineageService extends DelegatingDaos.DelegatingOpenLineageDao 
             .thenAccept(
                 (update) -> {
                   if (event.getEventType() != null) {
-                    if (event.getEventType().equalsIgnoreCase("COMPLETE")) {
+                    boolean isStreaming =
+                        Optional.ofNullable(event.getJob())
+                            .map(j -> j.getFacets())
+                            .map(f -> f.getJobType())
+                            .map(p -> p.getProcessingType())
+                            .filter(t -> t.equalsIgnoreCase("STREAMING"))
+                            .stream()
+                            .findAny()
+                            .isPresent();
+                    if (event.getEventType().equalsIgnoreCase("COMPLETE") || isStreaming) {
                       buildJobOutputUpdate(update).ifPresent(runService::notify);
                     }
                     buildJobInputUpdate(update).ifPresent(runService::notify);

--- a/api/src/main/java/marquez/service/RunService.java
+++ b/api/src/main/java/marquez/service/RunService.java
@@ -84,14 +84,14 @@ public class RunService extends DelegatingDaos.DelegatingRunDao {
     runStateDao.updateRunStateFor(runId.getValue(), runState, transitionedAt);
 
     if (runState.isDone()) {
+      JobRow jobRow =
+          jobDao.findJobByNameAsRow(runRow.getNamespaceName(), runRow.getJobName()).orElseThrow();
       BagOfJobVersionInfo bagOfJobVersionInfo =
           jobVersionDao.upsertJobVersionOnRunTransition(
-              jobDao
-                  .findJobByNameAsRow(runRow.getNamespaceName(), runRow.getJobName())
-                  .orElseThrow(),
-              runRow.getUuid(),
+              jobVersionDao.loadJobRowRunDetails(jobRow, runRow.getUuid()),
               runState,
-              transitionedAt);
+              transitionedAt,
+              true);
 
       // TODO: We should also notify that the outputs have been updated when a run is in a done
       // state to be consistent with existing job versioning logic. We'll want to add testing to

--- a/api/src/main/java/marquez/service/models/Job.java
+++ b/api/src/main/java/marquez/service/models/Job.java
@@ -5,6 +5,7 @@
 
 package marquez.service.models;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.net.URL;
 import java.time.Instant;
@@ -41,6 +42,7 @@ public final class Job {
   @Nullable @Setter private Run latestRun;
   @Getter private final ImmutableMap<String, Object> facets;
   @Nullable private UUID currentVersion;
+  @Getter @Nullable private ImmutableList<String> labels;
 
   public Job(
       @NonNull final JobId id,
@@ -56,7 +58,8 @@ public final class Job {
       @Nullable final String description,
       @Nullable final Run latestRun,
       @Nullable final ImmutableMap<String, Object> facets,
-      @Nullable UUID currentVersion) {
+      @Nullable UUID currentVersion,
+      @Nullable ImmutableList<String> labels) {
     this.id = id;
     this.type = type;
     this.name = name;
@@ -72,6 +75,7 @@ public final class Job {
     this.latestRun = latestRun;
     this.facets = (facets == null) ? ImmutableMap.of() : facets;
     this.currentVersion = currentVersion;
+    this.labels = (labels == null) ? ImmutableList.of() : labels;
   }
 
   public Optional<URL> getLocation() {

--- a/api/src/main/java/marquez/service/models/LineageEvent.java
+++ b/api/src/main/java/marquez/service/models/LineageEvent.java
@@ -15,6 +15,7 @@ import java.time.ZonedDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -24,6 +25,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import marquez.common.models.JobType;
 
 /**
  * Requires jackson serialization features: mapper.registerModule(new JavaTimeModule());
@@ -206,6 +208,25 @@ public class LineageEvent extends BaseEvent {
     @NotNull private String namespace;
     @NotNull private String name;
     @Valid private JobFacet facets;
+
+    /**
+     * Verifies if a job is a streaming job.
+     *
+     * @return
+     */
+    @JsonIgnore
+    public boolean isStreamingJob() {
+      return Optional.ofNullable(this.facets)
+          .map(JobFacet::getJobType)
+          .map(JobTypeJobFacet::getProcessingType)
+          .filter(type -> type.equalsIgnoreCase("STREAMING"))
+          .isPresent();
+    }
+
+    @JsonIgnore
+    public JobType type() {
+      return isStreamingJob() ? JobType.STREAM : JobType.BATCH;
+    }
   }
 
   @Builder

--- a/api/src/main/java/marquez/service/models/LineageEvent.java
+++ b/api/src/main/java/marquez/service/models/LineageEvent.java
@@ -214,19 +214,13 @@ public class LineageEvent extends BaseEvent {
   @Setter
   @Valid
   @ToString
-  @JsonPropertyOrder({
-    "documentation",
-    "sourceCodeLocation",
-    "sql",
-    "description",
-    "processingType"
-  })
+  @JsonPropertyOrder({"documentation", "sourceCodeLocation", "sql", "description", "jobType"})
   public static class JobFacet {
 
     @Valid private DocumentationJobFacet documentation;
     @Valid private SourceCodeLocationJobFacet sourceCodeLocation;
     @Valid private SQLJobFacet sql;
-    @Valid private ProcessingTypeJobFacet processingType;
+    @Valid private JobTypeJobFacet jobType;
     @Builder.Default @JsonIgnore private Map<String, Object> additional = new LinkedHashMap<>();
 
     @JsonAnySetter
@@ -247,8 +241,8 @@ public class LineageEvent extends BaseEvent {
       return sourceCodeLocation;
     }
 
-    public ProcessingTypeJobFacet getProcessingTypeJobFacet() {
-      return processingType;
+    public JobTypeJobFacet getJobType() {
+      return jobType;
     }
 
     public SQLJobFacet getSql() {
@@ -308,21 +302,28 @@ public class LineageEvent extends BaseEvent {
     }
   }
 
-  // TODO: make it up to date with https://github.com/OpenLineage/OpenLineage/pull/2241/files
   @NoArgsConstructor
   @Getter
   @Setter
   @Valid
   @ToString
-  public static class ProcessingTypeJobFacet extends BaseFacet {
+  public static class JobTypeJobFacet extends BaseFacet {
 
     @NotNull private String processingType;
+    @NotNull private String integration;
+    @NotNull private String jobType;
 
     @Builder
-    public ProcessingTypeJobFacet(
-        @NotNull URI _producer, @NotNull URI _schemaURL, @NotNull String processingType) {
+    public JobTypeJobFacet(
+        @NotNull URI _producer,
+        @NotNull URI _schemaURL,
+        @NotNull String processingType,
+        @NotNull String integration,
+        @NotNull String jobType) {
       super(_producer, _schemaURL);
       this.processingType = processingType;
+      this.integration = integration;
+      this.jobType = jobType;
     }
   }
 

--- a/api/src/main/java/marquez/service/models/LineageEvent.java
+++ b/api/src/main/java/marquez/service/models/LineageEvent.java
@@ -214,12 +214,19 @@ public class LineageEvent extends BaseEvent {
   @Setter
   @Valid
   @ToString
-  @JsonPropertyOrder({"documentation", "sourceCodeLocation", "sql", "description"})
+  @JsonPropertyOrder({
+    "documentation",
+    "sourceCodeLocation",
+    "sql",
+    "description",
+    "processingType"
+  })
   public static class JobFacet {
 
     @Valid private DocumentationJobFacet documentation;
     @Valid private SourceCodeLocationJobFacet sourceCodeLocation;
     @Valid private SQLJobFacet sql;
+    @Valid private ProcessingTypeJobFacet processingType;
     @Builder.Default @JsonIgnore private Map<String, Object> additional = new LinkedHashMap<>();
 
     @JsonAnySetter
@@ -238,6 +245,10 @@ public class LineageEvent extends BaseEvent {
 
     public SourceCodeLocationJobFacet getSourceCodeLocation() {
       return sourceCodeLocation;
+    }
+
+    public ProcessingTypeJobFacet getProcessingTypeJobFacet() {
+      return processingType;
     }
 
     public SQLJobFacet getSql() {
@@ -294,6 +305,24 @@ public class LineageEvent extends BaseEvent {
     public SQLJobFacet(@NotNull URI _producer, @NotNull URI _schemaURL, @NotNull String query) {
       super(_producer, _schemaURL);
       this.query = query;
+    }
+  }
+
+  // TODO: make it up to date with https://github.com/OpenLineage/OpenLineage/pull/2241/files
+  @NoArgsConstructor
+  @Getter
+  @Setter
+  @Valid
+  @ToString
+  public static class ProcessingTypeJobFacet extends BaseFacet {
+
+    @NotNull private String processingType;
+
+    @Builder
+    public ProcessingTypeJobFacet(
+        @NotNull URI _producer, @NotNull URI _schemaURL, @NotNull String processingType) {
+      super(_producer, _schemaURL);
+      this.processingType = processingType;
     }
   }
 

--- a/api/src/test/java/marquez/ColumnLineageIntegrationTest.java
+++ b/api/src/test/java/marquez/ColumnLineageIntegrationTest.java
@@ -23,6 +23,7 @@ import marquez.db.LineageTestUtils;
 import marquez.db.OpenLineageDao;
 import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
 import marquez.service.models.LineageEvent;
+import marquez.service.models.LineageEvent.JobFacet;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,8 +38,7 @@ public class ColumnLineageIntegrationTest extends BaseIntegrationTest {
   public void setup(Jdbi jdbi) {
     OpenLineageDao openLineageDao = jdbi.onDemand(OpenLineageDao.class);
 
-    LineageEvent.JobFacet jobFacet =
-        new LineageEvent.JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    LineageEvent.JobFacet jobFacet = JobFacet.builder().build();
 
     LineageEvent.Dataset dataset_A = getDatasetA();
     LineageEvent.Dataset dataset_B = getDatasetB();

--- a/api/src/test/java/marquez/db/BackfillTestUtils.java
+++ b/api/src/test/java/marquez/db/BackfillTestUtils.java
@@ -115,9 +115,7 @@ public class BackfillTestUtils {
                         nominalTimeRunFacet,
                         parentRun.orElse(null),
                         ImmutableMap.of("airflow_version", ImmutableMap.of("version", "abc")))))
-            .job(
-                new LineageEvent.Job(
-                    NAMESPACE, jobName, new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP)))
+            .job(new LineageEvent.Job(NAMESPACE, jobName, JobFacet.builder().build()))
             .inputs(
                 Collections.singletonList(
                     new LineageEvent.Dataset(

--- a/api/src/test/java/marquez/db/ColumnLineageTestUtils.java
+++ b/api/src/test/java/marquez/db/ColumnLineageTestUtils.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 import marquez.api.JdbiUtils;
 import marquez.db.models.UpdateLineageRow;
 import marquez.service.models.LineageEvent;
+import marquez.service.models.LineageEvent.JobFacet;
 import org.jdbi.v3.core.Jdbi;
 
 public class ColumnLineageTestUtils {
@@ -110,8 +111,7 @@ public class ColumnLineageTestUtils {
 
   public static UpdateLineageRow createLineage(
       OpenLineageDao openLineageDao, LineageEvent.Dataset input, LineageEvent.Dataset output) {
-    LineageEvent.JobFacet jobFacet =
-        new LineageEvent.JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    LineageEvent.JobFacet jobFacet = JobFacet.builder().build();
     return LineageTestUtils.createLineageRow(
         openLineageDao,
         "job_" + UUID.randomUUID(),

--- a/api/src/test/java/marquez/db/DatasetDaoTest.java
+++ b/api/src/test/java/marquez/db/DatasetDaoTest.java
@@ -41,7 +41,7 @@ class DatasetDaoTest {
   private static DatasetDao datasetDao;
   private static OpenLineageDao openLineageDao;
 
-  private final JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+  private final JobFacet jobFacet = JobFacet.builder().build();
 
   static Jdbi jdbi;
 

--- a/api/src/test/java/marquez/db/DatasetFacetsDaoTest.java
+++ b/api/src/test/java/marquez/db/DatasetFacetsDaoTest.java
@@ -20,6 +20,7 @@ import marquez.db.models.UpdateLineageRow;
 import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
 import marquez.service.models.LineageEvent;
 import marquez.service.models.LineageEvent.Dataset;
+import marquez.service.models.LineageEvent.JobFacet;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -308,8 +309,7 @@ public class DatasetFacetsDaoTest {
 
   @Test
   public void testInsertOutputDatasetFacetsFor() {
-    LineageEvent.JobFacet jobFacet =
-        new LineageEvent.JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    LineageEvent.JobFacet jobFacet = JobFacet.builder().build();
 
     UpdateLineageRow lineageRow =
         LineageTestUtils.createLineageRow(
@@ -340,8 +340,7 @@ public class DatasetFacetsDaoTest {
 
   @Test
   public void testInsertInputDatasetFacetsFor() {
-    LineageEvent.JobFacet jobFacet =
-        new LineageEvent.JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    LineageEvent.JobFacet jobFacet = JobFacet.builder().build();
 
     UpdateLineageRow lineageRow =
         LineageTestUtils.createLineageRow(
@@ -372,8 +371,7 @@ public class DatasetFacetsDaoTest {
 
   private UpdateLineageRow createLineageRowWithInputDataset(
       LineageEvent.DatasetFacets.DatasetFacetsBuilder inputDatasetFacetsbuilder) {
-    LineageEvent.JobFacet jobFacet =
-        new LineageEvent.JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    LineageEvent.JobFacet jobFacet = JobFacet.builder().build();
 
     return LineageTestUtils.createLineageRow(
         openLineageDao,
@@ -389,8 +387,7 @@ public class DatasetFacetsDaoTest {
 
   private UpdateLineageRow createLineageRowWithOutputDataset(
       LineageEvent.DatasetFacets.DatasetFacetsBuilder outputDatasetFacetsbuilder) {
-    LineageEvent.JobFacet jobFacet =
-        new LineageEvent.JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    LineageEvent.JobFacet jobFacet = JobFacet.builder().build();
 
     return LineageTestUtils.createLineageRow(
         openLineageDao,

--- a/api/src/test/java/marquez/db/FacetTestUtils.java
+++ b/api/src/test/java/marquez/db/FacetTestUtils.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.UUID;
 import marquez.db.models.UpdateLineageRow;
 import marquez.service.models.LineageEvent;
+import marquez.service.models.LineageEvent.JobFacet;
 import org.apache.commons.lang3.StringUtils;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
@@ -20,14 +21,20 @@ public class FacetTestUtils {
 
   public static UpdateLineageRow createLineageWithFacets(OpenLineageDao openLineageDao) {
     LineageEvent.JobFacet jobFacet =
-        new LineageEvent.JobFacet(
-            new LineageEvent.DocumentationJobFacet(PRODUCER_URL, SCHEMA_URL, "some-documentation"),
-            new LineageEvent.SourceCodeLocationJobFacet(
-                PRODUCER_URL, SCHEMA_URL, "git", "git@github.com:OpenLineage/OpenLineage.git"),
-            new LineageEvent.SQLJobFacet(PRODUCER_URL, SCHEMA_URL, "some sql query"),
-            Map.of(
-                "ownership", "some-owner",
-                "sourceCode", "some-code"));
+        JobFacet.builder()
+            .documentation(
+                new LineageEvent.DocumentationJobFacet(
+                    PRODUCER_URL, SCHEMA_URL, "some-documentation"))
+            .sourceCodeLocation(
+                new LineageEvent.SourceCodeLocationJobFacet(
+                    PRODUCER_URL, SCHEMA_URL, "git", "git@github.com:OpenLineage/OpenLineage.git"))
+            .sql(new LineageEvent.SQLJobFacet(PRODUCER_URL, SCHEMA_URL, "some sql query"))
+            .additional(
+                Map.of(
+                    "ownership", "some-owner",
+                    "sourceCode", "some-code"))
+            .build();
+
     return LineageTestUtils.createLineageRow(
         openLineageDao,
         "job_" + UUID.randomUUID(),

--- a/api/src/test/java/marquez/db/JobFacetsDaoTest.java
+++ b/api/src/test/java/marquez/db/JobFacetsDaoTest.java
@@ -18,6 +18,7 @@ import marquez.api.JdbiUtils;
 import marquez.db.models.UpdateLineageRow;
 import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
 import marquez.service.models.LineageEvent;
+import marquez.service.models.LineageEvent.JobFacet;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -63,12 +64,14 @@ public class JobFacetsDaoTest {
             openLineageDao,
             "job_" + UUID.randomUUID(),
             "COMPLETE",
-            new LineageEvent.JobFacet(
-                null,
-                new LineageEvent.SourceCodeLocationJobFacet(
-                    PRODUCER_URL, SCHEMA_URL, "git", "git@github.com:OpenLineage/OpenLineage.git"),
-                null,
-                LineageTestUtils.EMPTY_MAP),
+            JobFacet.builder()
+                .sourceCodeLocation(
+                    new LineageEvent.SourceCodeLocationJobFacet(
+                        PRODUCER_URL,
+                        SCHEMA_URL,
+                        "git",
+                        "git@github.com:OpenLineage/OpenLineage.git"))
+                .build(),
             Collections.emptyList(),
             Collections.emptyList());
 
@@ -88,12 +91,16 @@ public class JobFacetsDaoTest {
   @Test
   public void testGetFacetsByRunUuid() {
     LineageEvent.JobFacet jobFacet =
-        new LineageEvent.JobFacet(
-            new LineageEvent.DocumentationJobFacet(PRODUCER_URL, SCHEMA_URL, "some-documentation"),
-            new LineageEvent.SourceCodeLocationJobFacet(
-                PRODUCER_URL, SCHEMA_URL, "git", "git@github.com:OpenLineage/OpenLineage.git"),
-            new LineageEvent.SQLJobFacet(PRODUCER_URL, SCHEMA_URL, "some sql query"),
-            null);
+        JobFacet.builder()
+            .documentation(
+                new LineageEvent.DocumentationJobFacet(
+                    PRODUCER_URL, SCHEMA_URL, "some-documentation"))
+            .sourceCodeLocation(
+                new LineageEvent.SourceCodeLocationJobFacet(
+                    PRODUCER_URL, SCHEMA_URL, "git", "git@github.com:OpenLineage/OpenLineage.git"))
+            .sql(new LineageEvent.SQLJobFacet(PRODUCER_URL, SCHEMA_URL, "some sql query"))
+            .build();
+
     UpdateLineageRow lineageRow =
         LineageTestUtils.createLineageRow(
             openLineageDao,

--- a/api/src/test/java/marquez/db/JobVersionDaoTest.java
+++ b/api/src/test/java/marquez/db/JobVersionDaoTest.java
@@ -242,7 +242,10 @@ public class JobVersionDaoTest extends BaseIntegrationTest {
             jdbiForTesting, runRow.getUuid(), RunState.COMPLETED, jobMeta.getOutputs());
 
     jobVersionDao.upsertJobVersionOnRunTransition(
-        jobRow, runRow.getUuid(), RunState.COMPLETED, Instant.now());
+        jobVersionDao.loadJobRowRunDetails(jobRow, runRow.getUuid()),
+        RunState.COMPLETED,
+        Instant.now(),
+        true);
 
     List<JobVersion> jobVersions =
         jobVersionDao.findAllJobVersions(namespaceRow.getName(), jobRow.getName(), 10, 0);
@@ -311,7 +314,10 @@ public class JobVersionDaoTest extends BaseIntegrationTest {
     // (6) Add a new job version on the run state transition to COMPLETED.
     final BagOfJobVersionInfo bagOfJobVersionInfo =
         jobVersionDao.upsertJobVersionOnRunTransition(
-            jobRow, runRow.getUuid(), RunState.COMPLETED, newTimestamp());
+            jobVersionDao.loadJobRowRunDetails(jobRow, runRow.getUuid()),
+            RunState.COMPLETED,
+            newTimestamp(),
+            true);
 
     // Ensure the job version is associated with the latest run.
     final RunRow latestRunRowForJobVersion = runDao.findRunByUuidAsRow(runRow.getUuid()).get();

--- a/api/src/test/java/marquez/db/LineageDaoTest.java
+++ b/api/src/test/java/marquez/db/LineageDaoTest.java
@@ -67,7 +67,7 @@ public class LineageDaoTest {
               new SchemaField("firstname", "string", "the first name"),
               new SchemaField("lastname", "string", "the last name"),
               new SchemaField("birthdate", "date", "the date of birth")));
-  private final JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+  private final JobFacet jobFacet = JobFacet.builder().build();
 
   static Jdbi jdbi;
 
@@ -393,7 +393,7 @@ public class LineageDaoTest {
   /** A failed consumer job doesn't show up in the datasets out edges */
   @Test
   public void testGetLineageWithFailedConsumer() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
 
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
@@ -513,7 +513,7 @@ public class LineageDaoTest {
   /** A failed producer job doesn't show up in the lineage */
   @Test
   public void testGetLineageWithFailedProducer() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
 
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
@@ -542,7 +542,7 @@ public class LineageDaoTest {
   /** A failed producer job doesn't show up in the lineage */
   @Test
   public void testGetLineageChangedJobVersion() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
 
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
@@ -568,7 +568,7 @@ public class LineageDaoTest {
 
   @Test
   public void testGetJobFromInputOrOutput() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
 
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
@@ -592,7 +592,7 @@ public class LineageDaoTest {
 
   @Test
   public void testGetJobFromInputOrOutputPrefersRecentOutputJob() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
 
     // add some consumer jobs prior to the write so we know that the sort isn't simply picking
     // the first job created

--- a/api/src/test/java/marquez/db/OpenLineageDaoTest.java
+++ b/api/src/test/java/marquez/db/OpenLineageDaoTest.java
@@ -73,7 +73,7 @@ class OpenLineageDaoTest {
   /** When reading a dataset, the version is assumed to be the version last written */
   @Test
   void testUpdateMarquezModel() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
             dao,
@@ -117,11 +117,9 @@ class OpenLineageDaoTest {
   @Test
   void testUpdateMarquezModelWithJobEvent() {
     JobFacet jobFacet =
-        new JobFacet(
-            DocumentationJobFacet.builder().description("documentation").build(),
-            null,
-            null,
-            LineageTestUtils.EMPTY_MAP);
+        JobFacet.builder()
+            .documentation(DocumentationJobFacet.builder().description("documentation").build())
+            .build();
 
     Job job = new Job(NAMESPACE, READ_JOB_NAME, jobFacet);
 
@@ -183,7 +181,7 @@ class OpenLineageDaoTest {
                         PRODUCER_URL, SCHEMA_URL, "TRUNCATE"))
                 .build());
 
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
             dao, WRITE_JOB_NAME, "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList(dataset));
@@ -195,7 +193,7 @@ class OpenLineageDaoTest {
 
   @Test
   void testUpdateMarquezModelDatasetWithColumnLineageFacet() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
             dao,
@@ -247,7 +245,7 @@ class OpenLineageDaoTest {
 
   @Test
   void testUpdateMarquezModelDatasetWithColumnLineageFacetWhenInputFieldDoesNotExist() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
             dao,
@@ -283,7 +281,7 @@ class OpenLineageDaoTest {
                                     TRANSFORMATION_TYPE)))))
                 .build());
 
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
             dao,
@@ -334,7 +332,7 @@ class OpenLineageDaoTest {
                                     UPDATED_TRANSFORMATION_TYPE)))))
                 .build());
 
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
     UpdateLineageRow writeJob1 =
         LineageTestUtils.createLineageRow(
             dao,
@@ -385,7 +383,7 @@ class OpenLineageDaoTest {
                                 "symlinkNamespace", "symlinkName", "some-type"))))
                 .build());
 
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
             dao, WRITE_JOB_NAME, "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList(dataset));
@@ -425,7 +423,7 @@ class OpenLineageDaoTest {
    */
   @Test
   void testUpdateMarquezModelWithInputOnlyDataset() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
             dao,
@@ -449,7 +447,7 @@ class OpenLineageDaoTest {
    */
   @Test
   void testUpdateMarquezModelWithNonMatchingReadSchema() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
             dao,
@@ -496,7 +494,7 @@ class OpenLineageDaoTest {
    */
   @Test
   void testUpdateMarquezModelWithPriorWrites() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
     UpdateLineageRow writeJob1 =
         LineageTestUtils.createLineageRow(
             dao,
@@ -569,7 +567,7 @@ class OpenLineageDaoTest {
 
   @Test
   void testGetOpenLineageEvents() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
     UpdateLineageRow writeJob =
         LineageTestUtils.createLineageRow(
             dao,
@@ -590,7 +588,7 @@ class OpenLineageDaoTest {
 
   @Test
   void testInputOutputDatasetFacets() {
-    JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    JobFacet jobFacet = JobFacet.builder().build();
     UpdateLineageRow lineageRow =
         LineageTestUtils.createLineageRow(
             dao,

--- a/api/src/test/java/marquez/db/RunDaoTest.java
+++ b/api/src/test/java/marquez/db/RunDaoTest.java
@@ -83,7 +83,10 @@ class RunDaoTest {
         jdbi, runRow.getUuid(), RunState.COMPLETED, jobMeta.getOutputs());
 
     jobVersionDao.upsertJobVersionOnRunTransition(
-        jobRow, runRow.getUuid(), RunState.COMPLETED, Instant.now());
+        jobVersionDao.loadJobRowRunDetails(jobRow, runRow.getUuid()),
+        RunState.COMPLETED,
+        Instant.now(),
+        true);
 
     Optional<Run> run = runDao.findRunByUuid(runRow.getUuid());
     assertThat(run)
@@ -198,7 +201,10 @@ class RunDaoTest {
                   jdbi, runRow.getUuid(), RunState.COMPLETED, outputs);
 
               jobVersionDao.upsertJobVersionOnRunTransition(
-                  jobRow, runRow.getUuid(), RunState.COMPLETED, Instant.now());
+                  jobVersionDao.loadJobRowRunDetails(jobRow, runRow.getUuid()),
+                  RunState.COMPLETED,
+                  Instant.now(),
+                  true);
               return runRow;
             });
   }

--- a/api/src/test/java/marquez/db/RunFacetsDaoTest.java
+++ b/api/src/test/java/marquez/db/RunFacetsDaoTest.java
@@ -58,7 +58,7 @@ public class RunFacetsDaoTest {
             openLineageDao,
             "job_" + UUID.randomUUID(),
             "COMPLETE",
-            new LineageEvent.JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP),
+            JobFacet.builder().build(),
             Collections.emptyList(),
             Collections.emptyList(),
             new LineageEvent.ParentRunFacet(
@@ -112,7 +112,7 @@ public class RunFacetsDaoTest {
         openLineageDao,
         "job_" + UUID.randomUUID(),
         "COMPLETE",
-        new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP),
+        JobFacet.builder().build(),
         Collections.emptyList(),
         Collections.emptyList(),
         new ParentRunFacet(
@@ -164,12 +164,16 @@ public class RunFacetsDaoTest {
   @Test
   public void testGetFacetsByRunUuid() {
     LineageEvent.JobFacet jobFacet =
-        new LineageEvent.JobFacet(
-            new LineageEvent.DocumentationJobFacet(PRODUCER_URL, SCHEMA_URL, "some-documentation"),
-            new LineageEvent.SourceCodeLocationJobFacet(
-                PRODUCER_URL, SCHEMA_URL, "git", "git@github.com:OpenLineage/OpenLineage.git"),
-            new LineageEvent.SQLJobFacet(PRODUCER_URL, SCHEMA_URL, "some sql query"),
-            null);
+        JobFacet.builder()
+            .documentation(
+                new LineageEvent.DocumentationJobFacet(
+                    PRODUCER_URL, SCHEMA_URL, "some-documentation"))
+            .sourceCodeLocation(
+                new LineageEvent.SourceCodeLocationJobFacet(
+                    PRODUCER_URL, SCHEMA_URL, "git", "git@github.com:OpenLineage/OpenLineage.git"))
+            .sql(new LineageEvent.SQLJobFacet(PRODUCER_URL, SCHEMA_URL, "some sql query"))
+            .build();
+
     UpdateLineageRow lineageRow =
         LineageTestUtils.createLineageRow(
             openLineageDao,

--- a/api/src/test/java/marquez/db/migrations/V57_1__BackfillFacetsTest.java
+++ b/api/src/test/java/marquez/db/migrations/V57_1__BackfillFacetsTest.java
@@ -28,6 +28,7 @@ import marquez.db.OpenLineageDao;
 import marquez.db.models.UpdateLineageRow;
 import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
 import marquez.service.models.LineageEvent;
+import marquez.service.models.LineageEvent.JobFacet;
 import org.flywaydb.core.api.migration.Context;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.AfterEach;
@@ -167,8 +168,7 @@ public class V57_1__BackfillFacetsTest {
 
   @Test
   public void testMigrateForLineageWithNoDatasets() throws Exception {
-    LineageEvent.JobFacet jobFacet =
-        new LineageEvent.JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    LineageEvent.JobFacet jobFacet = LineageEvent.JobFacet.builder().build();
     LineageTestUtils.createLineageRow(
         openLineageDao,
         "job_" + UUID.randomUUID(),

--- a/api/src/test/java/marquez/service/ColumnLineageServiceTest.java
+++ b/api/src/test/java/marquez/service/ColumnLineageServiceTest.java
@@ -41,6 +41,7 @@ import marquez.service.models.ColumnLineageInputField;
 import marquez.service.models.Dataset;
 import marquez.service.models.Lineage;
 import marquez.service.models.LineageEvent;
+import marquez.service.models.LineageEvent.JobFacet;
 import marquez.service.models.Node;
 import marquez.service.models.NodeId;
 import org.jdbi.v3.core.Jdbi;
@@ -70,7 +71,7 @@ public class ColumnLineageServiceTest {
     fieldDao = jdbi.onDemand(DatasetFieldDao.class);
     datasetDao = jdbi.onDemand(DatasetDao.class);
     lineageService = new ColumnLineageService(dao, fieldDao);
-    jobFacet = new LineageEvent.JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
+    jobFacet = JobFacet.builder().build();
   }
 
   @AfterEach

--- a/api/src/test/java/marquez/service/LineageServiceTest.java
+++ b/api/src/test/java/marquez/service/LineageServiceTest.java
@@ -6,17 +6,21 @@
 package marquez.service;
 
 import static marquez.db.LineageTestUtils.NAMESPACE;
+import static marquez.db.LineageTestUtils.PRODUCER_URL;
+import static marquez.db.LineageTestUtils.SCHEMA_URL;
 import static marquez.db.LineageTestUtils.newDatasetFacet;
 import static marquez.db.LineageTestUtils.writeDownstreamLineage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import marquez.api.JdbiUtils;
+import marquez.common.models.DatasetId;
 import marquez.common.models.DatasetName;
 import marquez.common.models.InputDatasetVersion;
 import marquez.common.models.JobId;
@@ -39,6 +43,7 @@ import marquez.service.models.JobData;
 import marquez.service.models.Lineage;
 import marquez.service.models.LineageEvent.Dataset;
 import marquez.service.models.LineageEvent.JobFacet;
+import marquez.service.models.LineageEvent.ProcessingTypeJobFacet;
 import marquez.service.models.LineageEvent.SchemaField;
 import marquez.service.models.Node;
 import marquez.service.models.NodeId;
@@ -71,8 +76,7 @@ public class LineageServiceTest {
               new SchemaField("firstname", "string", "the first name"),
               new SchemaField("lastname", "string", "the last name"),
               new SchemaField("birthdate", "date", "the date of birth")));
-  private final JobFacet jobFacet = new JobFacet(null, null, null, LineageTestUtils.EMPTY_MAP);
-
+  private final JobFacet jobFacet = JobFacet.builder().build();
   static Jdbi jdbi;
 
   @BeforeAll
@@ -423,6 +427,59 @@ public class LineageServiceTest {
         .first()
         .extracting(Edge::getDestination)
         .matches(n -> n.isJobType() && n.asJobId().getName().getValue().equals("writeJob"));
+  }
+
+  @Test
+  public void testGetLineageForRunningStreamingJob() {
+    Dataset input = Dataset.builder().name("input-dataset").namespace(NAMESPACE).build();
+    Dataset output = Dataset.builder().name("output-dataset").namespace(NAMESPACE).build();
+
+    // (1) Run batch job which outputs input-dataset
+    LineageTestUtils.createLineageRow(
+        openLineageDao,
+        "someInputBatchJob",
+        "COMPLETE",
+        jobFacet,
+        Collections.emptyList(),
+        Arrays.asList(input));
+
+    // (2) Run streaming job on the reading output of this job
+    LineageTestUtils.createLineageRow(
+        openLineageDao,
+        "streamingjob",
+        "RUNNING",
+        JobFacet.builder()
+            .processingType(new ProcessingTypeJobFacet(PRODUCER_URL, SCHEMA_URL, "STREAMING"))
+            .build(),
+        Arrays.asList(input),
+        Arrays.asList(output));
+
+    // (3) Run batch job that reads output of streaming job (Note: streaming job is still running)
+    LineageTestUtils.createLineageRow(
+        openLineageDao,
+        "someOutputBatchJob",
+        "COMPLETE",
+        jobFacet,
+        Arrays.asList(output),
+        Collections.emptyList());
+
+    // (4) lineage on output dataset shall be same as lineage on input dataset
+    Lineage lineageFromInput =
+        lineageService.lineage(
+            NodeId.of(
+                new DatasetId(new NamespaceName(NAMESPACE), new DatasetName("input-dataset"))),
+            5,
+            true);
+
+    Lineage lineageFromOutput =
+        lineageService.lineage(
+            NodeId.of(
+                new DatasetId(new NamespaceName(NAMESPACE), new DatasetName("output-dataset"))),
+            5,
+            true);
+
+    assertThat(lineageFromInput.getGraph()).hasSize(5); // 2 datasets + 3 jobs
+    assertThat(lineageFromInput.getGraph()).isEqualTo(lineageFromOutput.getGraph());
   }
 
   @Test

--- a/api/src/test/java/marquez/service/LineageServiceTest.java
+++ b/api/src/test/java/marquez/service/LineageServiceTest.java
@@ -6,8 +6,6 @@
 package marquez.service;
 
 import static marquez.db.LineageTestUtils.NAMESPACE;
-import static marquez.db.LineageTestUtils.PRODUCER_URL;
-import static marquez.db.LineageTestUtils.SCHEMA_URL;
 import static marquez.db.LineageTestUtils.newDatasetFacet;
 import static marquez.db.LineageTestUtils.writeDownstreamLineage;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,7 +41,7 @@ import marquez.service.models.JobData;
 import marquez.service.models.Lineage;
 import marquez.service.models.LineageEvent.Dataset;
 import marquez.service.models.LineageEvent.JobFacet;
-import marquez.service.models.LineageEvent.ProcessingTypeJobFacet;
+import marquez.service.models.LineageEvent.JobTypeJobFacet;
 import marquez.service.models.LineageEvent.SchemaField;
 import marquez.service.models.Node;
 import marquez.service.models.NodeId;
@@ -449,7 +447,7 @@ public class LineageServiceTest {
         "streamingjob",
         "RUNNING",
         JobFacet.builder()
-            .processingType(new ProcessingTypeJobFacet(PRODUCER_URL, SCHEMA_URL, "STREAMING"))
+            .jobType(JobTypeJobFacet.builder().processingType("STREAMING").build())
             .build(),
         Arrays.asList(input),
         Arrays.asList(output));

--- a/api/src/test/java/marquez/service/OpenLineageServiceIntegrationTest.java
+++ b/api/src/test/java/marquez/service/OpenLineageServiceIntegrationTest.java
@@ -605,7 +605,7 @@ public class OpenLineageServiceIntegrationTest {
     // (3) Assert that output is present and has dataset_version written
     assertThat(datasetRow).isPresent().flatMap(Dataset::getCurrentVersion).isPresent();
 
-    // (4) Assert that job is present although job_version entry is not
+    // (4) Assert that job is present and its current version is present
     Job job = jobDao.findJobByName(NAMESPACE, "streaming_job_name").get();
     assertThat(job.getInputs()).hasSize(1);
     assertThat(job.getCurrentVersion()).isPresent();

--- a/api/src/test/java/marquez/service/OpenLineageServiceIntegrationTest.java
+++ b/api/src/test/java/marquez/service/OpenLineageServiceIntegrationTest.java
@@ -36,6 +36,7 @@ import marquez.common.models.RunState;
 import marquez.db.DatasetDao;
 import marquez.db.DatasetVersionDao;
 import marquez.db.JobDao;
+import marquez.db.JobVersionDao;
 import marquez.db.NamespaceDao;
 import marquez.db.OpenLineageDao;
 import marquez.db.RunArgsDao;
@@ -57,7 +58,8 @@ import marquez.service.models.LineageEvent;
 import marquez.service.models.LineageEvent.DatasetFacets;
 import marquez.service.models.LineageEvent.DatasourceDatasetFacet;
 import marquez.service.models.LineageEvent.JobFacet;
-import marquez.service.models.LineageEvent.ProcessingTypeJobFacet;
+import marquez.service.models.LineageEvent.JobTypeJobFacet;
+import marquez.service.models.LineageEvent.LineageEventBuilder;
 import marquez.service.models.LineageEvent.RunFacet;
 import marquez.service.models.LineageEvent.SQLJobFacet;
 import marquez.service.models.LineageEvent.SchemaDatasetFacet;
@@ -85,8 +87,9 @@ public class OpenLineageServiceIntegrationTest {
 
   private JobService jobService;
   private OpenLineageDao openLineageDao;
-
+  private Jdbi jdbi;
   private JobDao jobDao;
+  private JobVersionDao jobVersionDao;
   private DatasetDao datasetDao;
   private DatasetVersionDao datasetVersionDao;
   private ArgumentCaptor<JobInputUpdate> runInputListener;
@@ -149,9 +152,11 @@ public class OpenLineageServiceIntegrationTest {
 
   @BeforeEach
   public void setup(Jdbi jdbi) throws SQLException {
+    this.jdbi = jdbi;
     openLineageDao = jdbi.onDemand(OpenLineageDao.class);
     datasetVersionDao = jdbi.onDemand(DatasetVersionDao.class);
     jobDao = jdbi.onDemand(JobDao.class);
+    jobVersionDao = jdbi.onDemand(JobVersionDao.class);
     runService = mock(RunService.class);
     jobService = new JobService(jobDao, runService);
     runInputListener = ArgumentCaptor.forClass(JobInputUpdate.class);
@@ -550,8 +555,12 @@ public class OpenLineageServiceIntegrationTest {
   }
 
   @Test
-  void testStreamingJob() {
-    LineageEvent.Dataset dataset =
+  void testStreamingJob() throws ExecutionException, InterruptedException {
+    // (1) Create output
+    LineageEvent.Dataset input =
+        LineageEvent.Dataset.builder().name(DATASET_NAME).namespace(NAMESPACE).build();
+
+    LineageEvent.Dataset output =
         LineageEvent.Dataset.builder()
             .name(DATASET_NAME)
             .namespace(NAMESPACE)
@@ -562,44 +571,153 @@ public class OpenLineageServiceIntegrationTest {
                             PRODUCER_URL,
                             SCHEMA_URL,
                             Arrays.asList(new SchemaField("col", "STRING", "my name"))))
-                    .dataSource(
-                        DatasourceDatasetFacet.builder()
-                            .name("theDatasource")
-                            .uri("http://thedatasource")
-                            .build())
                     .build())
             .build();
 
-    // Streaming job not followed by a COMPLETE event
+    // (2) Streaming job not followed by a COMPLETE event writing to a output
     UUID firstRunId = UUID.randomUUID();
-    lineageService.createAsync(
+    lineageService
+        .createAsync(
+            LineageEvent.builder()
+                .eventType("RUNNING")
+                .run(new LineageEvent.Run(firstRunId.toString(), RunFacet.builder().build()))
+                .job(
+                    LineageEvent.Job.builder()
+                        .name("streaming_job_name")
+                        .namespace(NAMESPACE)
+                        .facets(
+                            JobFacet.builder()
+                                .jobType(
+                                    JobTypeJobFacet.builder()
+                                        .processingType("STREAMING")
+                                        .integration("FLINK")
+                                        .jobType("JOB")
+                                        .build())
+                                .build())
+                        .build())
+                .eventTime(Instant.now().atZone(TIMEZONE))
+                .inputs(Collections.singletonList(input))
+                .outputs(Collections.singletonList(output))
+                .build())
+        .get();
+    Optional<Dataset> datasetRow = datasetDao.findDatasetByName(NAMESPACE, DATASET_NAME);
+
+    // (3) Assert that output is present and has dataset_version written
+    assertThat(datasetRow).isPresent().flatMap(Dataset::getCurrentVersion).isPresent();
+
+    // (4) Assert that job is present although job_version entry is not
+    Job job = jobDao.findJobByName(NAMESPACE, "streaming_job_name").get();
+    assertThat(job.getInputs()).hasSize(1);
+    assertThat(job.getCurrentVersion()).isPresent();
+    assertThat(job.getType()).isEqualTo(JobType.STREAM);
+    assertThat(job.getLabels()).containsExactly("JOB", "FLINK");
+
+    UUID initialJobVersion = job.getCurrentVersion().get();
+    Instant updatedAt =
+        jdbi.withHandle(
+            h ->
+                h.createQuery("SELECT max(updated_at) FROM job_versions")
+                    .mapTo(Instant.class)
+                    .first());
+
+    // (5) Send COMPLETE event streaming job
+    lineageService
+        .createAsync(
+            LineageEvent.builder()
+                .eventType("COMPLETE")
+                .run(new LineageEvent.Run(firstRunId.toString(), RunFacet.builder().build()))
+                .job(
+                    LineageEvent.Job.builder()
+                        .name("streaming_job_name")
+                        .namespace(NAMESPACE)
+                        .facets(
+                            JobFacet.builder()
+                                .jobType(
+                                    JobTypeJobFacet.builder()
+                                        .processingType("STREAMING")
+                                        .integration("FLINK")
+                                        .jobType("JOB")
+                                        .build())
+                                .build())
+                        .build())
+                .eventTime(Instant.now().atZone(TIMEZONE))
+                .inputs(Collections.emptyList())
+                .outputs(Collections.emptyList())
+                .build())
+        .get();
+
+    // (6) Assert job version exists
+    job = jobDao.findJobByName(NAMESPACE, "streaming_job_name").get();
+    assertThat(job.getCurrentVersion()).isPresent();
+    assertThat(job.getType()).isEqualTo(JobType.STREAM);
+    assertThat(job.getLabels()).containsExactly("JOB", "FLINK");
+    assertThat(job.getCurrentVersion().get()).isEqualTo(initialJobVersion);
+
+    // (7) Make sure updated_at in job version did not change
+    Instant lastUpdatedAt =
+        jdbi.withHandle(
+            h ->
+                h.createQuery("SELECT max(updated_at) FROM job_versions")
+                    .mapTo(Instant.class)
+                    .first());
+    assertThat(updatedAt).isEqualTo(lastUpdatedAt);
+  }
+
+  @Test
+  void testStreamingJobCreateSingleJobAndDatasetVersion()
+      throws ExecutionException, InterruptedException {
+    LineageEvent.Dataset dataset =
+        LineageEvent.Dataset.builder().name(DATASET_NAME).namespace(NAMESPACE).build();
+    UUID firstRunId = UUID.randomUUID();
+    LineageEventBuilder eventBuilder =
         LineageEvent.builder()
             .eventType("RUNNING")
             .run(new LineageEvent.Run(firstRunId.toString(), RunFacet.builder().build()))
             .job(
                 LineageEvent.Job.builder()
-                    .name(JOB_NAME)
+                    .name("streaming_job_name")
                     .namespace(NAMESPACE)
                     .facets(
                         JobFacet.builder()
-                            .processingType(
-                                new ProcessingTypeJobFacet(PRODUCER_URL, SCHEMA_URL, "STREAMING"))
+                            .jobType(JobTypeJobFacet.builder().processingType("STREAMING").build())
                             .build())
                     .build())
-            .eventTime(Instant.now().atZone(TIMEZONE))
-            .inputs(new ArrayList<>())
-            .outputs(Collections.singletonList(dataset))
-            .build());
-    Optional<Dataset> datasetRow = datasetDao.findDatasetByName(NAMESPACE, DATASET_NAME);
+            .eventTime(Instant.now().atZone(TIMEZONE));
+    LineageEvent lineageEvent = eventBuilder.outputs(Collections.singletonList(dataset)).build();
 
-    // assertThat(datasetRow).isPresent().flatMap(Dataset::getCurrentVersion).isNotPresent();
+    // (1) Emit running event
+    lineageService.createAsync(lineageEvent).get();
 
-    // Assert that datasets can be retrieved
-    // TODO
+    UUID datasetVersionUuid =
+        datasetDao.findDatasetAsRow(NAMESPACE, DATASET_NAME).get().getCurrentVersionUuid().get();
+    int initialJobVersionsCount =
+        jobVersionDao.findAllJobVersions(NAMESPACE, "streaming_job_name", 10, 0).size();
 
-    // TODO: job can be retrieved by name
+    // (2) Emit other running event
+    lineageService.createAsync(lineageEvent).get();
 
-    // Assert that it is returned via lineage endpoint
+    // (3) Emit running event with no input nor output datasets
+    lineageService.createAsync(eventBuilder.build()).get();
+    assertThat(jobVersionDao.findAllJobVersions(NAMESPACE, "streaming_job_name", 10, 0).size())
+        .isEqualTo(initialJobVersionsCount);
+
+    // (4) Emit event with other input dataset
+    LineageEvent.Dataset otherdataset =
+        LineageEvent.Dataset.builder().name("otherDataset").namespace(NAMESPACE).build();
+    lineageService
+        .createAsync(eventBuilder.inputs(Collections.singletonList(otherdataset)).build())
+        .get();
+    assertThat(jobVersionDao.findAllJobVersions(NAMESPACE, "streaming_job_name", 10, 0).size())
+        .isEqualTo(initialJobVersionsCount + 1);
+
+    // (5) Verify dataset's version has not changed
+    assertThat(
+            datasetDao
+                .findDatasetAsRow(NAMESPACE, DATASET_NAME)
+                .get()
+                .getCurrentVersionUuid()
+                .get())
+        .isEqualTo(datasetVersionUuid);
   }
 
   private void checkExists(LineageEvent.Dataset ds) {

--- a/api/src/test/java/marquez/service/models/LineageEventTest.java
+++ b/api/src/test/java/marquez/service/models/LineageEventTest.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 import java.util.List;
 import marquez.common.Utils;
 import marquez.common.models.FlexibleDateTimeDeserializer;
+import marquez.service.models.LineageEvent.JobTypeJobFacet;
+import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -94,5 +96,17 @@ public class LineageEventTest {
                 FlexibleDateTimeDeserializer.DATE_TIME_OPTIONAL_OFFSET.format(zonedDateTime)));
     JsonNode actualNode = mapper.readTree(serialized);
     assertThat(actualNode).isEqualTo(expectedNode);
+  }
+
+  @Test
+  public void testJobTypeJobFacetSerialization() throws IOException {
+    URL expectedResource = Resources.getResource(EVENT_FULL);
+    LineageEvent deserialized =
+        (LineageEvent) Utils.newObjectMapper().readValue(expectedResource, BaseEvent.class);
+    JobTypeJobFacet facet = deserialized.getJob().getFacets().getJobType();
+
+    assertThat(facet.getJobType()).isEqualTo("QUERY");
+    assertThat(facet.getIntegration()).isEqualTo("FLINK");
+    assertThat(facet.getProcessingType()).isEqualTo("STREAMING");
   }
 }

--- a/api/src/test/resources/open_lineage/event_full.json
+++ b/api/src/test/resources/open_lineage/event_full.json
@@ -61,6 +61,13 @@
         },
         "query": "SELECT * FROM foo"
       },
+      "jobType": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",
+        "jobType": "QUERY",
+        "integration": "FLINK",
+        "processingType": "STREAMING"
+      },
       "additionalProp1": {
         "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
         "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/spec/OpenLineage.yml#MyCustomJobFacet",


### PR DESCRIPTION
### Problem

Currently, `job_version` is created once the job finishes. This assumption no longer holds for streaming jobs which can run for days or weeks while continuously writing output datasets. 

It makes sense in this case, to create job version and identify input/output datasets at the beginning of the job and modify it on the fly if a job changes. 

In particular, a `lineage` endpoint shall include streaming jobs in lineage graph as they're running and datasets being written by streaming jobs should be available (and have dataset version modified) once the job is started. 

### Solution

 * add extra logic to create job_version entry and its references before the job completes,
 * make sure new version is written only once,
 * support `JobTypeJobFacet` to determine if a job is `batch` or `streaming`
 * store job characteristics in `jobs` table. 

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
