### PR TITLE
[PERF] Refacto run dao sql query

### DIFF
--- a/api/src/main/java/marquez/db/RunDao.java
+++ b/api/src/main/java/marquez/db/RunDao.java
@@ -153,6 +153,7 @@ public interface RunDao extends BaseDao {
                 run_uuid,
                 JSON_AGG(facet ORDER BY lineage_event_time ASC) AS facets
             FROM run_facets_view
+            -- This filter here is used for performance purpose: we only aggregate the json of run_uuid that matters
             WHERE
                 run_uuid IN (SELECT uuid FROM runs_view WHERE job_uuid IN (SELECT uuid FROM filtered_jobs))
             GROUP BY run_uuid
@@ -167,6 +168,7 @@ public interface RunDao extends BaseDao {
                    )) AS input_versions
                FROM runs_input_mapping im
                INNER JOIN dataset_versions dv ON im.dataset_version_uuid = dv.uuid
+               -- This filter here is used for performance purpose: we only aggregate the json of run_uuid that matters
                WHERE
                    im.run_uuid IN (SELECT uuid FROM runs_view WHERE job_uuid IN (SELECT uuid FROM filtered_jobs))
                GROUP BY im.run_uuid
@@ -180,6 +182,7 @@ public interface RunDao extends BaseDao {
                                        'dataset_version_uuid', uuid
                                        )) AS output_versions
               FROM dataset_versions dv
+              -- This filter here is used for performance purpose: we only aggregate the json of run_uuid that matters
               WHERE dv.run_uuid IN (SELECT uuid FROM runs_view WHERE job_uuid IN (SELECT uuid FROM filtered_jobs))
               GROUP BY dv.run_uuid
           ),
@@ -193,6 +196,7 @@ public interface RunDao extends BaseDao {
                       'facet', facet
                   ) ORDER BY created_at ASC) as dataset_facets
               FROM dataset_facets_view
+              -- This filter here is used for performance purpose: we only aggregate the json of run_uuid that matters
               WHERE run_uuid IN (SELECT uuid FROM runs_view WHERE job_uuid IN (SELECT uuid FROM filtered_jobs))
               AND (type ILIKE 'output' OR type ILIKE 'input')
               GROUP BY run_uuid

