### PR TITLE
Hardcoding circle CI image in config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
   build-api:
     working_directory: ~/marquez
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2004:2023.10.1
     environment:
       TESTCONTAINERS_RYUK_DISABLED: true
     steps:
@@ -49,7 +49,7 @@ jobs:
   build-image-api:
     working_directory: ~/marquez
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2004:2023.10.1
     steps:
       - checkout
       - run: docker build --no-cache --tag "marquezproject/marquez:${CIRCLE_SHA1}" .
@@ -60,7 +60,7 @@ jobs:
   build-image-web:
     working_directory: ~/marquez/web
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2004:2023.10.1
     steps:
       - *checkout_project_root
       - run: docker build --no-cache --tag "marquezproject/marquez-web:${CIRCLE_SHA1}" .
@@ -92,7 +92,7 @@ jobs:
   build-client-java:
     working_directory: ~/marquez
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2004:2023.10.1
     steps:
       - checkout
       - restore_cache:
@@ -150,7 +150,7 @@ jobs:
   load-test-api:
     working_directory: ~/marquez
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2004:2023.10.1
     steps:
       - checkout
       - run: ./.circleci/get-docker-compose.sh
@@ -165,7 +165,7 @@ jobs:
   migrate-db:
     working_directory: ~/marquez
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2004:2023.10.1
     resource_class: large
     steps:
       - checkout
@@ -175,7 +175,7 @@ jobs:
   publish-snapshot:
     working_directory: ~/marquez
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2004:2023.10.1
     steps:
       - checkout
       - run: ./.circleci/get-jdk17.sh
@@ -184,7 +184,7 @@ jobs:
   release-java:
     working_directory: ~/marquez
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2004:2023.10.1
     steps:
       - checkout
       - run: ./.circleci/get-jdk17.sh
@@ -204,7 +204,7 @@ jobs:
   release-docker:
     working_directory: ~/marquez
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2004:2023.10.1
     steps:
       - checkout
       - run: ./docker/login.sh


### PR DESCRIPTION
### Problem

Current circle CI builds are failing the

```
api-load-test.sh
```

as k6 doesn't not seem to be installing.  Last successful image build was using

```
ubuntu-2004:2023.10.1
```

so swapping  all references in the config from
```
ubuntu-2004:current
```
to
```
ubuntu-2004:2023.10.1
```

Closes: #2743 

### Solution

Hard coding last known working image into config.

One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [x] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
