### PR TITLE
api: fill data in column lineage input nodes.

### DIFF
--- a/api/src/main/java/marquez/db/models/ColumnLineageNodeData.java
+++ b/api/src/main/java/marquez/db/models/ColumnLineageNodeData.java
@@ -42,6 +42,17 @@ public class ColumnLineageNodeData implements NodeData {
     this.inputFields = inputFields;
   }
 
+  public ColumnLineageNodeData(InputFieldNodeData data) {
+    this.namespace = data.namespace;
+    this.dataset = data.dataset;
+    this.datasetVersion = data.datasetVersion;
+    this.field = data.field;
+    this.fieldType = "";
+    this.transformationDescription = data.transformationDescription;
+    this.transformationType = data.transformationType;
+    this.inputFields = ImmutableList.of();
+  }
+
   /**
    * @deprecated Moved into {@link ColumnLineageInputField} to support multiple jobs writing to a
    *     single dataset. This method is scheduled to be removed in release {@code 0.30.0}.

--- a/api/src/main/java/marquez/service/ColumnLineageService.java
+++ b/api/src/main/java/marquez/service/ColumnLineageService.java
@@ -68,10 +68,14 @@ public class ColumnLineageService extends DelegatingDaos.DelegatingColumnLineage
               NodeId nodeId = toNodeId(columnLineageNodeData, includeVersion);
               graphNodes.put(nodeId, Node.datasetField().data(columnLineageNodeData).id(nodeId));
               columnLineageNodeData.getInputFields().stream()
-                  .map(i -> toNodeId(i, includeVersion))
                   .forEach(
-                      inputNodeId -> {
-                        graphNodes.putIfAbsent(inputNodeId, Node.datasetField().id(inputNodeId));
+                      inputNode -> {
+                        NodeId inputNodeId = toNodeId(inputNode, includeVersion);
+                        graphNodes.putIfAbsent(
+                            inputNodeId,
+                            Node.datasetField()
+                                .id(inputNodeId)
+                                .data(new ColumnLineageNodeData(inputNode)));
                         Optional.ofNullable(outEdges.get(inputNodeId))
                             .ifPresentOrElse(
                                 nodeEdges -> nodeEdges.add(nodeId),

--- a/api/src/main/java/marquez/service/models/NodeData.java
+++ b/api/src/main/java/marquez/service/models/NodeData.java
@@ -8,11 +8,13 @@ package marquez.service.models;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import marquez.db.models.ColumnLineageNodeData;
+import marquez.db.models.InputFieldNodeData;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
 @JsonSubTypes({
   @JsonSubTypes.Type(DatasetData.class),
   @JsonSubTypes.Type(JobData.class),
-  @JsonSubTypes.Type(ColumnLineageNodeData.class)
+  @JsonSubTypes.Type(ColumnLineageNodeData.class),
+  @JsonSubTypes.Type(InputFieldNodeData.class)
 })
 public interface NodeData {}

--- a/api/src/test/java/marquez/service/ColumnLineageServiceTest.java
+++ b/api/src/test/java/marquez/service/ColumnLineageServiceTest.java
@@ -11,7 +11,6 @@ import static marquez.db.ColumnLineageTestUtils.getDatasetB;
 import static marquez.db.ColumnLineageTestUtils.getDatasetC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
@@ -102,7 +101,10 @@ public class ColumnLineageServiceTest {
 
     // check dataset_A node
     Node col_a = getNode(lineage, "dataset_a", "col_b").get();
-    assertNull((ColumnLineageNodeData) col_a.getData());
+    ColumnLineageNodeData col_a_data = (ColumnLineageNodeData) col_a.getData();
+    assertThat(col_a_data.getInputFields()).hasSize(0);
+    assertEquals("dataset_a", col_a_data.getDataset());
+    assertEquals("", col_a_data.getFieldType());
 
     // verify edges
     // assert dataset_B (col_c) -> dataset_A (col_a)


### PR DESCRIPTION
### Problem

As stated in #2725 data is null for output nodes in column lineage endpoint.

### Solution

Fill data field.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