--- a/api/src/main/java/marquez/db/RunDao.java
+++ b/api/src/main/java/marquez/db/RunDao.java
@@ -140,54 +140,80 @@ public interface RunDao extends BaseDao {
 
   @SqlQuery(
       """
-          SELECT r.*, ra.args, f.facets,
-          j.namespace_name, j.name, jv.version AS job_version,
-          ri.input_versions, ro.output_versions, df.dataset_facets
-          FROM runs_view AS r
-          INNER JOIN jobs_view j ON r.job_uuid=j.uuid
-          LEFT JOIN LATERAL
-          (
-            SELECT rf.run_uuid, JSON_AGG(rf.facet ORDER BY rf.lineage_event_time ASC) AS facets
-            FROM run_facets_view rf
-            WHERE rf.run_uuid=r.uuid
-            GROUP BY rf.run_uuid
-          ) AS f ON r.uuid=f.run_uuid
-          LEFT OUTER JOIN run_args AS ra ON ra.uuid = r.run_args_uuid
-          LEFT OUTER JOIN job_versions jv ON jv.uuid=r.job_version_uuid
-          LEFT OUTER JOIN (
-           SELECT im.run_uuid, JSON_AGG(json_build_object('namespace', dv.namespace_name,
-                  'name', dv.dataset_name,
-                  'version', dv.version,
-                  'dataset_version_uuid', uuid
-                  )) AS input_versions
-           FROM runs_input_mapping im
-           INNER JOIN dataset_versions dv on im.dataset_version_uuid = dv.uuid
-           GROUP BY im.run_uuid
-          ) ri ON ri.run_uuid=r.uuid
-          LEFT OUTER JOIN (
-            SELECT run_uuid, JSON_AGG(json_build_object('namespace', namespace_name,
-                                                        'name', dataset_name,
-                                                        'version', version,
-                                                        'dataset_version_uuid', uuid
-                                                        )) AS output_versions
-            FROM dataset_versions
+          WITH filtered_jobs AS (
+            SELECT
+                jv.uuid,
+                jv.namespace_name,
+                jv.name
+            FROM jobs_view jv
+            WHERE jv.namespace_name=:namespace AND (jv.name=:jobName OR :jobName = ANY(jv.aliases))
+          ),
+          run_facets_agg AS (
+            SELECT
+                run_uuid,
+                JSON_AGG(facet ORDER BY lineage_event_time ASC) AS facets
+            FROM run_facets_view
+            WHERE
+                run_uuid IN (SELECT uuid FROM runs_view WHERE job_uuid IN (SELECT uuid FROM filtered_jobs))
             GROUP BY run_uuid
-          ) ro ON ro.run_uuid=r.uuid
-          LEFT OUTER JOIN (
+          ),
+          input_versions_agg AS (
+               SELECT
+                   im.run_uuid,
+                   JSON_AGG(json_build_object('namespace', dv.namespace_name,
+                        'name', dv.dataset_name,
+                        'version', dv.version,
+                        'dataset_version_uuid', dv.uuid
+                   )) AS input_versions
+               FROM runs_input_mapping im
+               INNER JOIN dataset_versions dv ON im.dataset_version_uuid = dv.uuid
+               WHERE
+                   im.run_uuid IN (SELECT uuid FROM runs_view WHERE job_uuid IN (SELECT uuid FROM filtered_jobs))
+               GROUP BY im.run_uuid
+          ),
+          output_versions_agg AS (
+              SELECT
+                  dv.run_uuid,
+              JSON_AGG(json_build_object('namespace', namespace_name,
+                                       'name', dataset_name,
+                                       'version', version,
+                                       'dataset_version_uuid', uuid
+                                       )) AS output_versions
+              FROM dataset_versions dv
+              WHERE dv.run_uuid IN (SELECT uuid FROM runs_view WHERE job_uuid IN (SELECT uuid FROM filtered_jobs))
+              GROUP BY dv.run_uuid
+          ),
+          dataset_facets_agg AS (
+              SELECT
+                  run_uuid,
+                  JSON_AGG(json_build_object(
+                      'dataset_version_uuid', dataset_version_uuid,
+                      'name', name,
+                      'type', type,
+                      'facet', facet
+                  ) ORDER BY created_at ASC) as dataset_facets
+              FROM dataset_facets_view
+              WHERE run_uuid IN (SELECT uuid FROM runs_view WHERE job_uuid IN (SELECT uuid FROM filtered_jobs))
+              AND (type ILIKE 'output' OR type ILIKE 'input')
+              GROUP BY run_uuid
+          )
           SELECT
-              run_uuid,
-              JSON_AGG(json_build_object(
-                  'dataset_version_uuid', dataset_version_uuid,
-                  'name', name,
-                  'type', type,
-                  'facet', facet
-              ) ORDER BY created_at ASC) as dataset_facets
-          FROM dataset_facets_view
-          WHERE (type ILIKE 'output' OR type ILIKE 'input')
-          GROUP BY run_uuid
-          ) AS df ON r.uuid = df.run_uuid
-          WHERE j.namespace_name=:namespace AND (j.name=:jobName OR :jobName = ANY(j.aliases))
-          ORDER BY STARTED_AT DESC NULLS LAST
+              r.*,
+              ra.args,
+              f.facets,
+              jv.version AS job_version,
+              ri.input_versions,
+              ro.output_versions,
+              df.dataset_facets
+          FROM runs_view r
+          INNER JOIN filtered_jobs fj ON r.job_uuid = fj.uuid
+          LEFT JOIN run_facets_agg f ON r.uuid = f.run_uuid
+          LEFT JOIN run_args ra ON ra.uuid = r.run_args_uuid
+          LEFT JOIN job_versions jv ON jv.uuid = r.job_version_uuid
+          LEFT JOIN input_versions_agg ri ON r.uuid = ri.run_uuid
+          LEFT JOIN output_versions_agg ro ON r.uuid = ro.run_uuid
+          LEFT JOIN dataset_facets_agg df ON r.uuid = df.run_uuid
+          ORDER BY r.started_at DESC NULLS LAST
           LIMIT :limit OFFSET :offset
       """)
   List<Run> findAll(String namespace, String jobName, int limit, int offset);


### PR DESCRIPTION
### Problem

Closes: [2686](https://github.com/MarquezProject/marquez/issues/2686)

The SQL query run for listing all runs is quite slow and often result in a time out.

### Solution

The logic is quite the same as before, the heavy operation is all the 4 JSON_AGG so we just need to filter first and apply this operation only on the relevent rows 

`run_uuid IN (SELECT uuid FROM runs_view WHERE job_uuid IN (SELECT uuid FROM filtered_jobs))`. 

For a given namespace and job name and a db.t4g.medium (vCPU: 2, RAM: 4 GB) machine:

- The old query takes: 1 minute 14 seconds
- The new query takes: 1.919 seconds

````
WITH filtered_jobs AS (
            SELECT
                jv.uuid,
                jv.namespace_name,
                jv.name
            FROM jobs_view jv
            WHERE jv.namespace_name=:namespace AND (jv.name=:jobName OR :jobName = ANY(jv.aliases))
          ),
          run_facets_agg AS (
            SELECT
                run_uuid,
                JSON_AGG(facet ORDER BY lineage_event_time ASC) AS facets
            FROM run_facets_view
            WHERE
                run_uuid IN (SELECT uuid FROM runs_view WHERE job_uuid IN (SELECT uuid FROM filtered_jobs))
            GROUP BY run_uuid
          ),
          input_versions_agg AS (
               SELECT
                   im.run_uuid,
                   JSON_AGG(json_build_object('namespace', dv.namespace_name,
                        'name', dv.dataset_name,
                        'version', dv.version,
                        'dataset_version_uuid', dv.uuid
                   )) AS input_versions
               FROM runs_input_mapping im
               INNER JOIN dataset_versions dv ON im.dataset_version_uuid = dv.uuid
               WHERE
                   im.run_uuid IN (SELECT uuid FROM runs_view WHERE job_uuid IN (SELECT uuid FROM filtered_jobs))
               GROUP BY im.run_uuid
          ),
          output_versions_agg AS (
              SELECT
                  dv.run_uuid,
              JSON_AGG(json_build_object('namespace', namespace_name,
                                       'name', dataset_name,
                                       'version', version,
                                       'dataset_version_uuid', uuid
                                       )) AS output_versions
              FROM dataset_versions dv
              WHERE dv.run_uuid IN (SELECT uuid FROM runs_view WHERE job_uuid IN (SELECT uuid FROM filtered_jobs))
              GROUP BY dv.run_uuid
          ),
          dataset_facets_agg AS (
              SELECT
                  run_uuid,
                  JSON_AGG(json_build_object(
                      'dataset_version_uuid', dataset_version_uuid,
                      'name', name,
                      'type', type,
                      'facet', facet
                  ) ORDER BY created_at ASC) as dataset_facets
              FROM dataset_facets_view
              WHERE run_uuid IN (SELECT uuid FROM runs_view WHERE job_uuid IN (SELECT uuid FROM filtered_jobs))
              AND (type ILIKE 'output' OR type ILIKE 'input')
              GROUP BY run_uuid
          )
          SELECT
              r.*,
              ra.args,
              f.facets,
              jv.version AS job_version,
              ri.input_versions,
              ro.output_versions,
              df.dataset_facets
          FROM runs_view r
          INNER JOIN filtered_jobs fj ON r.job_uuid = fj.uuid
          LEFT JOIN run_facets_agg f ON r.uuid = f.run_uuid
          LEFT JOIN run_args ra ON ra.uuid = r.run_args_uuid
          LEFT JOIN job_versions jv ON jv.uuid = r.job_version_uuid
          LEFT JOIN input_versions_agg ri ON r.uuid = ri.run_uuid
          LEFT JOIN output_versions_agg ro ON r.uuid = ro.run_uuid
          LEFT JOIN dataset_facets_agg df ON r.uuid = df.run_uuid
          ORDER BY r.started_at DESC NULLS LAST
          LIMIT :limit OFFSET :offset
````
One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
