### PR TITLE
Quality of life updates for new lineage graph

### DIFF
--- a/web/libs/graph/src/components/ZoomPanSvg/ZoomPanSvg.tsx
+++ b/web/libs/graph/src/components/ZoomPanSvg/ZoomPanSvg.tsx
@@ -33,7 +33,7 @@ export interface ZoomPanControls {
   centerOnExtent(extent: Extent): void
   scaleZoom(kDelta?: number): void
   resetZoom(): void
-  centerOnPositionedNode(nodeId: string): void
+  centerOnPositionedNode(nodeId: string, k?: number): void
 }
 
 interface Props extends BoxProps {
@@ -232,12 +232,12 @@ export const ZoomPanSvg = ({
     animateToZoomState(zoomIdentity)
   }
 
-  const centerOnPositionedNode = (nodeId: string) => {
+  const centerOnPositionedNode = (nodeId: string, k = currentZoomState.k) => {
     const node = positionedNodes.find((node) => node.id === nodeId)
     if (!node) return
 
     const extent = getNodeExtent(node)
-    centerOnExtent(extent)
+    centerOnExtent(extent, k)
   }
 
   const fitContent = () => {

--- a/web/src/routes/column-level/ZoomControls.tsx
+++ b/web/src/routes/column-level/ZoomControls.tsx
@@ -1,4 +1,4 @@
-import { CropFree, ZoomIn, ZoomOut } from '@mui/icons-material'
+import { CenterFocusStrong, CropFree, ZoomIn, ZoomOut } from '@mui/icons-material'
 import { Tooltip } from '@mui/material'
 import { theme } from '../../helpers/theme'
 import Box from '@mui/material/Box'
@@ -8,9 +8,14 @@ import React from 'react'
 interface ZoomControlsProps {
   handleScaleZoom: (inOrOut: 'in' | 'out') => void
   handleResetZoom: () => void
+  handleCenterOnNode?: () => void
 }
 
-export const ZoomControls = ({ handleScaleZoom, handleResetZoom }: ZoomControlsProps) => {
+export const ZoomControls = ({
+  handleScaleZoom,
+  handleResetZoom,
+  handleCenterOnNode,
+}: ZoomControlsProps) => {
   return (
     <Box
       display={'flex'}
@@ -38,6 +43,13 @@ export const ZoomControls = ({ handleScaleZoom, handleResetZoom }: ZoomControlsP
           <CropFree />
         </IconButton>
       </Tooltip>
+      {handleCenterOnNode && (
+        <Tooltip title={'Center on selected node'} placement={'left'}>
+          <IconButton size={'small'} onClick={handleCenterOnNode}>
+            <CenterFocusStrong />
+          </IconButton>
+        </Tooltip>
+      )}
     </Box>
   )
 }

--- a/web/src/routes/table-level/ActionBar.tsx
+++ b/web/src/routes/table-level/ActionBar.tsx
@@ -109,10 +109,12 @@ export const ActionBar = ({
             control={
               <Switch
                 size={'small'}
-                defaultChecked
                 value={isFull}
+                defaultChecked={searchParams.get('isFull') === 'true'}
                 onChange={(_, checked) => {
                   setIsFull(checked)
+                  searchParams.set('isFull', checked.toString())
+                  setSearchParams(searchParams)
                 }}
               />
             }
@@ -123,8 +125,11 @@ export const ActionBar = ({
               <Switch
                 size={'small'}
                 value={isCompact}
+                defaultChecked={searchParams.get('isCompact') === 'true'}
                 onChange={(_, checked) => {
                   setIsCompact(checked)
+                  searchParams.set('isCompact', checked.toString())
+                  setSearchParams(searchParams)
                 }}
               />
             }

--- a/web/src/routes/table-level/TableLevel.tsx
+++ b/web/src/routes/table-level/TableLevel.tsx
@@ -1,8 +1,8 @@
 import * as Redux from 'redux'
 import { ActionBar } from './ActionBar'
 import { Box } from '@mui/system'
+import { DEFAULT_MAX_SCALE, Graph, ZoomPanControls } from '../../../libs/graph'
 import { Drawer } from '@mui/material'
-import { Graph, ZoomPanControls } from '../../../libs/graph'
 import { IState } from '../../store/reducers'
 import { JobOrDataset } from '../../components/lineage/types'
 import { LineageGraph } from '../../types/api'
@@ -41,8 +41,8 @@ const ColumnLevel: React.FC<ColumnLevelProps> = ({
 
   const [depth, setDepth] = useState(Number(searchParams.get('depth')) || 2)
 
-  const [isCompact, setIsCompact] = useState(false)
-  const [isFull, setIsFull] = useState(true)
+  const [isCompact, setIsCompact] = useState(searchParams.get('isCompact') === 'true')
+  const [isFull, setIsFull] = useState(searchParams.get('isFull') === 'true')
 
   const graphControls = useRef<ZoomPanControls>()
 
@@ -62,6 +62,13 @@ const ColumnLevel: React.FC<ColumnLevelProps> = ({
 
   const handleResetZoom = () => {
     graphControls.current?.fitContent()
+  }
+
+  const handleCenterOnNode = () => {
+    graphControls.current?.centerOnPositionedNode(
+      `${nodeType}:${namespace}:${name}`,
+      DEFAULT_MAX_SCALE
+    )
   }
 
   const setGraphControls = useCallbackRef((zoomControls) => {
@@ -103,7 +110,11 @@ const ColumnLevel: React.FC<ColumnLevelProps> = ({
             <TableLevelDrawer />
           </Box>
         </Drawer>
-        <ZoomControls handleScaleZoom={handleScaleZoom} handleResetZoom={handleResetZoom} />
+        <ZoomControls
+          handleCenterOnNode={handleCenterOnNode}
+          handleScaleZoom={handleScaleZoom}
+          handleResetZoom={handleResetZoom}
+        />
         <ParentSize>
           {(parent) => (
             <Graph<JobOrDataset, TableLevelNodeData>


### PR DESCRIPTION
### Problem

![image](https://github.com/MarquezProject/marquez/assets/7514204/62cc23e4-9574-4ce4-93c2-f273082ba72d)

Several small updates for our graph:
- Preserve `complete` and `full` mode in the url for lineage graph navigation
- Default `complete` mode to false (This is going to make large graphs more palatable) 
- Adding button to zoom to the selected node. (Lineage graph only)

One-line summary: Visual updates from early feedback on lineage graph navigation.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
