### PR TITLE
Fix show tags refresh

### DIFF
--- a/web/src/components/datasets/DatasetDetailPage.tsx
+++ b/web/src/components/datasets/DatasetDetailPage.tsx
@@ -105,13 +105,7 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
 
   useEffect(() => {
     fetchDatasetVersions(lineageDataset.namespace, lineageDataset.name)
-  }, [lineageDataset.name])
-
-  useEffect(() => {
-    if (showTags) {
-      fetchDatasetVersions(lineageDataset.namespace, lineageDataset.name)
-    }
-  }, [showTags])
+  }, [lineageDataset.name, showTags])
 
   // if the dataset is deleted then redirect to datasets end point
   useEffect(() => {

--- a/web/src/components/datasets/DatasetDetailPage.tsx
+++ b/web/src/components/datasets/DatasetDetailPage.tsx
@@ -213,6 +213,7 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
                     checked={showTags}
                     onChange={() => setShowTags(!showTags)}
                     inputProps={{ 'aria-label': 'toggle show tags' }}
+                    disabled={versionsLoading}
                   />
                 }
                 label={i18next.t('datasets.show_field_tags')}


### PR DESCRIPTION
### Problem

Currently with the changes from #2798 it's _possibly_ introduced a slight bug in that it takes 2 toggles of the "Show Field Tags" to register the changes in the UI.  Believe this is due to the lag between showTags dependencies and the new version being retrieved.

I've tried to limit the number of calls to the back end so rather then update on every tag addition/deletion it only updates when the "Show Field Tags" is toggled.
### Solution

add showTags to the dependencies fetchDatasetVersions and disable the show tags toggle until the latest version has been pulled.


https://github.com/MarquezProject/marquez/assets/34074888/17d7fe25-7132-4e91-b68b-d7b4d5a2222b



> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary:

Fix showTags bugs

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [x] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
