### PR TITLE
Fix dataset tag reducers bug

### DIFF
--- a/web/src/store/reducers/datasets.ts
+++ b/web/src/store/reducers/datasets.ts
@@ -64,13 +64,13 @@ export default (state: IDatasetsState = initialState, action: IDatasetsAction): 
     case DELETE_DATASET_SUCCESS:
       return { ...state, deletedDatasetName: payload.datasetName }
     case DELETE_DATASET_TAG:
-      return { ...state, refreshTags: true }
+      return { ...state, refreshTags: false }
     case DELETE_DATASET_TAG_SUCCESS:
-      return { ...state, result: payload.datasets, refreshTags: false }
-    case ADD_DATASET_TAG:
       return { ...state, refreshTags: true }
+    case ADD_DATASET_TAG:
+      return { ...state, refreshTags: false }
     case ADD_DATASET_TAG_SUCCESS:
-      return { ...state, result: payload.datasets, refreshTags: false }
+      return { ...state, refreshTags: true }
     default:
       return state
   }


### PR DESCRIPTION
### Problem

PR #2714  introduced the ability to add tags to a dataset.

Looks like the reducer was not done correctly and its interfering with the datasets route on the side bar after a dataset tag update.

Closes: #2715

### Solution

remove result from dataset tags reducer

One-line summary:

remove result from dataset tags reducer to fix sidebar bug

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [x] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
