### PR TITLE
Flink fix terminal streaming events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/MarquezProject/marquez/compare/0.45.0...HEAD)
 
+### Fixed
+
+* Streaming API: fix behaviour for `COMPLETE`/`FAIL` events within streaming jobs [`#2768`](https://github.com/MarquezProject/marquez/pull/2768) [@pawel-big-lebowski]( https://github.com/pawel-big-lebowski) 
+  *New `job_version` is not created for a streaming job terminal event with no dataset information and existing version is kept.*
+
 ## [0.45.0](https://github.com/MarquezProject/marquez/compare/0.44.0...0.45.0) - 2024-03-07
 
 ### Added

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -374,7 +374,7 @@ public interface OpenLineageDao extends BaseDao {
         insertDatasetFacets(daos, dataset, record, runUuid, event.getEventType(), now);
         insertInputDatasetFacets(daos, dataset, record, runUuid, event.getEventType(), now);
       }
-    } else {
+    } else if (!event.isTerminalEventForStreamingJobWithNoDatasets()) {
       // mark job_versions_io_mapping as obsolete
       daos.getJobVersionDao().markInputOrOutputDatasetAsPreviousFor(job.getUuid(), IoType.INPUT);
     }
@@ -390,7 +390,7 @@ public interface OpenLineageDao extends BaseDao {
         insertDatasetFacets(daos, dataset, record, runUuid, event.getEventType(), now);
         insertOutputDatasetFacets(daos, dataset, record, runUuid, event.getEventType(), now);
       }
-    } else {
+    } else if (!event.isTerminalEventForStreamingJobWithNoDatasets()) {
       // mark job_versions_io_mapping as obsolete
       daos.getJobVersionDao().markInputOrOutputDatasetAsPreviousFor(job.getUuid(), IoType.OUTPUT);
     }
@@ -790,6 +790,10 @@ public interface OpenLineageDao extends BaseDao {
     JobRowRunDetails jobRowRunDetails =
         jobVersionDao.loadJobRowRunDetails(
             updateLineageRow.getJob(), updateLineageRow.getRun().getUuid());
+
+    if (event.isTerminalEventForStreamingJobWithNoDatasets()) {
+      return;
+    }
 
     if (!jobVersionDao.versionExists(jobRowRunDetails.jobVersion().getValue())) {
       // need to insert new job version

--- a/api/src/main/java/marquez/service/models/LineageEvent.java
+++ b/api/src/main/java/marquez/service/models/LineageEvent.java
@@ -52,6 +52,20 @@ public class LineageEvent extends BaseEvent {
   @Valid @NotNull private String producer;
   @Valid private URI schemaURL;
 
+  @JsonIgnore
+  public boolean isTerminalEvent() {
+    return (eventType != null)
+        && (eventType.equalsIgnoreCase("COMPLETE") || eventType.equalsIgnoreCase("FAIL"));
+  }
+
+  @JsonIgnore
+  public boolean isTerminalEventForStreamingJobWithNoDatasets() {
+    return isTerminalEvent()
+        && (job != null && job.isStreamingJob())
+        && (outputs == null || outputs.isEmpty())
+        && (inputs == null || inputs.isEmpty());
+  }
+
   @AllArgsConstructor
   @NoArgsConstructor
   @Setter

--- a/api/src/test/java/marquez/service/models/LineageEventTest.java
+++ b/api/src/test/java/marquez/service/models/LineageEventTest.java
@@ -6,6 +6,8 @@
 package marquez.service.models;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,10 +23,12 @@ import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import marquez.common.Utils;
 import marquez.common.models.FlexibleDateTimeDeserializer;
 import marquez.service.models.LineageEvent.JobTypeJobFacet;
+import marquez.service.models.LineageEvent.LineageEventBuilder;
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -108,5 +112,81 @@ public class LineageEventTest {
     assertThat(facet.getJobType()).isEqualTo("QUERY");
     assertThat(facet.getIntegration()).isEqualTo("FLINK");
     assertThat(facet.getProcessingType()).isEqualTo("STREAMING");
+  }
+
+  @Test
+  public void testIsTerminalEvent() {
+    LineageEventBuilder builder = LineageEvent.builder();
+
+    assertThat(builder.eventType("compleTe").build().isTerminalEvent()).isTrue();
+    assertThat(builder.eventType("Fail").build().isTerminalEvent()).isTrue();
+    assertThat(builder.eventType("start").build().isTerminalEvent()).isFalse();
+  }
+
+  @Test
+  public void testIsTerminalEventForStreamingJobWithNoDatasets() {
+    LineageEvent.Job streamingJob = mock(LineageEvent.Job.class);
+    when(streamingJob.isStreamingJob()).thenReturn(true);
+
+    assertThat(
+            LineageEvent.builder()
+                .job(streamingJob)
+                .eventType("complete")
+                .build()
+                .isTerminalEventForStreamingJobWithNoDatasets())
+        .isTrue();
+
+    assertThat(
+            LineageEvent.builder()
+                .job(streamingJob)
+                .eventType("start")
+                .build()
+                .isTerminalEventForStreamingJobWithNoDatasets())
+        .isFalse();
+
+    assertThat(
+            LineageEvent.builder()
+                .job(streamingJob)
+                .eventType("complete")
+                .inputs(Collections.emptyList())
+                .build()
+                .isTerminalEventForStreamingJobWithNoDatasets())
+        .isTrue();
+
+    assertThat(
+            LineageEvent.builder()
+                .job(streamingJob)
+                .eventType("complete")
+                .inputs(Collections.singletonList(mock(LineageEvent.Dataset.class)))
+                .build()
+                .isTerminalEventForStreamingJobWithNoDatasets())
+        .isFalse();
+
+    assertThat(
+            LineageEvent.builder()
+                .job(streamingJob)
+                .eventType("complete")
+                .outputs(Collections.emptyList())
+                .build()
+                .isTerminalEventForStreamingJobWithNoDatasets())
+        .isTrue();
+
+    assertThat(
+            LineageEvent.builder()
+                .job(streamingJob)
+                .eventType("complete")
+                .outputs(Collections.singletonList(mock(LineageEvent.Dataset.class)))
+                .build()
+                .isTerminalEventForStreamingJobWithNoDatasets())
+        .isFalse();
+
+    assertThat(
+            LineageEvent.builder()
+                .job(streamingJob)
+                .eventType("complete")
+                .job(mock(LineageEvent.Job.class))
+                .build()
+                .isTerminalEventForStreamingJobWithNoDatasets())
+        .isFalse();
   }
 }


### PR DESCRIPTION
### Problem

Marquez creates new job version for streaming jobs whenever hash of a job version changes. We introduced this assumption as it makes sense most of the time. However, this does not make much sense for terminal events. In other words, a terminal event for streaming job like `complete` with no input nor output datasets contained, should mean only a job has finished. It shouldn't mean creating a new job version which is current behaviour. 

Closes: #2767

### Solution

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a database schema migration, please describe the schema modification(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
