### PR TITLE
Add tags API tests and class `BaseResourceIntegrationTest`

### DIFF
--- a/api/src/test/java/marquez/api/BaseResourceIntegrationTest.java
+++ b/api/src/test/java/marquez/api/BaseResourceIntegrationTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.api;
+
+import static marquez.common.models.CommonModelGenerator.newNamespaceName;
+import static marquez.db.DbTest.POSTGRES_12_1;
+
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineageClient;
+import io.openlineage.client.transports.HttpTransport;
+import java.net.URI;
+import java.net.URL;
+import marquez.MarquezApp;
+import marquez.MarquezConfig;
+import marquez.client.MarquezClient;
+import marquez.client.Utils;
+import marquez.client.models.Tag;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/** Base class for {@code resource} integration tests. */
+@org.junit.jupiter.api.Tag("IntegrationTests")
+@Testcontainers
+abstract class BaseResourceIntegrationTest {
+  static final String ERROR_NAMESPACE_NOT_FOUND = "Namespace '%s' not found.";
+  static final String ERROR_JOB_VERSION_NOT_FOUND = "Job version '%s' not found.";
+  static final String ERROR_JOB_NOT_FOUND = "Job '%s' not found.";
+  static final String ERROR_FAIL_IF_NOT_IN = "Expected '%s' in '%s'.";
+
+  @Container
+  static final PostgreSQLContainer<?> DB_CONTAINER = new PostgreSQLContainer<>(POSTGRES_12_1);
+
+  static {
+    DB_CONTAINER.start();
+  }
+
+  /* The OL producer. */
+  static final URI OL_PRODUCER =
+      URI.create(
+          "https://github.com/MarquezProject/marquez/tree/main/api/src/test/java/marquez/api/models/ActiveRun.java");
+
+  /* Load test configuration. */
+  static final String CONFIG_FILE = "config.test.yml";
+  static final String CONFIG_FILE_PATH = ResourceHelpers.resourceFilePath(CONFIG_FILE);
+
+  /* Tags defined in 'config.test.yml'. */
+  static final Tag PII = new Tag("PII", "Personally identifiable information");
+  static final Tag SENSITIVE = new Tag("SENSITIVE", "Contains sensitive information");
+
+  static String NAMESPACE_NAME;
+  static DropwizardAppExtension<MarquezConfig> MARQUEZ_APP;
+
+  static OpenLineage OL;
+  static OpenLineageClient OL_CLIENT;
+  static MarquezClient MARQUEZ_CLIENT;
+
+  @BeforeAll
+  public static void setUpOnce() throws Exception {
+    // (1) Use a randomly generated namespace.
+    NAMESPACE_NAME = newNamespaceName().getValue();
+
+    // (2) Configure Marquez application using test configuration and database.
+    MARQUEZ_APP =
+        new DropwizardAppExtension<>(
+            MarquezApp.class,
+            CONFIG_FILE_PATH,
+            ConfigOverride.config("db.url", DB_CONTAINER.getJdbcUrl()),
+            ConfigOverride.config("db.user", DB_CONTAINER.getUsername()),
+            ConfigOverride.config("db.password", DB_CONTAINER.getPassword()));
+    MARQUEZ_APP.before();
+
+    final URL url = Utils.toUrl("http://localhost:" + MARQUEZ_APP.getLocalPort());
+
+    // (3) Configure clients.
+    OL = new OpenLineage(OL_PRODUCER);
+    OL_CLIENT =
+        OpenLineageClient.builder()
+            .transport(HttpTransport.builder().uri(url.toURI()).build())
+            .build();
+    MARQUEZ_CLIENT = MarquezClient.builder().baseUrl(url).build();
+  }
+
+  @AfterAll
+  public static void cleanUp() {
+    MARQUEZ_APP.after();
+  }
+}

--- a/api/src/test/java/marquez/api/BaseResourceIntegrationTest.java
+++ b/api/src/test/java/marquez/api/BaseResourceIntegrationTest.java
@@ -6,7 +6,7 @@
 package marquez.api;
 
 import static marquez.common.models.CommonModelGenerator.newNamespaceName;
