### PR TITLE
Web Refresh + Loading States

### DIFF
--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as Redux from 'redux'
-import { ChevronLeftRounded, ChevronRightRounded } from '@mui/icons-material'
 import {
+  Button,
   Chip,
   Container,
   Table,
@@ -14,6 +14,7 @@ import {
   Tooltip,
   createTheme,
 } from '@mui/material'
+import { ChevronLeftRounded, ChevronRightRounded, Refresh } from '@mui/icons-material'
 import { Dataset } from '../../types/api'
 import { IState } from '../../store/reducers'
 import { MqScreenLoad } from '../../components/core/screen-load/MqScreenLoad'
@@ -98,20 +99,48 @@ const Datasets: React.FC<DatasetsProps> = ({
           {datasets.length === 0 ? (
             <Box p={2}>
               <MqEmpty title={i18next.t('datasets_route.empty_title')}>
-                <MqText subdued>{i18next.t('datasets_route.empty_body')}</MqText>
+                <>
+                  <MqText subdued>{i18next.t('datasets_route.empty_body')}</MqText>
+                  <Button
+                    color={'primary'}
+                    size={'small'}
+                    onClick={() => {
+                      if (selectedNamespace) {
+                        fetchDatasets(selectedNamespace, PAGE_SIZE, state.page * PAGE_SIZE)
+                      }
+                    }}
+                  >
+                    Refresh
+                  </Button>
+                </>
               </MqEmpty>
             </Box>
           ) : (
             <>
-              <Box p={2} display={'flex'}>
-                <MqText heading>{i18next.t('datasets_route.heading')}</MqText>
-                <Chip
-                  size={'small'}
-                  variant={'outlined'}
-                  color={'primary'}
-                  sx={{ marginLeft: 1 }}
-                  label={totalCount + ' total'}
-                ></Chip>
+              <Box p={2} display={'flex'} justifyContent={'space-between'} alignItems={'center'}>
+                <Box display={'flex'}>
+                  <MqText heading>{i18next.t('datasets_route.heading')}</MqText>
+                  <Chip
+                    size={'small'}
+                    variant={'outlined'}
+                    color={'primary'}
+                    sx={{ marginLeft: 1 }}
+                    label={totalCount + ' total'}
+                  ></Chip>
+                </Box>
+                <Tooltip title={'Refresh'}>
+                  <IconButton
+                    color={'primary'}
+                    size={'small'}
+                    onClick={() => {
+                      if (selectedNamespace) {
+                        fetchDatasets(selectedNamespace, PAGE_SIZE, state.page * PAGE_SIZE)
+                      }
+                    }}
+                  >
+                    <Refresh fontSize={'small'} />
+                  </IconButton>
+                </Tooltip>
               </Box>
               <Table size='small'>
                 <TableHead>

--- a/web/src/routes/datasets/Datasets.tsx
+++ b/web/src/routes/datasets/Datasets.tsx
@@ -26,6 +26,7 @@ import { fetchDatasets, resetDatasets } from '../../store/actionCreators'
 import { formatUpdatedAt } from '../../helpers'
 import { useTheme } from '@emotion/react'
 import Box from '@mui/material/Box'
+import CircularProgress from '@mui/material/CircularProgress/CircularProgress'
 import IconButton from '@mui/material/IconButton'
 import MqEmpty from '../../components/core/empty/MqEmpty'
 import MqStatus from '../../components/core/status/MqStatus'
@@ -94,7 +95,36 @@ const Datasets: React.FC<DatasetsProps> = ({
   const i18next = require('i18next')
   return (
     <Container maxWidth={'lg'} disableGutters>
-      <MqScreenLoad loading={isDatasetsLoading || !isDatasetsInit}>
+      <Box p={2} display={'flex'} justifyContent={'space-between'} alignItems={'center'}>
+        <Box display={'flex'}>
+          <MqText heading>{i18next.t('datasets_route.heading')}</MqText>
+          <Chip
+            size={'small'}
+            variant={'outlined'}
+            color={'primary'}
+            sx={{ marginLeft: 1 }}
+            label={totalCount + ' total'}
+          ></Chip>
+        </Box>
+        <Box display={'flex'} alignItems={'center'}>
+          {isDatasetsLoading && <CircularProgress size={16} />}
+          <Tooltip title={'Refresh'}>
+            <IconButton
+              sx={{ ml: 2 }}
+              color={'primary'}
+              size={'small'}
+              onClick={() => {
+                if (selectedNamespace) {
+                  fetchDatasets(selectedNamespace, PAGE_SIZE, state.page * PAGE_SIZE)
+                }
+              }}
+            >
+              <Refresh fontSize={'small'} />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      </Box>
+      <MqScreenLoad loading={isDatasetsLoading && !isDatasetsInit}>
         <>
           {datasets.length === 0 ? (
             <Box p={2}>
@@ -117,31 +147,6 @@ const Datasets: React.FC<DatasetsProps> = ({
             </Box>
           ) : (
             <>
-              <Box p={2} display={'flex'} justifyContent={'space-between'} alignItems={'center'}>
-                <Box display={'flex'}>
-                  <MqText heading>{i18next.t('datasets_route.heading')}</MqText>
-                  <Chip
-                    size={'small'}
-                    variant={'outlined'}
-                    color={'primary'}
-                    sx={{ marginLeft: 1 }}
-                    label={totalCount + ' total'}
-                  ></Chip>
-                </Box>
-                <Tooltip title={'Refresh'}>
-                  <IconButton
-                    color={'primary'}
-                    size={'small'}
-                    onClick={() => {
-                      if (selectedNamespace) {
-                        fetchDatasets(selectedNamespace, PAGE_SIZE, state.page * PAGE_SIZE)
-                      }
-                    }}
-                  >
-                    <Refresh fontSize={'small'} />
-                  </IconButton>
-                </Tooltip>
-              </Box>
               <Table size='small'>
                 <TableHead>
                   <TableRow>

--- a/web/src/routes/events/Events.tsx
+++ b/web/src/routes/events/Events.tsx
@@ -232,7 +232,7 @@ const Events: React.FC<EventsProps> = ({
                     color={'primary'}
                     size={'small'}
                     onClick={() => {
-                      fetchEvents(state.dateFrom, state.dateTo, PAGE_SIZE, state.page * PAGE_SIZE)
+                      refresh()
                     }}
                   >
                     Refresh

--- a/web/src/routes/events/Events.tsx
+++ b/web/src/routes/events/Events.tsx
@@ -14,7 +14,7 @@ import {
   Tooltip,
   createTheme,
 } from '@mui/material'
-import { ChevronLeftRounded, ChevronRightRounded } from '@mui/icons-material'
+import { ChevronLeftRounded, ChevronRightRounded, Refresh } from '@mui/icons-material'
 import { Event } from '../../types/api'
 import { IState } from '../../store/reducers'
 import { MqScreenLoad } from '../../components/core/screen-load/MqScreenLoad'
@@ -174,6 +174,17 @@ const Events: React.FC<EventsProps> = ({
                 ></Chip>
               </Box>
             </Box>
+            <Tooltip title={'Refresh'}>
+              <IconButton
+                color={'primary'}
+                size={'small'}
+                onClick={() => {
+                  fetchEvents(state.dateFrom, state.dateTo, PAGE_SIZE, state.page * PAGE_SIZE)
+                }}
+              >
+                <Refresh fontSize={'small'} />
+              </IconButton>
+            </Tooltip>
           </Box>
           <Box
             p={2}
@@ -202,7 +213,18 @@ const Events: React.FC<EventsProps> = ({
           {state.events?.length === 0 ? (
             <Box p={2}>
               <MqEmpty title={i18next.t('events_route.empty_title')}>
-                <MqText subdued>{i18next.t('events_route.empty_body')}</MqText>
+                <>
+                  <MqText subdued>{i18next.t('events_route.empty_body')}</MqText>
+                  <Button
+                    color={'primary'}
+                    size={'small'}
+                    onClick={() => {
+                      fetchEvents(state.dateFrom, state.dateTo, PAGE_SIZE, state.page * PAGE_SIZE)
+                    }}
+                  >
+                    Refresh
+                  </Button>
+                </>
               </MqEmpty>
             </Box>
           ) : (

--- a/web/src/routes/events/Events.tsx
+++ b/web/src/routes/events/Events.tsx
@@ -131,7 +131,12 @@ const Events: React.FC<EventsProps> = ({
     const params: { [key: string]: string } = {}
     searchParams.forEach((value, key) => (params[key] = value))
     setSearchParams({ ...params, [keyDate]: formatDateAPIQuery(e.toDate()) })
-    setState({ [keyDate]: formatDatePicker(e.toDate()), page: 0, rowExpanded: null } as any)
+    setState({
+      ...state,
+      [keyDate]: formatDatePicker(e.toDate()),
+      page: 0,
+      rowExpanded: null,
+    } as any)
   }
 
   const handleClickPage = (direction: 'prev' | 'next') => {
@@ -152,6 +157,14 @@ const Events: React.FC<EventsProps> = ({
     const title = `${data.job.name}-${data.eventType}-${data.run.runId}`
     const blob = new Blob([JSON.stringify(data)], { type: 'application/json' })
     saveAs(blob, `${title}.json`)
+  }
+
+  const refresh = () => {
+    const dateFrom =
+      searchParams.get('dateFrom') || formatDateAPIQuery(moment().startOf('day').toString())
+    const dateTo =
+      searchParams.get('dateTo') || formatDateAPIQuery(moment().endOf('day').toString())
+    fetchEvents(dateFrom, dateTo, PAGE_SIZE, state.page * PAGE_SIZE)
   }
 
   const i18next = require('i18next')
@@ -179,7 +192,7 @@ const Events: React.FC<EventsProps> = ({
                 color={'primary'}
                 size={'small'}
                 onClick={() => {
-                  fetchEvents(state.dateFrom, state.dateTo, PAGE_SIZE, state.page * PAGE_SIZE)
+                  refresh()
                 }}
               >
                 <Refresh fontSize={'small'} />

--- a/web/src/routes/jobs/Jobs.tsx
+++ b/web/src/routes/jobs/Jobs.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as Redux from 'redux'
-import { ChevronLeftRounded, ChevronRightRounded } from '@mui/icons-material'
 import {
+  Button,
   Chip,
   Container,
   Table,
@@ -14,6 +14,7 @@ import {
   Tooltip,
   createTheme,
 } from '@mui/material'
+import { ChevronLeftRounded, ChevronRightRounded, Refresh } from '@mui/icons-material'
 import { IState } from '../../store/reducers'
 import { Job } from '../../types/api'
 import { MqScreenLoad } from '../../components/core/screen-load/MqScreenLoad'
@@ -99,20 +100,48 @@ const Jobs: React.FC<JobsProps> = ({
           {jobs.length === 0 ? (
             <Box p={2}>
               <MqEmpty title={i18next.t('jobs_route.empty_title')}>
-                <MqText subdued>{i18next.t('jobs_route.empty_body')}</MqText>
+                <>
+                  <MqText subdued>{i18next.t('jobs_route.empty_body')}</MqText>
+                  <Button
+                    color={'primary'}
+                    size={'small'}
+                    onClick={() => {
+                      if (selectedNamespace) {
+                        fetchJobs(selectedNamespace, PAGE_SIZE, state.page * PAGE_SIZE)
+                      }
+                    }}
+                  >
+                    Refresh
+                  </Button>
+                </>
               </MqEmpty>
             </Box>
           ) : (
             <>
-              <Box p={2} display={'flex'}>
-                <MqText heading>{i18next.t('jobs_route.heading')}</MqText>
-                <Chip
-                  size={'small'}
-                  variant={'outlined'}
-                  color={'primary'}
-                  sx={{ marginLeft: 1 }}
-                  label={totalCount + ' total'}
-                ></Chip>
+              <Box p={2} display={'flex'} justifyContent={'space-between'} alignItems={'center'}>
+                <Box display={'flex'}>
+                  <MqText heading>{i18next.t('jobs_route.heading')}</MqText>
+                  <Chip
+                    size={'small'}
+                    variant={'outlined'}
+                    color={'primary'}
+                    sx={{ marginLeft: 1 }}
+                    label={totalCount + ' total'}
+                  ></Chip>
+                </Box>
+                <Tooltip title={'Refresh'}>
+                  <IconButton
+                    color={'primary'}
+                    size={'small'}
+                    onClick={() => {
+                      if (selectedNamespace) {
+                        fetchJobs(selectedNamespace, PAGE_SIZE, state.page * PAGE_SIZE)
+                      }
+                    }}
+                  >
+                    <Refresh fontSize={'small'} />
+                  </IconButton>
+                </Tooltip>
               </Box>
               <Table size='small'>
                 <TableHead>

--- a/web/src/routes/jobs/Jobs.tsx
+++ b/web/src/routes/jobs/Jobs.tsx
@@ -27,6 +27,7 @@ import { formatUpdatedAt } from '../../helpers'
 import { stopWatchDuration } from '../../helpers/time'
 import { useTheme } from '@emotion/react'
 import Box from '@mui/material/Box'
+import CircularProgress from '@mui/material/CircularProgress/CircularProgress'
 import IconButton from '@mui/material/IconButton'
 import MqEmpty from '../../components/core/empty/MqEmpty'
 import MqStatus from '../../components/core/status/MqStatus'
@@ -95,7 +96,36 @@ const Jobs: React.FC<JobsProps> = ({
   const i18next = require('i18next')
   return (
     <Container maxWidth={'lg'} disableGutters>
-      <MqScreenLoad loading={isJobsLoading || !isJobsInit}>
+      <Box p={2} display={'flex'} justifyContent={'space-between'} alignItems={'center'}>
+        <Box display={'flex'}>
+          <MqText heading>{i18next.t('jobs_route.heading')}</MqText>
+          <Chip
+            size={'small'}
+            variant={'outlined'}
+            color={'primary'}
+            sx={{ marginLeft: 1 }}
+            label={totalCount + ' total'}
+          ></Chip>
+        </Box>
+        <Box display={'flex'} alignItems={'center'}>
+          {isJobsLoading && <CircularProgress size={16} />}
+          <Tooltip title={'Refresh'}>
+            <IconButton
+              sx={{ ml: 2 }}
+              color={'primary'}
+              size={'small'}
+              onClick={() => {
+                if (selectedNamespace) {
+                  fetchJobs(selectedNamespace, PAGE_SIZE, state.page * PAGE_SIZE)
+                }
+              }}
+            >
+              <Refresh fontSize={'small'} />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      </Box>
+      <MqScreenLoad loading={isJobsLoading && !isJobsInit}>
         <>
           {jobs.length === 0 ? (
             <Box p={2}>
@@ -118,31 +148,6 @@ const Jobs: React.FC<JobsProps> = ({
             </Box>
           ) : (
             <>
-              <Box p={2} display={'flex'} justifyContent={'space-between'} alignItems={'center'}>
-                <Box display={'flex'}>
-                  <MqText heading>{i18next.t('jobs_route.heading')}</MqText>
-                  <Chip
-                    size={'small'}
-                    variant={'outlined'}
-                    color={'primary'}
-                    sx={{ marginLeft: 1 }}
-                    label={totalCount + ' total'}
-                  ></Chip>
-                </Box>
-                <Tooltip title={'Refresh'}>
-                  <IconButton
-                    color={'primary'}
-                    size={'small'}
-                    onClick={() => {
-                      if (selectedNamespace) {
-                        fetchJobs(selectedNamespace, PAGE_SIZE, state.page * PAGE_SIZE)
-                      }
-                    }}
-                  >
-                    <Refresh fontSize={'small'} />
-                  </IconButton>
-                </Tooltip>
-              </Box>
               <Table size='small'>
                 <TableHead>
                   <TableRow>


### PR DESCRIPTION
### Problem
Users would like to refresh pages without refreshing the browser, so we've added buttons to refresh all list pages.

<img width="1152" alt="image" src="https://github.com/MarquezProject/marquez/assets/7514204/c0b4ea8e-4653-49fd-b036-b751be55b721">
> Note: Upper right corner of diagram.
<img width="480" alt="image" src="https://github.com/MarquezProject/marquez/assets/7514204/e1f681d6-39b2-40a6-a911-15cc36e50e37">

One-line summary:
Refresh button for jobs, datasets, and lineage events pages. This also will work in empty states.



### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
