### PR TITLE
Add scripts to Head for GA traffic metrics.

### DIFF
--- a/docs/v2/docusaurus.config.js
+++ b/docs/v2/docusaurus.config.js
@@ -10,7 +10,6 @@ const config = {
     tagline: 'Data lineage for every pipeline.',
     favicon: 'img/favicon.ico',
 
-
     // Set the production url of your site here
     url: 'https://peppy-sprite-186812.netlify.app',
     // Set the /<baseUrl>/ pathname under which your site is served
@@ -32,6 +31,7 @@ const config = {
         defaultLocale: 'en',
         locales: ['en'],
     },
+    
     headTags: [
         {
             tagName: 'link',
@@ -41,6 +41,7 @@ const config = {
             }
         }
     ],
+    
     presets: [
         [
             'classic',
@@ -162,6 +163,15 @@ const config = {
                 theme: lightCodeTheme,
             },
         }),
+    
+    scripts: [
+        'js/google_analytics.js',
+        {
+            src: 'https://www.googletagmanager.com/gtag/js?id=G-223DXLT48B',
+            async: true,
+        },
+    ],
+    
     plugins: [
         [
             'docusaurus-plugin-openapi-docs',
@@ -177,6 +187,7 @@ const config = {
             },
         ]
     ],
+    
     themes: ["docusaurus-theme-openapi-docs"]
 };
 

--- a/docs/v2/static/js/google_analytics.js
+++ b/docs/v2/static/js/google_analytics.js
@@ -1,0 +1,5 @@
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+
+gtag('config', 'G-223DXLT48B');


### PR DESCRIPTION
### Problem

Traffic metrics on GA have been inactive since the github domain was decommissioned.

### Solution

This adds required scripts from Google for starting usage data collection on the new site.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