-import static marquez.db.DbTest.POSTGRES_12_1;
+import static marquez.db.DbTest.POSTGRES_14;
 
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
@@ -37,7 +37,7 @@ abstract class BaseResourceIntegrationTest {
   static final String ERROR_FAIL_IF_NOT_IN = "Expected '%s' in '%s'.";
 
   @Container
-  static final PostgreSQLContainer<?> DB_CONTAINER = new PostgreSQLContainer<>(POSTGRES_12_1);
+  static final PostgreSQLContainer<?> DB_CONTAINER = new PostgreSQLContainer<>(POSTGRES_14);
 
   static {
     DB_CONTAINER.start();

--- a/api/src/test/java/marquez/api/TagResourceIntegrationTest.java
+++ b/api/src/test/java/marquez/api/TagResourceIntegrationTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2018-2022 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package marquez.api;
 
 import static marquez.common.models.CommonModelGenerator.newDescription;

--- a/api/src/test/java/marquez/api/TagResourceIntegrationTest.java
+++ b/api/src/test/java/marquez/api/TagResourceIntegrationTest.java
@@ -2,14 +2,13 @@ package marquez.api;
 
 import static marquez.common.models.CommonModelGenerator.newDescription;
 import static marquez.common.models.CommonModelGenerator.newTagName;
-import static marquez.service.models.ServiceModelGenerator.newTag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
 import marquez.client.models.Tag;
 import org.junit.jupiter.api.Test;
 
-public class TagResourceTest extends BaseResourceIntegrationTest {
+public class TagResourceIntegrationTest extends BaseResourceIntegrationTest {
   @Test
   public void testApp_createTag() {
     // (1) List tags.

--- a/api/src/test/java/marquez/api/TagResourceTest.java
+++ b/api/src/test/java/marquez/api/TagResourceTest.java
@@ -1,0 +1,35 @@
+package marquez.api;
+
+import static marquez.common.models.CommonModelGenerator.newDescription;
+import static marquez.common.models.CommonModelGenerator.newTagName;
+import static marquez.service.models.ServiceModelGenerator.newTag;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import marquez.client.models.Tag;
+import org.junit.jupiter.api.Test;
+
+public class TagResourceTest extends BaseResourceIntegrationTest {
+  @Test
+  public void testApp_createTag() {
+    // (1) List tags.
+    final Set<Tag> tagsBefore = MARQUEZ_CLIENT.listTags();
+
+    // (2) Add new tag.
+    final Tag newTag = MARQUEZ_CLIENT.createTag(newTagName().getValue(), newDescription());
+
+    // (3) List tags; ensure new tag has been added.
+    final Set<Tag> tagsAfter = MARQUEZ_CLIENT.listTags();
+    assertThat(tagsAfter).hasSize(tagsBefore.size() + 1);
+    assertThat(tagsAfter).contains(newTag);
+  }
+
+  @Test
+  public void testApp_listTags() {
+    // (1) List tags.
+    final Set<Tag> tags = MARQUEZ_CLIENT.listTags();
+
+    // (2) Ensure tags 'PII', 'SENSITIVE' defined in 'config.test.yml' are present.
+    assertThat(tags).contains(PII, SENSITIVE);
+  }
+}

--- a/api/src/test/java/marquez/db/DbTest.java
+++ b/api/src/test/java/marquez/db/DbTest.java
@@ -33,11 +33,10 @@ import org.testcontainers.utility.DockerImageName;
 @Tag("DataAccessTests")
 @Testcontainers
 public abstract class DbTest {
-  public static final DockerImageName POSTGRES_12_1 = DockerImageName.parse("postgres:14");
+  public static final DockerImageName POSTGRES_14 = DockerImageName.parse("postgres:14");
 
   @Container
-  private static final PostgreSQLContainer<?> DB_CONTAINER =
-      new PostgreSQLContainer<>(POSTGRES_12_1);
+  private static final PostgreSQLContainer<?> DB_CONTAINER = new PostgreSQLContainer<>(POSTGRES_14);
 
   // Defined statically to significantly improve overall test execution.
   @RegisterExtension

--- a/api/src/test/java/marquez/db/DbTest.java
+++ b/api/src/test/java/marquez/db/DbTest.java
@@ -32,8 +32,8 @@ import org.testcontainers.utility.DockerImageName;
  */
 @Tag("DataAccessTests")
 @Testcontainers
-class DbTest {
-  private static final DockerImageName POSTGRES_12_1 = DockerImageName.parse("postgres:14");
+public abstract class DbTest {
+  public static final DockerImageName POSTGRES_12_1 = DockerImageName.parse("postgres:14");
 
   @Container
   private static final PostgreSQLContainer<?> DB_CONTAINER =


### PR DESCRIPTION
This PR adds an integration test suite for **class** [`TagResource`](https://github.com/MarquezProject/marquez/blob/main/api/src/main/java/marquez/api/TagResource.java) and the base **class** `BaseResourceIntegrationTest` to be used when writing resource integration test.