### PR TITLE
change url path encoding to match jersey decoding

### DIFF
--- a/clients/java/src/main/java/marquez/client/MarquezPathV1.java
+++ b/clients/java/src/main/java/marquez/client/MarquezPathV1.java
@@ -6,9 +6,7 @@
 package marquez.client;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import com.google.common.net.UrlEscapers;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.stream.Collectors;
@@ -57,11 +55,7 @@ class MarquezPathV1 {
   }
 
   static String encode(String input) {
-    try {
-      return URLEncoder.encode(input, StandardCharsets.UTF_8.toString());
-    } catch (UnsupportedEncodingException e) {
-      throw new MarquezClientException(e);
-    }
+    return UrlEscapers.urlPathSegmentEscaper().escape(input);
   }
 
   static String listNamespacesPath() {

--- a/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
@@ -105,7 +105,7 @@ public class MarquezHttpTest {
   public void testClient_properlyFormatsNamespaces() throws Exception {
     final String pathTemplate = "/namespaces/%s";
     final String pathArg = "database://localhost:1234";
-    final String path = "/namespaces/database%3A%2F%2Flocalhost%3A1234";
+    final String path = "/namespaces/database:%2F%2Flocalhost:1234";
 
     URL expected = new URL(BASE_URL + BASE_PATH + path);
     URL actual = marquezUrl.from(path(pathTemplate, pathArg));

--- a/clients/java/src/test/java/marquez/client/MarquezPathV1Test.java
+++ b/clients/java/src/test/java/marquez/client/MarquezPathV1Test.java
@@ -23,17 +23,26 @@ public class MarquezPathV1Test {
 
   private static Stream<Arguments> testPath_namespaceUrl() {
     return Stream.of(
-        Arguments.of("/api/v1/namespaces/s3%3A%2F%2Fbucket", "s3://bucket"),
-        Arguments.of("/api/v1/namespaces/bigquery%3A", "bigquery:"),
+        Arguments.of("/api/v1/namespaces/s3:%2F%2Fbucket", "s3://bucket"),
+        Arguments.of("/api/v1/namespaces/bigquery:", "bigquery:"),
         Arguments.of("/api/v1/namespaces/usual-namespace-name", "usual-namespace-name"),
-        Arguments.of("/api/v1/namespaces/a%3A%5C%3Aa", "a:\\:a"));
+        Arguments.of("/api/v1/namespaces/a:%5C:a", "a:\\:a"));
   }
 
-  @Test
-  void testPath_datasetUrl() {
-    Assertions.assertEquals(
-        "/api/v1/namespaces/s3%3A%2F%2Fbuckets/datasets/source-file.json",
-        MarquezPathV1.datasetPath("s3://buckets", "source-file.json"));
+  @ParameterizedTest
+  @MethodSource
+  void testPath_datasetUrl(String expected, String namespaceName, String datasetName) {
+    Assertions.assertEquals(expected, MarquezPathV1.datasetPath(namespaceName, datasetName));
+  }
+
+  private static Stream<Arguments> testPath_datasetUrl() {
+    return Stream.of(
+        Arguments.of(
+            "/api/v1/namespaces/s3:%2F%2Fbucket/datasets/source-file.json",
+            "s3://bucket", "source-file.json"),
+        Arguments.of(
+            "/api/v1/namespaces/snowflake:%2F%2Faccount/datasets/DATABASE.SCHEMA.%22Exotic%20Table%20Name!%22",
+            "snowflake://account", "DATABASE.SCHEMA.\"Exotic Table Name!\""));
   }
 
   @Test


### PR DESCRIPTION
### Problem

When an entity that is referred to in a path, like a Dataset or Job, has spaces in the name, the Java client will fail to retrieve it, with a 404 from Marquez.

This is because the Marquez API (via Jersey) seems to decode paths based on proper URI encoding, where spaces should be represented with `%20`, but the existing implementation used `URLEncoder` which only does HTML form encoding, where spaces are represented with `+`.

In other words...

- With a dataset named `My Dataset`
- The URL that will be matched by the API is `namespaces/{namespace}/datasets/My%20Dataset`
- But the URL that the Java client currently forms is `namespaces/{namespace}/datasets/My+Dataset`

...hence the 404.

It's worth noting that query parameters don't suffer from this, so e.g. the lineage and column-lineage endpoints are unaffected.

### Solution

Swap out the implementation of `MarquezPathV1::encode` to use `UrlEscapers` path segment escaper which does proper URI encoding.

This does change behaviour regarding colons - the new implementation does not replace `:` with `%3A` as the old one did. The API is tolerant of either so this shouldn't be an issue. And again query parameters are forgiving of all variations.

One-line summary: change url path encoding to match jersey decoding

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
