### PR TITLE
Use webpack bundled icon instead of GitHub hosted content

### DIFF
--- a/web/src/components/sidenav/Sidenav.tsx
+++ b/web/src/components/sidenav/Sidenav.tsx
@@ -19,6 +19,8 @@ import { FormControl, MenuItem, Select } from '@mui/material'
 import { MqInputNoIcon } from '../core/input-base/MqInputBase'
 import { useTheme } from '@emotion/react'
 
+import iconSearchArrow from '../../img/iconSearchArrow.svg'
+
 interface SidenavProps {}
 
 const Sidenav: React.FC<SidenavProps> = () => {
@@ -97,7 +99,7 @@ const Sidenav: React.FC<SidenavProps> = () => {
               active={location.pathname === '/events'}
             >
               <SVG
-                src='https://raw.githubusercontent.com/MarquezProject/marquez/main/web/src/img/iconSearchArrow.svg'
+                src={iconSearchArrow}
                 width={'30px'}
               />
             </MqIconButton>


### PR DESCRIPTION
### Problem

Currently the `Events` item in `Sidenav` uses the icon hosted in GitHub, which may cause issue with strict `Content-Security-Policy` settings.

<img width="995" alt="image" src="https://github.com/MarquezProject/marquez/assets/207625/84214cc6-ac1d-496b-8df1-c005784acd93">


### Solution

One-line summary: use the icon SVG bundled by Webpack instead of linking to `raw.githubusercontent.com`.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
