### PR TITLE
refacto dataset version query

### DIFF
--- a/api/src/main/java/marquez/db/DatasetVersionDao.java
+++ b/api/src/main/java/marquez/db/DatasetVersionDao.java
@@ -268,7 +268,6 @@ public interface DatasetVersionDao extends BaseDao {
       	) f ON f.dataset_version_uuid = dv.uuid
       	WHERE dv.namespace_name = :namespaceName
             AND dv.dataset_name = :datasetName
-      	ORDER BY dv.created_at DESC
       	LIMIT :limit OFFSET :offset
         )
         SELECT
@@ -280,6 +279,7 @@ public interface DatasetVersionDao extends BaseDao {
         GROUP BY type, name, physical_name, namespace_name, source_name, description, lifecycle_state,
             created_at, version, fields, createdByRunUuid, schema_location,
             tags, dataset_version_uuid
+        ORDER BY created_at DESC
   """)
   List<DatasetVersion> findAll(String namespaceName, String datasetName, int limit, int offset);
 

--- a/api/src/main/java/marquez/db/DatasetVersionDao.java
+++ b/api/src/main/java/marquez/db/DatasetVersionDao.java
@@ -244,29 +244,42 @@ public interface DatasetVersionDao extends BaseDao {
 
   @SqlQuery(
       """
-      SELECT d.type, d.name, d.physical_name, d.namespace_name, d.source_name, d.description, dv.lifecycle_state,
-          dv.created_at, dv.version, dv.fields, dv.run_uuid AS createdByRunUuid, sv.schema_location,
-          t.tags, f.facets
-      FROM dataset_versions dv
-      LEFT JOIN datasets_view d ON d.uuid = dv.dataset_uuid
-      LEFT JOIN stream_versions AS sv ON sv.dataset_version_uuid = dv.uuid
-      LEFT JOIN (
-          SELECT ARRAY_AGG(t.name) AS tags, m.dataset_uuid
-          FROM tags AS t
-                   INNER JOIN datasets_tag_mapping AS m ON m.tag_uuid = t.uuid
-          GROUP BY m.dataset_uuid
-      ) t ON t.dataset_uuid = dv.dataset_uuid
-      LEFT JOIN (
-          SELECT dvf.dataset_version_uuid,
-          JSONB_AGG(dvf.facet ORDER BY dvf.lineage_event_time ASC) AS facets
-          FROM dataset_facets_view dvf
-          WHERE  (type ILIKE 'dataset' OR type ILIKE 'unknown')
-          GROUP BY dataset_version_uuid
-      ) f ON f.dataset_version_uuid = dv.uuid
-      WHERE dv.namespace_name = :namespaceName
-      AND dv.dataset_name = :datasetName
-      ORDER BY dv.created_at DESC
-      LIMIT :limit OFFSET :offset
+      WITH dataset_info AS (
+	    SELECT d.type, d.name, d.physical_name, d.namespace_name, d.source_name, d.description, dv.lifecycle_state,
+		dv.created_at, dv.version, dv.fields, dv.run_uuid AS createdByRunUuid, sv.schema_location,
+		t.tags, f.facets, f.lineage_event_time, f.dataset_version_uuid, facet_name
+		FROM dataset_versions dv
+		LEFT JOIN datasets_view d ON d.uuid = dv.dataset_uuid
+		LEFT JOIN stream_versions AS sv ON sv.dataset_version_uuid = dv.uuid
+		LEFT JOIN (
+			SELECT ARRAY_AGG(t.name) AS tags, m.dataset_uuid
+			FROM tags AS t
+			INNER JOIN datasets_tag_mapping AS m ON m.tag_uuid = t.uuid
+			GROUP BY m.dataset_uuid
+		) t ON t.dataset_uuid = dv.dataset_uuid
+		LEFT JOIN (
+			SELECT
+				dataset_version_uuid,
+				name as facet_name,
+				facet as facets,lineage_event_time
+			FROM dataset_facets_view
+			WHERE
+				(type ILIKE 'dataset' OR type ILIKE 'unknown')
+      	) f ON f.dataset_version_uuid = dv.uuid
+      	WHERE dv.namespace_name = :namespaceName
+            AND dv.dataset_name = :datasetName
+      	ORDER BY dv.created_at DESC
+      	LIMIT :limit OFFSET :offset
+        )
+        SELECT
+	        type, name, physical_name, namespace_name, source_name, description, lifecycle_state,
+            created_at, version, fields, createdByRunUuid, schema_location,
+            tags, dataset_version_uuid,
+	        JSONB_AGG(facets ORDER BY lineage_event_time ASC) AS facets
+        FROM dataset_info
+        GROUP BY type, name, physical_name, namespace_name, source_name, description, lifecycle_state,
+            created_at, version, fields, createdByRunUuid, schema_location,
+            tags, dataset_version_uuid
   """)
   List<DatasetVersion> findAll(String namespaceName, String datasetName, int limit, int offset);
 


### PR DESCRIPTION
### Problem

The SQL query run for dataset version is quite slow and often result in a time out.

Closes: [2684](https://github.com/MarquezProject/marquez/issues/2684)

### Solution

In this query the JSONB_AGG operation is the task that takes the most time, so I just re-write the query by putting the "heavy operation" (JSONB_AGG) after all JOIN and filters.

For a given namespace and dataset name and a db.t4g.medium (vCPU: 2, RAM: 4 GB) machine:
- The old query takes: 4 minutes 21 seconds
- The new query takes: 1.230 seconds

````
WITH dataset_info AS (
	    SELECT d.type, d.name, d.physical_name, d.namespace_name, d.source_name, d.description, dv.lifecycle_state,
		dv.created_at, dv.version, dv.fields, dv.run_uuid AS createdByRunUuid, sv.schema_location,
		t.tags, f.facets, f.lineage_event_time, f.dataset_version_uuid, facet_name
		FROM dataset_versions dv
		LEFT JOIN datasets_view d ON d.uuid = dv.dataset_uuid
		LEFT JOIN stream_versions AS sv ON sv.dataset_version_uuid = dv.uuid
		LEFT JOIN (
			SELECT ARRAY_AGG(t.name) AS tags, m.dataset_uuid
			FROM tags AS t
			INNER JOIN datasets_tag_mapping AS m ON m.tag_uuid = t.uuid
			GROUP BY m.dataset_uuid
		) t ON t.dataset_uuid = dv.dataset_uuid
		LEFT JOIN (
			SELECT
				dataset_version_uuid,
				name as facet_name,
				facet as facets,lineage_event_time
			FROM dataset_facets_view
			WHERE
				(type ILIKE 'dataset' OR type ILIKE 'unknown')
      	) f ON f.dataset_version_uuid = dv.uuid
      	WHERE dv.namespace_name = :namespaceName
            AND dv.dataset_name = :datasetName
      	ORDER BY dv.created_at DESC
      	LIMIT :limit OFFSET :offset
        )
        SELECT
	        type, name, physical_name, namespace_name, source_name, description, lifecycle_state,
            created_at, version, fields, createdByRunUuid, schema_location,
            tags, dataset_version_uuid,
	        JSONB_AGG(facets ORDER BY lineage_event_time ASC) AS facets
        FROM dataset_info
        GROUP BY type, name, physical_name, namespace_name, source_name, description, lifecycle_state,
            created_at, version, fields, createdByRunUuid, schema_location,
            tags, dataset_version_uuid

````

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
