### PR TITLE
CI fix: remove delombok plugin from gradle

### DIFF
--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -35,7 +35,6 @@ import marquez.db.JobVersionDao.BagOfJobVersionInfo;
 import marquez.db.JobVersionDao.IoType;
 import marquez.db.JobVersionDao.JobRowRunDetails;
 import marquez.db.RunDao.RunUpsert;
-import marquez.db.RunDao.RunUpsert.RunUpsertBuilder;
 import marquez.db.mappers.LineageEventMapper;
 import marquez.db.models.ColumnLineageRow;
 import marquez.db.models.DatasetFieldRow;
@@ -330,7 +329,7 @@ public interface OpenLineageDao extends BaseDao {
 
     final UUID runUuid = runToUuid(event.getRun().getRunId());
     RunRow run;
-    RunUpsertBuilder runUpsertBuilder =
+    RunUpsert.RunUpsertBuilder runUpsertBuilder =
         RunUpsert.builder()
             .runUuid(runUuid)
             .parentRunUuid(parentUuid.orElse(null))

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ buildscript {
         classpath 'com.adarshr:gradle-test-logger-plugin:3.2.0'
         classpath 'gradle.plugin.com.github.johnrengelman:shadow:7.1.2'
         classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.22.0'
-        classpath "io.freefair.gradle:lombok-plugin:8.4"
     }
 }
 
@@ -40,7 +39,6 @@ subprojects {
     apply plugin: 'com.github.johnrengelman.shadow'
     apply plugin: "com.diffplug.spotless"
     apply plugin: "pmd"
-    apply plugin: "io.freefair.lombok"
 
     project(':api') {
         apply plugin: 'application'
@@ -97,11 +95,7 @@ subprojects {
         archiveClassifier.set("sources")
     }
 
-    task delombokJavadocs(type: Javadoc) {
-        source = delombok
-    }
-
-    task javadocJar(type: Jar, dependsOn: delombokJavadocs) {
+    task javadocJar(type: Jar) {
         from javadoc.destinationDir
         archiveClassifier.set("javadoc")
     }


### PR DESCRIPTION
### Problem

Publish snapshot is failing on `:api:delombokJavadocs` task.

### Solution

Remove delombok Gradle plugin code when generating java docs. This should fix snapshot publishing. 

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
