### PR TITLE
add DELETE end point for dataset tags

### DIFF
--- a/api/src/main/java/marquez/api/DatasetResource.java
+++ b/api/src/main/java/marquez/api/DatasetResource.java
@@ -216,7 +216,8 @@ public class DatasetResource extends BaseResource {
         tagName.getValue(),
         datasetName.getValue(),
         namespaceName.getValue());
-    datasetService.deleteDatasetTag(datasetName.getValue(), tagName.getValue());
+    datasetService.deleteDatasetTag(
+        namespaceName.getValue(), datasetName.getValue(), tagName.getValue());
     Dataset dataset =
         datasetService
             .findDatasetByName(namespaceName.getValue(), datasetName.getValue())

--- a/api/src/main/java/marquez/api/DatasetResource.java
+++ b/api/src/main/java/marquez/api/DatasetResource.java
@@ -201,6 +201,28 @@ public class DatasetResource extends BaseResource {
   @Timed
   @ResponseMetered
   @ExceptionMetered
+  @DELETE
+  @Path("/{dataset}/tags/{tag}")
+  @Produces(APPLICATION_JSON)
+  public Response deleteDatasetTag(
+      @PathParam("namespace") NamespaceName namespaceName,
+      @PathParam("dataset") DatasetName datasetName,
+      @PathParam("tag") TagName tagName) {
+    throwIfNotExists(namespaceName);
+    throwIfNotExists(namespaceName, datasetName);
+    
+    log.info("Deleted tag '{}' from dataset '{}' on namespace '{}'", tagName.getValue(), datasetName.getValue(), namespaceName.getValue());
+    datasetService.deleteDatasetTag(datasetName.getValue(), tagName.getValue());
+    Dataset dataset =
+        datasetService
+            .findDatasetByName(namespaceName.getValue(), datasetName.getValue())
+            .orElseThrow(() -> new DatasetNotFoundException(datasetName));
+    return Response.ok(dataset).build();
+  }
+
+  @Timed
+  @ResponseMetered
+  @ExceptionMetered
   @POST
   @Path("/{dataset}/fields/{field}/tags/{tag}")
   @Consumes(APPLICATION_JSON)

--- a/api/src/main/java/marquez/api/DatasetResource.java
+++ b/api/src/main/java/marquez/api/DatasetResource.java
@@ -210,8 +210,12 @@ public class DatasetResource extends BaseResource {
       @PathParam("tag") TagName tagName) {
     throwIfNotExists(namespaceName);
     throwIfNotExists(namespaceName, datasetName);
-    
-    log.info("Deleted tag '{}' from dataset '{}' on namespace '{}'", tagName.getValue(), datasetName.getValue(), namespaceName.getValue());
+
+    log.info(
+        "Deleted tag '{}' from dataset '{}' on namespace '{}'",
+        tagName.getValue(),
+        datasetName.getValue(),
+        namespaceName.getValue());
     datasetService.deleteDatasetTag(datasetName.getValue(), tagName.getValue());
     Dataset dataset =
         datasetService

--- a/api/src/main/java/marquez/db/DatasetDao.java
+++ b/api/src/main/java/marquez/db/DatasetDao.java
@@ -272,6 +272,18 @@ public interface DatasetDao extends BaseDao {
       """)
   Optional<DatasetRow> delete(String namespaceName, String name);
 
+  @SqlUpdate(
+      """
+        DELETE FROM datasets_tag_mapping dtm
+        WHERE EXISTS (
+            SELECT 1
+            FROM datasets d
+            JOIN tags t ON d.uuid = dtm.dataset_uuid AND t.uuid = dtm.tag_uuid
+            WHERE d.name = :datasetName AND t.name = :tagName
+        );
+      """)
+  void deleteDatasetTag(String datasetName, String tagName);
+
   @Transaction
   default Dataset upsertDatasetMeta(
       NamespaceName namespaceName, DatasetName datasetName, DatasetMeta datasetMeta) {

--- a/api/src/main/java/marquez/db/DatasetDao.java
+++ b/api/src/main/java/marquez/db/DatasetDao.java
@@ -277,12 +277,27 @@ public interface DatasetDao extends BaseDao {
         DELETE FROM datasets_tag_mapping dtm
         WHERE EXISTS (
             SELECT 1
-            FROM datasets d
-            JOIN tags t ON d.uuid = dtm.dataset_uuid AND t.uuid = dtm.tag_uuid
-            WHERE d.name = :datasetName AND t.name = :tagName
+            FROM
+              datasets d
+            JOIN
+              tags t
+            ON
+              d.uuid = dtm.dataset_uuid
+            AND
+              t.uuid = dtm.tag_uuid
+            JOIN
+              namespaces n
+            ON
+              d.namespace_uuid = n.uuid
+            WHERE
+              d.name = :datasetName
+            AND
+              t.name = :tagName
+            AND
+              n.name = :namespaceName
         );
       """)
-  void deleteDatasetTag(String datasetName, String tagName);
+  void deleteDatasetTag(String namespaceName, String datasetName, String tagName);
 
   @Transaction
   default Dataset upsertDatasetMeta(

--- a/api/src/test/java/marquez/api/BaseResourceIntegrationTest.java
+++ b/api/src/test/java/marquez/api/BaseResourceIntegrationTest.java
@@ -5,9 +5,16 @@
 
 package marquez.api;
 
+import static marquez.common.models.CommonModelGenerator.newConnectionUrlFor;
+import static marquez.common.models.CommonModelGenerator.newDatasetName;
+import static marquez.common.models.CommonModelGenerator.newDbSourceType;
+import static marquez.common.models.CommonModelGenerator.newDescription;
 import static marquez.common.models.CommonModelGenerator.newNamespaceName;
+import static marquez.common.models.CommonModelGenerator.newOwnerName;
+import static marquez.common.models.CommonModelGenerator.newSourceName;
 import static marquez.db.DbTest.POSTGRES_14;
 
+import com.google.common.collect.ImmutableSet;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
@@ -16,11 +23,17 @@ import io.openlineage.client.OpenLineageClient;
 import io.openlineage.client.transports.HttpTransport;
 import java.net.URI;
 import java.net.URL;
+import java.util.Set;
 import marquez.MarquezApp;
 import marquez.MarquezConfig;
 import marquez.client.MarquezClient;
 import marquez.client.Utils;
+import marquez.client.models.DatasetId;
+import marquez.client.models.DbTableMeta;
+import marquez.client.models.NamespaceMeta;
+import marquez.client.models.SourceMeta;
 import marquez.client.models.Tag;
+import marquez.common.models.SourceType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -56,17 +69,61 @@ abstract class BaseResourceIntegrationTest {
   static final Tag PII = new Tag("PII", "Personally identifiable information");
   static final Tag SENSITIVE = new Tag("SENSITIVE", "Contains sensitive information");
 
+  // Namespace
   static String NAMESPACE_NAME;
-  static DropwizardAppExtension<MarquezConfig> MARQUEZ_APP;
+  static String NAMESPACE_DESCRIPTION;
+  static String OWNER_NAME;
 
+  // Source
+  static String SOURCE_TYPE;
+  static String SOURCE_NAME;
+  static URI CONNECTION_URL;
+  static String SOURCE_DESCRIPTION;
+
+  // Dataset
+  static String DB_TABLE_SOURCE_TYPE;
+  static String DB_TABLE_SOURCE_NAME;
+  static URI DB_TABLE_CONNECTION_URL;
+  static String DB_TABLE_SOURCE_DESCRIPTION;
+  static DatasetId DB_TABLE_ID;
+  static String DB_TABLE_NAME;
+  static String DB_TABLE_PHYSICAL_NAME;
+  static String DB_TABLE_DESCRIPTION;
+  static Set<String> DB_TABLE_TAGS;
+  static DbTableMeta DB_TABLE_META;
+
+  static DropwizardAppExtension<MarquezConfig> MARQUEZ_APP;
   static OpenLineage OL;
   static OpenLineageClient OL_CLIENT;
   static MarquezClient MARQUEZ_CLIENT;
 
   @BeforeAll
   public static void setUpOnce() throws Exception {
-    // (1) Use a randomly generated namespace.
+    // (1) Use a randomly generated namespace/dataset
     NAMESPACE_NAME = newNamespaceName().getValue();
+    NAMESPACE_DESCRIPTION = newDescription();
+    OWNER_NAME = newOwnerName().getValue();
+
+    SOURCE_TYPE = newDbSourceType().getValue();
+    SOURCE_NAME = newSourceName().getValue();
+    SOURCE_DESCRIPTION = newDescription();
+
+    DB_TABLE_SOURCE_TYPE = SourceType.of("POSTGRESQL").getValue();
+    DB_TABLE_SOURCE_NAME = SOURCE_NAME;
+    DB_TABLE_SOURCE_DESCRIPTION = newDescription();
+    DB_TABLE_ID = newDatasetIdWith(NAMESPACE_NAME);
+    DB_TABLE_NAME = DB_TABLE_ID.getName();
+    DB_TABLE_PHYSICAL_NAME = DB_TABLE_NAME;
+    DB_TABLE_DESCRIPTION = newDescription();
+    DB_TABLE_TAGS = ImmutableSet.of(PII.getName());
+    DB_TABLE_CONNECTION_URL = newConnectionUrlFor(SourceType.of("POSTGRESQL"));
+    DB_TABLE_META =
+        DbTableMeta.builder()
+            .physicalName(DB_TABLE_PHYSICAL_NAME)
+            .sourceName(DB_TABLE_SOURCE_NAME)
+            .tags(DB_TABLE_TAGS)
+            .description(DB_TABLE_DESCRIPTION)
+            .build();
 
     // (2) Configure Marquez application using test configuration and database.
     MARQUEZ_APP =
@@ -87,6 +144,28 @@ abstract class BaseResourceIntegrationTest {
             .transport(HttpTransport.builder().uri(url.toURI()).build())
             .build();
     MARQUEZ_CLIENT = MarquezClient.builder().baseUrl(url).build();
+  }
+
+  protected void createNamespace(String namespaceName) {
+    // (1) Create namespace for db table
+    final NamespaceMeta namespaceMeta =
+        NamespaceMeta.builder().ownerName(OWNER_NAME).description(NAMESPACE_DESCRIPTION).build();
+
+    MARQUEZ_CLIENT.createNamespace(namespaceName, namespaceMeta);
+  }
+
+  protected static DatasetId newDatasetIdWith(final String namespaceName) {
+    return new DatasetId(namespaceName, newDatasetName().getValue());
+  }
+
+  protected void createSource(String sourceName) {
+    final SourceMeta sourceMeta =
+        SourceMeta.builder()
+            .type(DB_TABLE_SOURCE_TYPE)
+            .connectionUrl(DB_TABLE_CONNECTION_URL)
+            .description(DB_TABLE_SOURCE_DESCRIPTION)
+            .build();
+    MARQUEZ_CLIENT.createSource(sourceName, sourceMeta);
   }
 
   @AfterAll

--- a/clients/java/src/main/java/marquez/client/MarquezClient.java
+++ b/clients/java/src/main/java/marquez/client/MarquezClient.java
@@ -240,6 +240,12 @@ public class MarquezClient {
     return Dataset.fromJson(bodyAsJson);
   }
 
+  public Dataset deleteDatasetTag(
+      @NonNull String namespaceName, @NonNull String datasetName, @NonNull String tagName) {
+    final String bodyAsJson = http.delete(url.toDatasetTagUrl(namespaceName, datasetName, tagName));
+    return Dataset.fromJson(bodyAsJson);
+  }
+
   public Dataset tagFieldWith(
       @NonNull String namespaceName,
       @NonNull String datasetName,

--- a/clients/java/src/test/java/marquez/client/MarquezClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezClientTest.java
@@ -990,6 +990,19 @@ public class MarquezClientTest {
   }
 
   @Test
+  public void testDeleteDatasetTag() throws Exception {
+    final URL url =
+        buildUrlFor(
+            "/namespaces/%s/datasets/%s/tags/%s", NAMESPACE_NAME, DB_TABLE_NAME, "tag_name");
+
+    final String runAsJson = Utils.getMapper().writeValueAsString(DB_TABLE);
+    when(http.delete(url)).thenReturn(runAsJson);
+
+    final Dataset dataset = client.deleteDatasetTag(NAMESPACE_NAME, DB_TABLE_NAME, "tag_name");
+    assertThat(dataset).isEqualTo(DB_TABLE);
+  }
+
+  @Test
   public void testTagField() throws Exception {
     final URL url =
         buildUrlFor(


### PR DESCRIPTION
### Problem

Currently we have no way via the API to a delete a tag from a dataset meaning datasets could potentially be "mis tagged"

Closes: #2692

### Solution

Solution is to create a DELETE end point which removes the linkage between the dataset and the tag in

```
datasets_tag_mapping
```

One-line summary:

Add DELETE end point for dataset tags.

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [x] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
