### PR TITLE
Feat/job to job lineage

### DIFF
--- a/api/src/main/java/marquez/db/Columns.java
+++ b/api/src/main/java/marquez/db/Columns.java
@@ -91,6 +91,7 @@ public final class Columns {
 
   /* JOB ROW COLUMNS */
   public static final String PARENT_JOB_NAME = "parent_job_name";
+  public static final String PARENT_JOB_UUID = "parent_job_uuid";
   public static final String SIMPLE_NAME = "simple_name";
   public static final String SYMLINK_TARGET_UUID = "symlink_target_uuid";
 

--- a/api/src/main/java/marquez/db/LineageDao.java
+++ b/api/src/main/java/marquez/db/LineageDao.java
@@ -100,6 +100,13 @@ public interface LineageDao {
 
   @SqlQuery(
       """
+    SELECT j.*, NULL as input_uuids, NULL AS output_uuids FROM jobs_view j
+    WHERE j.parent_job_uuid= :jobId
+    LIMIT 1""")
+  Optional<JobData> getParentJobData(UUID jobId);
+
+  @SqlQuery(
+      """
       SELECT ds.*, dv.fields, dv.lifecycle_state
       FROM datasets_view ds
       LEFT JOIN dataset_versions dv on dv.uuid = ds.current_version_uuid

--- a/api/src/main/java/marquez/db/mappers/JobDataMapper.java
+++ b/api/src/main/java/marquez/db/mappers/JobDataMapper.java
@@ -10,6 +10,7 @@ import static marquez.db.Columns.stringOrThrow;
 import static marquez.db.Columns.timestampOrThrow;
 import static marquez.db.Columns.urlOrNull;
 import static marquez.db.Columns.uuidArrayOrEmpty;
+import static marquez.db.Columns.uuidOrNull;
 import static marquez.db.Columns.uuidOrThrow;
 
 import com.google.common.collect.ImmutableSet;
@@ -39,6 +40,7 @@ public class JobDataMapper implements RowMapper<JobData> {
         JobName.of(stringOrThrow(results, Columns.NAME)),
         stringOrThrow(results, Columns.SIMPLE_NAME),
         stringOrNull(results, Columns.PARENT_JOB_NAME),
+        uuidOrNull(results, Columns.PARENT_JOB_UUID),
         timestampOrThrow(results, Columns.CREATED_AT),
         timestampOrThrow(results, Columns.UPDATED_AT),
         NamespaceName.of(stringOrThrow(results, Columns.NAMESPACE_NAME)),

--- a/api/src/main/java/marquez/db/mappers/JobMapper.java
+++ b/api/src/main/java/marquez/db/mappers/JobMapper.java
@@ -57,6 +57,7 @@ public final class JobMapper implements RowMapper<Job> {
             JobName.of(stringOrThrow(results, Columns.NAME)),
             stringOrThrow(results, Columns.SIMPLE_NAME),
             stringOrNull(results, Columns.PARENT_JOB_NAME),
+            uuidOrNull(results, Columns.PARENT_JOB_UUID),
             timestampOrThrow(results, Columns.CREATED_AT),
             timestampOrThrow(results, Columns.UPDATED_AT),
             getDatasetFromJsonOrNull(results, "current_inputs"),

--- a/api/src/main/java/marquez/db/mappers/JobRowMapper.java
+++ b/api/src/main/java/marquez/db/mappers/JobRowMapper.java
@@ -45,6 +45,7 @@ public final class JobRowMapper implements RowMapper<JobRow> {
         stringOrThrow(results, Columns.NAME),
         stringOrThrow(results, Columns.SIMPLE_NAME),
         stringOrNull(results, Columns.PARENT_JOB_NAME),
+        uuidOrNull(results, Columns.PARENT_JOB_UUID),
         stringOrNull(results, Columns.DESCRIPTION),
         uuidOrNull(results, Columns.CURRENT_VERSION_UUID),
         stringOrNull(results, "current_location"),

--- a/api/src/main/java/marquez/db/models/JobRow.java
+++ b/api/src/main/java/marquez/db/models/JobRow.java
@@ -25,6 +25,7 @@ public class JobRow {
   @NonNull String name;
   @NonNull String simpleName;
   @Nullable String parentJobName;
+  @Nullable UUID parentJoUuid;
   @Nullable String description;
   @Nullable UUID currentVersionUuid;
   @Nullable String location;

--- a/api/src/main/java/marquez/service/LineageService.java
+++ b/api/src/main/java/marquez/service/LineageService.java
@@ -149,6 +149,18 @@ public class LineageService extends DelegatingLineageDao {
         log.error("Could not find job node for {}", jobData);
         continue;
       }
+
+      Optional<JobData> parentJobData = getParentJobData(data.getParentJobUuid());
+      parentJobData.ifPresent(
+          parent -> {
+            log.error(
+                "--------Condition is working-------- child: {}, parent: {} with UUID: {} and data {}",
+                parent.getId().getName(),
+                data.getParentJobName(),
+                data.getParentJobUuid(),
+                data);
+          });
+
       Set<DatasetData> inputs =
           data.getInputUuids().stream()
               .map(datasetById::get)

--- a/api/src/main/java/marquez/service/LineageService.java
+++ b/api/src/main/java/marquez/service/LineageService.java
@@ -153,11 +153,10 @@ public class LineageService extends DelegatingLineageDao {
       Optional<JobData> parentJobData = getParentJobData(data.getParentJobUuid());
       parentJobData.ifPresent(
           parent -> {
-            log.error(
-                "--------Condition is working-------- child: {}, parent: {} with UUID: {} and data {}",
+            log.debug(
+                "child: {}, parent: {} with UUID: {}",
                 parent.getId().getName(),
                 data.getParentJobName(),
-                data.getParentJobUuid(),
                 data);
           });
 

--- a/api/src/main/java/marquez/service/models/Job.java
+++ b/api/src/main/java/marquez/service/models/Job.java
@@ -32,6 +32,7 @@ public final class Job {
   @Getter private final JobName name;
   @Getter private final String simpleName;
   @Getter private final String parentJobName;
+  @Getter private final UUID parentJobUuid;
   @Getter private final Instant createdAt;
   @Getter private final Instant updatedAt;
   @Getter private final NamespaceName namespace;
@@ -50,6 +51,7 @@ public final class Job {
       @NonNull final JobName name,
       @NonNull String simpleName,
       @Nullable String parentJobName,
+      @Nullable UUID parentJobUuid,
       @NonNull final Instant createdAt,
       @NonNull final Instant updatedAt,
       @NonNull final Set<DatasetId> inputs,
@@ -65,6 +67,7 @@ public final class Job {
     this.name = name;
     this.simpleName = simpleName;
     this.parentJobName = parentJobName;
+    this.parentJobUuid = parentJobUuid;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
     this.namespace = id.getNamespace();

--- a/api/src/main/java/marquez/service/models/JobData.java
+++ b/api/src/main/java/marquez/service/models/JobData.java
@@ -34,6 +34,7 @@ public class JobData implements NodeData {
   @NonNull JobName name;
   @NonNull String simpleName;
   @Nullable String parentJobName;
+  @Nullable UUID parentJobUuid;
   @NonNull Instant createdAt;
   @NonNull Instant updatedAt;
   @NonNull NamespaceName namespace;
@@ -70,5 +71,9 @@ public class JobData implements NodeData {
   @JsonIgnore
   public Set<UUID> getOutputUuids() {
     return outputUuids;
+  }
+
+  public UUID getParentJobUuid() {
+    return parentJobUuid;
   }
 }

--- a/api/src/test/java/marquez/db/models/DbModelGenerator.java
+++ b/api/src/test/java/marquez/db/models/DbModelGenerator.java
@@ -211,6 +211,7 @@ public final class DbModelGenerator extends Generator {
       @NonNull final UUID namespaceUuid,
       @NonNull final String namespaceName) {
     final String parentJobName = newJobName().getValue();
+    final UUID parentJobUuid = newRowUuid();
     final String jobName = newJobName().getValue();
     final String jobSimpleName = jobName;
     return new JobRow(
@@ -223,6 +224,7 @@ public final class DbModelGenerator extends Generator {
         jobName,
         jobSimpleName,
         parentJobName,
+        parentJobUuid,
         newDescription(),
         null,
         newLocation().toString(),


### PR DESCRIPTION
### Problem

Currently, Marquez displays the parent jobs and their child jobs independently with no lineage connection. For exemple, a Airflow task initiated in an Airflow DAG is not visually linked in the UI to its parent, although the information is present in the ParentRunFacet.

Closes: #2484

### Solution / Open Questions

This solution mainly serves as the trigger of a larger discussion towards full parent/child hierarchy handling in Marquez. Adding a Job to Job representation in the lineage could be a great step toward a retrieving a more complete picture of the data landscape in general. 

For now, the proposed modifications only focuses on the backend API, adding the Job UUID along with the parent name to the job metadata returned.

This could be used by the Front End to display the parent node as a short-term solution.

If we want to go further, this work leads to implementation questions: 
- Should the [lineage query](https://github.com/MarquezProject/marquez/blob/a9b0b3e2c1d7a28458c691a752ea83fe9778023e/api/src/main/java/marquez/db/LineageDao.java#L99) also return the parent jobs?
- Similar to jobs inputs and outputs, should the parents and children appear in the Job model? 
- How to model the hierarchy in the Front? A simple node to node relationship like jobs and datasets, or another graphical representation? 


One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
