### PR TITLE
Improve visual display for lineage

### DIFF
--- a/web/src/components/core/tooltip/MQTooltip.tsx
+++ b/web/src/components/core/tooltip/MQTooltip.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createTheme } from '@mui/material/styles'
+import { grey } from '@mui/material/colors'
 import { useTheme } from '@emotion/react'
 import React, { ReactElement } from 'react'
 import Tooltip from '@mui/material/Tooltip'
@@ -21,8 +22,8 @@ const MQTooltip: React.FC<MqToolTipProps> = ({ title, children, placement }) => 
       componentsProps={{
         tooltip: {
           sx: {
-            backgroundColor: theme.palette.background.default,
-            color: theme.palette.common.white,
+            backgroundColor: `${theme.palette.common.white}`,
+            color: grey['900'],
             border: `1px solid ${theme.palette.common.white}`,
             maxWidth: '600px',
             fontSize: 14,

--- a/web/src/helpers/theme.ts
+++ b/web/src/helpers/theme.ts
@@ -43,7 +43,7 @@ export const theme = createTheme({
       main: '#7D7D7D',
     },
     info: {
-      main: '#FECC00',
+      main: '#9c98ec',
     },
     background: {
       default: '#191f26',

--- a/web/src/routes/table-level/TableLevel.tsx
+++ b/web/src/routes/table-level/TableLevel.tsx
@@ -46,6 +46,8 @@ const ColumnLevel: React.FC<ColumnLevelProps> = ({
 
   const graphControls = useRef<ZoomPanControls>()
 
+  const collapsedNodes = searchParams.get('collapsedNodes')
+
   useEffect(() => {
     if (name && namespace && nodeType) {
       fetchLineage(nodeType as JobOrDataset, namespace, name, depth)
@@ -79,7 +81,8 @@ const ColumnLevel: React.FC<ColumnLevelProps> = ({
     lineage,
     `${nodeType}:${namespace}:${name}`,
     isCompact,
-    isFull
+    isFull,
+    collapsedNodes
   )
 
   useEffect(() => {

--- a/web/src/routes/table-level/TableLineageDatasetNode.tsx
+++ b/web/src/routes/table-level/TableLineageDatasetNode.tsx
@@ -36,7 +36,6 @@ const TableLineageDatasetNode = ({ node }: TableLineageDatasetNodeProps & StateP
   const [searchParams, setSearchParams] = useSearchParams()
   const isCollapsed = searchParams.get('collapsedNodes')?.split(',').includes(node.id)
 
-  console.log(isCollapsed)
   const handleClick = () => {
     navigate(
       `/lineage/dataset/${encodeURIComponent(node.data.dataset.namespace)}/${encodeURIComponent(

--- a/web/src/routes/table-level/TableLineageDatasetNode.tsx
+++ b/web/src/routes/table-level/TableLineageDatasetNode.tsx
@@ -62,98 +62,109 @@ const TableLineageDatasetNode = ({ node }: TableLineageDatasetNodeProps & StateP
   }
 
   return (
-    <MQTooltip title={addToToolTip(node.data.dataset)}>
-      <g>
-        <Box
-          component={'rect'}
-          sx={{
-            x: 0,
-            y: 0,
-            width: node.width,
-            height: node.height,
-            filter: isSelected ? `drop-shadow( 0 0 4px ${theme.palette.primary.main})` : 'none',
-            rx: 4,
-            fill: theme.palette.background.paper,
-            cursor: 'pointer',
-            transition: 'all 0.3',
-          }}
-          cursor={'pointer'}
-          onClick={handleClick}
-        />
-        <Box
-          component={'rect'}
-          x={0}
-          y={0}
-          height={24}
-          width={24}
-          sx={{ rx: 4, fill: theme.palette.info.main }}
-        />
-        <FontAwesomeIcon
-          aria-hidden={'true'}
-          title={'Job'}
-          icon={faDatabase}
-          width={ICON_SIZE}
-          height={ICON_SIZE}
-          x={6}
-          y={ICON_SIZE / 2}
-          color={theme.palette.common.white}
-          cursor={'pointer'}
-          onClick={handleClick}
-        />
-        <foreignObject width={16} height={24} x={node.width - 18} y={0}>
-          <MQTooltip title={isCollapsed ? 'Expand' : 'Collapse'} placement={'top'}>
-            <IconButton
-              sx={{ width: 16, height: 16 }}
-              onClick={(event) => {
-                event.stopPropagation()
-                const collapsedNodes = searchParams.get('collapsedNodes')
-                if (collapsedNodes) {
-                  const collapsedNodesArray = collapsedNodes.split(',')
-                  if (collapsedNodesArray.includes(node.id)) {
-                    collapsedNodesArray.splice(collapsedNodesArray.indexOf(node.id), 1)
-                  } else {
-                    collapsedNodesArray.push(node.id)
-                  }
-                  searchParams.set('collapsedNodes', collapsedNodesArray.toString())
+    <g>
+      <Box
+        component={'rect'}
+        sx={{
+          x: 0,
+          y: 0,
+          width: node.width,
+          height: node.height,
+          filter: isSelected ? `drop-shadow( 0 0 4px ${theme.palette.primary.main})` : 'none',
+          rx: 4,
+          fill: theme.palette.background.paper,
+          cursor: 'pointer',
+          transition: 'all 0.3',
+        }}
+        cursor={'pointer'}
+        onClick={handleClick}
+      />
+      <Box
+        component={'rect'}
+        x={0}
+        y={0}
+        height={24}
+        width={24}
+        sx={{ rx: 4, fill: theme.palette.info.main }}
+      />
+
+      <FontAwesomeIcon
+        aria-hidden={'true'}
+        title={'Job'}
+        icon={faDatabase}
+        width={ICON_SIZE}
+        height={ICON_SIZE}
+        x={6}
+        y={ICON_SIZE / 2}
+        color={theme.palette.common.white}
+        onClick={handleClick}
+      />
+      <foreignObject width={16} height={24} x={node.width - 18} y={0}>
+        <MQTooltip title={isCollapsed ? 'Expand' : 'Collapse'} placement={'top'}>
+          <IconButton
+            sx={{ width: 10, height: 10 }}
+            onClick={(event) => {
+              event.stopPropagation()
+              const collapsedNodes = searchParams.get('collapsedNodes')
+              if (collapsedNodes) {
+                const collapsedNodesArray = collapsedNodes.split(',')
+                if (collapsedNodesArray.includes(node.id)) {
+                  collapsedNodesArray.splice(collapsedNodesArray.indexOf(node.id), 1)
                 } else {
-                  searchParams.set('collapsedNodes', node.id)
+                  collapsedNodesArray.push(node.id)
                 }
-                setSearchParams(searchParams)
+                searchParams.set('collapsedNodes', collapsedNodesArray.toString())
+              } else {
+                searchParams.set('collapsedNodes', node.id)
+              }
+              setSearchParams(searchParams)
+            }}
+          >
+            <ChevronLeft
+              sx={{
+                width: 10,
+                height: 10,
+                rotate: !isCollapsed ? '-90deg' : 0,
+                transition: 'rotate .3s',
               }}
+            />
+          </IconButton>
+        </MQTooltip>
+      </foreignObject>
+      <MQTooltip title={addToToolTip(node.data.dataset)}>
+        <g>
+          <text
+            fontSize='8'
+            fontFamily={`${'Source Code Pro'}, mono`}
+            fill={'white'}
+            x={28}
+            y={10}
+            onClick={handleClick}
+            cursor={'pointer'}
+          >
+            DATASET
+          </text>
+          <text fontSize='8' fill={'white'} x={28} y={20} cursor={'pointer'} onClick={handleClick}>
+            {truncateText(node.data.dataset.name, 15)}
+          </text>
+        </g>
+      </MQTooltip>
+
+      {!isCompact &&
+        node.data.dataset.fields.map((field, index) => {
+          return (
+            <text
+              key={field.name}
+              fontSize='8'
+              fill={THEME_EXTRA.typography.subdued}
+              x={10}
+              y={14 + 10 + 10 * (index + 1)}
             >
-              <ChevronLeft
-                sx={{
-                  width: 16,
-                  height: 16,
-                  rotate: !isCollapsed ? '-90deg' : 0,
-                  transition: 'rotate .3s',
-                }}
-              />
-            </IconButton>
-          </MQTooltip>
-        </foreignObject>
-        <text fontSize='8' fill={'white'} x={28} y={10} onClick={handleClick} cursor={'pointer'}>
-          DATASET
-        </text>
-        <text fontSize='8' fill={'white'} x={28} y={20} cursor={'pointer'} onClick={handleClick}>
-          {truncateText(node.data.dataset.name, 15)}
-        </text>
-        {!isCompact &&
-          node.data.dataset.fields.map((field, index) => {
-            return (
-              <text
-                key={field.name}
-                fontSize='8'
-                fill={THEME_EXTRA.typography.subdued}
-                x={10}
-                y={14 + 10 + 10 * (index + 1)}
-              >
-                - {truncateText(field.name, 20)}
-              </text>
-            )
-          })}
-      </g>
-    </MQTooltip>
+              - {truncateText(field.name, 20)}
+            </text>
+          )
+        })}
+    </g>
   )
 }
 

--- a/web/src/routes/table-level/TableLineageDatasetNode.tsx
+++ b/web/src/routes/table-level/TableLineageDatasetNode.tsx
@@ -1,3 +1,4 @@
+import { ChevronLeft } from '@mui/icons-material'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { IState } from '../../store/reducers'
 import { LineageDataset } from '../../components/lineage/types'
@@ -6,11 +7,12 @@ import { PositionedNode } from '../../../libs/graph'
 import { THEME_EXTRA, theme } from '../../helpers/theme'
 import { TableLineageDatasetNodeData } from './nodes'
 import { connect } from 'react-redux'
+
 import { faDatabase } from '@fortawesome/free-solid-svg-icons/faDatabase'
-import { grey } from '@mui/material/colors'
 import { truncateText } from '../../helpers/text'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import Box from '@mui/system/Box'
+import IconButton from '@mui/material/IconButton'
 import MQTooltip from '../../components/core/tooltip/MQTooltip'
 import React from 'react'
 
@@ -31,7 +33,10 @@ const TableLineageDatasetNode = ({ node }: TableLineageDatasetNodeProps & StateP
   const navigate = useNavigate()
   const { name, namespace } = useParams()
   const isSelected = name === node.data.dataset.name && namespace === node.data.dataset.namespace
+  const [searchParams, setSearchParams] = useSearchParams()
+  const isCollapsed = searchParams.get('collapsedNodes')?.split(',').includes(node.id)
 
+  console.log(isCollapsed)
   const handleClick = () => {
     navigate(
       `/lineage/dataset/${encodeURIComponent(node.data.dataset.namespace)}/${encodeURIComponent(
@@ -66,15 +71,22 @@ const TableLineageDatasetNode = ({ node }: TableLineageDatasetNodeProps & StateP
             y: 0,
             width: node.width,
             height: node.height,
-            stroke: isSelected ? theme.palette.primary.main : grey['100'],
             filter: isSelected ? `drop-shadow( 0 0 4px ${theme.palette.primary.main})` : 'none',
             rx: 4,
             fill: theme.palette.background.paper,
             cursor: 'pointer',
-            transition: 'filter 0.3',
+            transition: 'all 0.3',
           }}
           cursor={'pointer'}
           onClick={handleClick}
+        />
+        <Box
+          component={'rect'}
+          x={0}
+          y={0}
+          height={24}
+          width={24}
+          sx={{ rx: 4, fill: theme.palette.info.main }}
         />
         <FontAwesomeIcon
           aria-hidden={'true'}
@@ -82,13 +94,48 @@ const TableLineageDatasetNode = ({ node }: TableLineageDatasetNodeProps & StateP
           icon={faDatabase}
           width={ICON_SIZE}
           height={ICON_SIZE}
-          x={4}
+          x={6}
           y={ICON_SIZE / 2}
-          color={theme.palette.warning.main}
+          color={theme.palette.common.white}
           cursor={'pointer'}
           onClick={handleClick}
         />
-        <text fontSize='8' fill={'white'} x={20} y={14} cursor={'pointer'} onClick={handleClick}>
+        <foreignObject width={16} height={24} x={node.width - 18} y={0}>
+          <MQTooltip title={isCollapsed ? 'Expand' : 'Collapse'} placement={'top'}>
+            <IconButton
+              sx={{ width: 16, height: 16 }}
+              onClick={(event) => {
+                event.stopPropagation()
+                const collapsedNodes = searchParams.get('collapsedNodes')
+                if (collapsedNodes) {
+                  const collapsedNodesArray = collapsedNodes.split(',')
+                  if (collapsedNodesArray.includes(node.id)) {
+                    collapsedNodesArray.splice(collapsedNodesArray.indexOf(node.id), 1)
+                  } else {
+                    collapsedNodesArray.push(node.id)
+                  }
+                  searchParams.set('collapsedNodes', collapsedNodesArray.toString())
+                } else {
+                  searchParams.set('collapsedNodes', node.id)
+                }
+                setSearchParams(searchParams)
+              }}
+            >
+              <ChevronLeft
+                sx={{
+                  width: 16,
+                  height: 16,
+                  rotate: !isCollapsed ? '-90deg' : 0,
+                  transition: 'rotate .3s',
+                }}
+              />
+            </IconButton>
+          </MQTooltip>
+        </foreignObject>
+        <text fontSize='8' fill={'white'} x={28} y={10} onClick={handleClick} cursor={'pointer'}>
+          DATASET
+        </text>
+        <text fontSize='8' fill={'white'} x={28} y={20} cursor={'pointer'} onClick={handleClick}>
           {truncateText(node.data.dataset.name, 15)}
         </text>
         {!isCompact &&
@@ -98,10 +145,10 @@ const TableLineageDatasetNode = ({ node }: TableLineageDatasetNodeProps & StateP
                 key={field.name}
                 fontSize='8'
                 fill={THEME_EXTRA.typography.subdued}
-                x={20}
+                x={10}
                 y={14 + 10 + 10 * (index + 1)}
               >
-                - {truncateText(field.name, 15)}
+                - {truncateText(field.name, 20)}
               </text>
             )
           })}

--- a/web/src/routes/table-level/TableLineageJobNode.tsx
+++ b/web/src/routes/table-level/TableLineageJobNode.tsx
@@ -6,7 +6,6 @@ import { PositionedNode } from '../../../libs/graph'
 import { TableLineageJobNodeData } from './nodes'
 import { connect } from 'react-redux'
 import { faCog } from '@fortawesome/free-solid-svg-icons/faCog'
-import { grey } from '@mui/material/colors'
 import { theme } from '../../helpers/theme'
 import { truncateText } from '../../helpers/text'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -62,7 +61,6 @@ const TableLineageJobNode = ({ node }: TableLineageJobNodeProps & StateProps) =>
             y: 0,
             width: node.width,
             height: node.height,
-            stroke: isSelected ? theme.palette.primary.main : grey['100'],
             filter: isSelected ? `drop-shadow( 0 0 4px ${theme.palette.primary.main})` : 'none',
             rx: 4,
             fill: theme.palette.background.paper,
@@ -71,20 +69,31 @@ const TableLineageJobNode = ({ node }: TableLineageJobNodeProps & StateProps) =>
           }}
           onClick={handleClick}
         />
+        <Box
+          component={'rect'}
+          x={0}
+          y={0}
+          height={node.height}
+          width={24}
+          sx={{ rx: 4, fill: theme.palette.primary.main }}
+        />
         <FontAwesomeIcon
           aria-hidden={'true'}
           title={'Job'}
           icon={faCog}
           width={ICON_SIZE}
           height={ICON_SIZE}
-          x={4}
+          x={6}
           y={ICON_SIZE / 2}
-          color={theme.palette.primary.main}
+          color={theme.palette.common.white}
           cursor={'pointer'}
           onClick={handleClick}
         />
-        <text fontSize='8' fill={'white'} x={20} y={14} onClick={handleClick} cursor={'pointer'}>
-          {truncateText(node.data.job.name, 15)}
+        <text fontSize='8' fill={'white'} x={28} y={10} onClick={handleClick} cursor={'pointer'}>
+          JOB
+        </text>
+        <text fontSize='8' fill={'white'} x={28} y={20} onClick={handleClick} cursor={'pointer'}>
+          {truncateText(node.data.job.name, 16)}
         </text>
       </g>
     </MQTooltip>

--- a/web/src/routes/table-level/TableLineageJobNode.tsx
+++ b/web/src/routes/table-level/TableLineageJobNode.tsx
@@ -52,51 +52,60 @@ const TableLineageJobNode = ({ node }: TableLineageJobNodeProps & StateProps) =>
   }
 
   return (
-    <MQTooltip title={addToToolTip(node.data.job)}>
-      <g>
-        <Box
-          component={'rect'}
-          sx={{
-            x: 0,
-            y: 0,
-            width: node.width,
-            height: node.height,
-            filter: isSelected ? `drop-shadow( 0 0 4px ${theme.palette.primary.main})` : 'none',
-            rx: 4,
-            fill: theme.palette.background.paper,
-            cursor: 'pointer',
-            transition: 'filter 0.3',
-          }}
-          onClick={handleClick}
-        />
-        <Box
-          component={'rect'}
-          x={0}
-          y={0}
-          height={node.height}
-          width={24}
-          sx={{ rx: 4, fill: theme.palette.primary.main }}
-        />
-        <FontAwesomeIcon
-          aria-hidden={'true'}
-          title={'Job'}
-          icon={faCog}
-          width={ICON_SIZE}
-          height={ICON_SIZE}
-          x={6}
-          y={ICON_SIZE / 2}
-          color={theme.palette.common.white}
-          cursor={'pointer'}
-          onClick={handleClick}
-        />
-        <text fontSize='8' fill={'white'} x={28} y={10} onClick={handleClick} cursor={'pointer'}>
-          JOB
-        </text>
-        <text fontSize='8' fill={'white'} x={28} y={20} onClick={handleClick} cursor={'pointer'}>
-          {truncateText(node.data.job.name, 16)}
-        </text>
-      </g>
-    </MQTooltip>
+    <g>
+      <Box
+        component={'rect'}
+        sx={{
+          x: 0,
+          y: 0,
+          width: node.width,
+          height: node.height,
+          filter: isSelected ? `drop-shadow( 0 0 4px ${theme.palette.primary.main})` : 'none',
+          rx: 4,
+          fill: theme.palette.background.paper,
+          cursor: 'pointer',
+          transition: 'filter 0.3',
+        }}
+        onClick={handleClick}
+      />
+      <Box
+        component={'rect'}
+        x={0}
+        y={0}
+        height={node.height}
+        width={24}
+        sx={{ rx: 4, fill: theme.palette.primary.main }}
+      />
+      <FontAwesomeIcon
+        aria-hidden={'true'}
+        title={'Job'}
+        icon={faCog}
+        width={ICON_SIZE}
+        height={ICON_SIZE}
+        x={6}
+        y={ICON_SIZE / 2}
+        color={theme.palette.common.white}
+        onClick={handleClick}
+      />
+      <MQTooltip title={addToToolTip(node.data.job)}>
+        <g>
+          <text
+            fontSize='8'
+            fontFamily={`${'Source Code Pro'}, mono`}
+            fill={'white'}
+            x={28}
+            y={10}
+            onClick={handleClick}
+            cursor={'pointer'}
+          >
+            JOB
+          </text>
+          <text fontSize='8' fill={'white'} x={28} y={20} onClick={handleClick} cursor={'pointer'}>
+            {truncateText(node.data.job.name, 16)}
+          </text>
+        </g>
+      </MQTooltip>
+    </g>
   )
 }
 

--- a/web/src/routes/table-level/layout.ts
+++ b/web/src/routes/table-level/layout.ts
@@ -76,13 +76,16 @@ export const createElkNodes = (
   lineageGraph: LineageGraph,
   currentGraphNode: Nullable<string>,
   isCompact: boolean,
-  isFull: boolean
+  isFull: boolean,
+  collapsedNodes: Nullable<string>
 ) => {
   const downstreamNodes = findDownstreamNodes(lineageGraph, currentGraphNode)
   const upstreamNodes = findUpstreamNodes(lineageGraph, currentGraphNode)
 
   const nodes: ElkNode<JobOrDataset, TableLevelNodeData>[] = []
   const edges: Edge[] = []
+
+  const collapsedNodesAsArray = collapsedNodes?.split(',')
 
   const filteredGraph = lineageGraph.graph.filter((node) => {
     if (isFull) return true
@@ -124,7 +127,8 @@ export const createElkNodes = (
         id: node.id,
         kind: node.type,
         width: 112,
-        height: isCompact ? 24 : 34 + data.fields.length * 10,
+        height:
+          isCompact || collapsedNodesAsArray?.includes(node.id) ? 24 : 34 + data.fields.length * 10,
         data: {
           dataset: data,
         },


### PR DESCRIPTION
- More detailed nodes
- Can collapse dataset nodes manually.

![image](https://github.com/MarquezProject/marquez/assets/7514204/f8ec63f1-94dd-487f-87bb-edfb72ed033a)


> Note: I don't think a dataset id can have a `,`... My serialization relies on that not being the case.

One-line summary: Visual improvements for nodes

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
