### PR TITLE
remove maven-archiver dependency from java client

### DIFF
--- a/clients/java/build.gradle
+++ b/clients/java/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
     implementation 'org.apache.commons:commons-lang3:3.13.0'
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
-    implementation 'org.apache.maven:maven-archiver:3.6.1'
 
     testImplementation "org.slf4j:slf4j-simple:${slf4jVersion}"
 }


### PR DESCRIPTION
### Problem

The Java client has a dependency on `maven-archiver`, which can bring some transitive vulnerabilities.

This is a build tool only though and shouldn't go through as a transitive dependency to consumers of the client. Further, I can't see why it's needed - the `api` module doesn't have it, and if I remove it and do a build and publish to my local Maven repo, it works fine.

### Solution

Remove the dependency from `build.gradle`.

If I'm wrong and this is needed, we could look instead at adding the dependency to `publishing` or `buildScript` to avoid consumers getting it unnecessarily.

One-line summary:  
remove maven-archiver dependency from java client

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
