### PR TITLE
Column Lineage Linking and sticky tab titles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ subprojects {
         dropwizardVersion = '2.1.12'
         jacocoVersion = '0.8.11'
         junit5Version = '5.10.2'
-        lombokVersion = '1.18.30'
+        lombokVersion = '1.18.32'
         mockitoVersion = '5.4.0'
         openlineageVersion = '1.13.1'
         slf4jVersion = '1.7.36'

--- a/web/src/components/datasets/DatasetDetailPage.tsx
+++ b/web/src/components/datasets/DatasetDetailPage.tsx
@@ -204,21 +204,21 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
         <Grid item xs={4}>
           <MqInfo
             icon={<CalendarIcon color={'disabled'} />}
-            label={'Updated at'}
+            label={'Updated at'.toUpperCase()}
             value={formatUpdatedAt(firstVersion.createdAt)}
           />
         </Grid>
         <Grid item xs={4}>
           <MqInfo
             icon={<StorageIcon color={'disabled'} />}
-            label={'Dataset Type'}
-            value={firstVersion.type}
+            label={'Dataset Type'.toUpperCase()}
+            value={<MqText font={'mono'}>{firstVersion.type}</MqText>}
           />
         </Grid>
         <Grid item xs={4}>
           <MqInfo
             icon={<ListIcon color={'disabled'} />}
-            label={'Fields'}
+            label={'Fields'.toUpperCase()}
             value={`${firstVersion.fields.length} columns`}
           />
         </Grid>
@@ -247,7 +247,6 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
           <Box display={'flex'} alignItems={'center'}>
             <FormControlLabel
               sx={{ textWrap: 'nowrap' }}
-              labelPlacement={'start'}
               control={
                 <Switch
                   size={'small'}

--- a/web/src/components/datasets/DatasetDetailPage.tsx
+++ b/web/src/components/datasets/DatasetDetailPage.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mui/material'
 import { CalendarIcon } from '@mui/x-date-pickers'
 import { CircularProgress } from '@mui/material'
-import { DatasetVersion } from '../../types/api'
+import { Dataset, DatasetVersion } from '../../types/api'
 import { IState } from '../../store/reducers'
 import { LineageDataset } from '../../types/lineage'
 import { MqInfo } from '../core/info/MqInfo'
@@ -26,6 +26,7 @@ import { datasetFacetsStatus } from '../../helpers/nodes'
 import {
   deleteDataset,
   dialogToggle,
+  fetchDataset,
   fetchDatasetVersions,
   resetDataset,
   resetDatasetVersions,
@@ -48,6 +49,7 @@ import StorageIcon from '@mui/icons-material/Storage'
 
 interface StateProps {
   lineageDataset: LineageDataset
+  dataset: Dataset
   versions: DatasetVersion[]
   versionsLoading: boolean
   datasets: IState['datasets']
@@ -57,6 +59,7 @@ interface StateProps {
 
 interface DispatchProps {
   fetchDatasetVersions: typeof fetchDatasetVersions
+  fetchDataset: typeof fetchDataset
   resetDatasetVersions: typeof resetDatasetVersions
   resetDataset: typeof resetDataset
   deleteDataset: typeof deleteDataset
@@ -76,7 +79,9 @@ function a11yProps(index: number) {
 const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
   const {
     datasets,
+    dataset,
     display,
+    fetchDataset,
     fetchDatasetVersions,
     resetDataset,
     resetDatasetVersions,
@@ -105,6 +110,7 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
 
   useEffect(() => {
     fetchDatasetVersions(lineageDataset.namespace, lineageDataset.name)
+    fetchDataset(lineageDataset.namespace, lineageDataset.name)
   }, [lineageDataset.name, showTags])
 
   // if the dataset is deleted then redirect to datasets end point
@@ -142,46 +148,6 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
       }}
     >
       <Box>
-        <Box display={'flex'} justifyContent={'space-between'} alignItems={'center'}>
-          <DatasetTags
-            datasetTags={tags}
-            datasetName={lineageDataset.name}
-            namespace={lineageDataset.namespace}
-          />
-          <Box display={'flex'} alignItems={'center'}>
-            <Box mr={1}>
-              <Button
-                variant='outlined'
-                size={'small'}
-                sx={{
-                  borderColor: theme.palette.error.main,
-                  color: theme.palette.error.main,
-                  '&:hover': {
-                    borderColor: alpha(theme.palette.error.main, 0.3),
-                    backgroundColor: alpha(theme.palette.error.main, 0.3),
-                  },
-                }}
-                onClick={() => {
-                  props.dialogToggle('')
-                }}
-              >
-                {i18next.t('datasets.dialog_delete')}
-              </Button>
-              <Dialog
-                dialogIsOpen={display.dialogIsOpen}
-                dialogToggle={dialogToggle}
-                title={i18next.t('jobs.dialog_confirmation_title')}
-                ignoreWarning={() => {
-                  deleteDataset(lineageDataset.name, lineageDataset.namespace)
-                  props.dialogToggle('')
-                }}
-              />
-            </Box>
-            <IconButton onClick={() => setSearchParams({})}>
-              <CloseIcon fontSize={'small'} />
-            </IconButton>
-          </Box>
-        </Box>
         <Box display={'flex'} alignItems={'center'} justifyContent={'space-between'} my={2}>
           {facetsStatus && (
             <Box mr={1}>
@@ -204,22 +170,6 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
               </MqText>
             </Box>
           </Box>
-          {tabIndex === 0 && (
-            <Box ml={1} display={'flex'} alignItems={'center'}>
-              <FormControlLabel
-                control={
-                  <Switch
-                    size={'small'}
-                    checked={showTags}
-                    onChange={() => setShowTags(!showTags)}
-                    inputProps={{ 'aria-label': 'toggle show tags' }}
-                    disabled={versionsLoading}
-                  />
-                }
-                label={i18next.t('datasets.show_field_tags')}
-              />
-            </Box>
-          )}
         </Box>
         <Box>
           <MqText subdued>{description}</MqText>
@@ -249,7 +199,47 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
           />
         </Grid>
       </Grid>
-      <Divider sx={{ mt: 1 }} />
+      <Divider sx={{ my: 2 }} />
+      <Box display={'flex'} justifyContent={'space-between'} alignItems={'center'}>
+        <DatasetTags
+          datasetTags={tags}
+          datasetName={lineageDataset.name}
+          namespace={lineageDataset.namespace}
+        />
+        <Box display={'flex'} alignItems={'center'}>
+          <Box mr={1}>
+            <Button
+              variant='outlined'
+              size={'small'}
+              sx={{
+                borderColor: theme.palette.error.main,
+                color: theme.palette.error.main,
+                '&:hover': {
+                  borderColor: alpha(theme.palette.error.main, 0.3),
+                  backgroundColor: alpha(theme.palette.error.main, 0.3),
+                },
+              }}
+              onClick={() => {
+                props.dialogToggle('')
+              }}
+            >
+              {i18next.t('datasets.dialog_delete')}
+            </Button>
+            <Dialog
+              dialogIsOpen={display.dialogIsOpen}
+              dialogToggle={dialogToggle}
+              title={i18next.t('jobs.dialog_confirmation_title')}
+              ignoreWarning={() => {
+                deleteDataset(lineageDataset.name, lineageDataset.namespace)
+                props.dialogToggle('')
+              }}
+            />
+          </Box>
+          <IconButton onClick={() => setSearchParams({})}>
+            <CloseIcon fontSize={'small'} />
+          </IconButton>
+        </Box>
+      </Box>
       <Box display={'flex'} justifyContent={'space-between'} mb={2}>
         <Box sx={{ borderBottom: 1, borderColor: 'divider', width: '100%' }}>
           <Tabs
@@ -262,22 +252,43 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
             <Tab label={i18next.t('datasets.history_tab')} {...a11yProps(2)} disableRipple={true} />
           </Tabs>
         </Box>
+        {tabIndex === 0 && (
+          <Box display={'flex'} alignItems={'center'}>
+            <FormControlLabel
+              sx={{ textWrap: 'nowrap' }}
+              labelPlacement={'start'}
+              control={
+                <Switch
+                  size={'small'}
+                  checked={showTags}
+                  onChange={() => setShowTags(!showTags)}
+                  inputProps={{ 'aria-label': 'toggle show tags' }}
+                  disabled={versionsLoading}
+                />
+              }
+              label={i18next.t('datasets.show_field_tags')}
+            />
+          </Box>
+        )}
       </Box>
       {tabIndex === 0 && (
         <DatasetInfo
+          dataset={dataset}
           datasetFields={firstVersion.fields}
           facets={firstVersion.facets}
           run={firstVersion.createdByRun}
           showTags={showTags}
+          isCurrentVersion
         />
       )}
-      {tabIndex === 1 && <DatasetVersions versions={props.versions} />}
+      {tabIndex === 1 && <DatasetVersions dataset={dataset} versions={props.versions} />}
     </Box>
   )
 }
 
 const mapStateToProps = (state: IState) => ({
   datasets: state.datasets,
+  dataset: state.dataset.result,
   display: state.display,
   versions: state.datasetVersions.result.versions,
   versionsLoading: state.datasetVersions.isLoading,
@@ -288,6 +299,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch) =>
   bindActionCreators(
     {
       fetchDatasetVersions: fetchDatasetVersions,
+      fetchDataset: fetchDataset,
       resetDatasetVersions: resetDatasetVersions,
       resetDataset: resetDataset,
       deleteDataset: deleteDataset,

--- a/web/src/components/datasets/DatasetDetailPage.tsx
+++ b/web/src/components/datasets/DatasetDetailPage.tsx
@@ -141,14 +141,17 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
   const facetsStatus = datasetFacetsStatus(firstVersion.facets)
 
   return (
-    <Box
-      my={2}
-      sx={{
-        padding: `0 ${theme.spacing(2)}`,
-      }}
-    >
-      <Box>
-        <Box display={'flex'} alignItems={'center'} justifyContent={'space-between'} my={2}>
+    <Box px={2}>
+      <Box
+        position={'sticky'}
+        top={'98px'}
+        bgcolor={theme.palette.background.default}
+        pt={2}
+        zIndex={theme.zIndex.appBar}
+        sx={{ borderBottom: 1, borderColor: 'divider', width: '100%' }}
+        mb={2}
+      >
+        <Box display={'flex'} alignItems={'center'} justifyContent={'space-between'} pb={2}>
           {facetsStatus && (
             <Box mr={1}>
               <MqStatus label={'Quality'} color={facetsStatus} />
@@ -158,24 +161,45 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
             <MqText heading font={'mono'}>
               {name}
             </MqText>
-            <Box ml={1}>
-              <MqText
-                small
-                link
-                linkTo={`/datasets/column-level/${encodeURIComponent(
-                  encodeURIComponent(firstVersion.id.namespace)
-                )}/${encodeURIComponent(firstVersion.id.name)}`}
+          </Box>
+          <Box display={'flex'} alignItems={'center'}>
+            <Box mr={1}>
+              <Button
+                variant='outlined'
+                size={'small'}
+                sx={{
+                  borderColor: theme.palette.error.main,
+                  color: theme.palette.error.main,
+                  '&:hover': {
+                    borderColor: alpha(theme.palette.error.main, 0.3),
+                    backgroundColor: alpha(theme.palette.error.main, 0.3),
+                  },
+                }}
+                onClick={() => {
+                  props.dialogToggle('')
+                }}
               >
-                COLUMN LEVEL
-              </MqText>
+                {i18next.t('datasets.dialog_delete')}
+              </Button>
+              <Dialog
+                dialogIsOpen={display.dialogIsOpen}
+                dialogToggle={dialogToggle}
+                title={i18next.t('jobs.dialog_confirmation_title')}
+                ignoreWarning={() => {
+                  deleteDataset(lineageDataset.name, lineageDataset.namespace)
+                  props.dialogToggle('')
+                }}
+              />
             </Box>
+            <IconButton onClick={() => setSearchParams({})}>
+              <CloseIcon fontSize={'small'} />
+            </IconButton>
           </Box>
         </Box>
         <Box>
           <MqText subdued>{description}</MqText>
         </Box>
       </Box>
-      <Divider sx={{ my: 1 }} />
       <Grid container spacing={2}>
         <Grid item xs={4}>
           <MqInfo
@@ -206,39 +230,6 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
           datasetName={lineageDataset.name}
           namespace={lineageDataset.namespace}
         />
-        <Box display={'flex'} alignItems={'center'}>
-          <Box mr={1}>
-            <Button
-              variant='outlined'
-              size={'small'}
-              sx={{
-                borderColor: theme.palette.error.main,
-                color: theme.palette.error.main,
-                '&:hover': {
-                  borderColor: alpha(theme.palette.error.main, 0.3),
-                  backgroundColor: alpha(theme.palette.error.main, 0.3),
-                },
-              }}
-              onClick={() => {
-                props.dialogToggle('')
-              }}
-            >
-              {i18next.t('datasets.dialog_delete')}
-            </Button>
-            <Dialog
-              dialogIsOpen={display.dialogIsOpen}
-              dialogToggle={dialogToggle}
-              title={i18next.t('jobs.dialog_confirmation_title')}
-              ignoreWarning={() => {
-                deleteDataset(lineageDataset.name, lineageDataset.namespace)
-                props.dialogToggle('')
-              }}
-            />
-          </Box>
-          <IconButton onClick={() => setSearchParams({})}>
-            <CloseIcon fontSize={'small'} />
-          </IconButton>
-        </Box>
       </Box>
       <Box display={'flex'} justifyContent={'space-between'} mb={2}>
         <Box sx={{ borderBottom: 1, borderColor: 'divider', width: '100%' }}>

--- a/web/src/components/datasets/DatasetDetailPage.tsx
+++ b/web/src/components/datasets/DatasetDetailPage.tsx
@@ -158,9 +158,12 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
             </Box>
           )}
           <Box display={'flex'} alignItems={'center'}>
-            <MqText heading font={'mono'}>
-              {name}
-            </MqText>
+            <Box>
+              <MqText heading font={'mono'}>
+                {name}
+              </MqText>
+              <MqText subdued>{description}</MqText>
+            </Box>
           </Box>
           <Box display={'flex'} alignItems={'center'}>
             <Box mr={1}>
@@ -195,9 +198,6 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
               <CloseIcon fontSize={'small'} />
             </IconButton>
           </Box>
-        </Box>
-        <Box>
-          <MqText subdued>{description}</MqText>
         </Box>
       </Box>
       <Grid container spacing={2}>

--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -103,8 +103,7 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = (props) => {
             </TableHead>
             <TableBody>
               {datasetFields.map((field) => {
-                console.log()
-                const hasColumnLineage = dataset?.columnLineage.find((f) => f.name === field.name)
+                const hasColumnLineage = dataset?.columnLineage?.find((f) => f.name === field.name)
                 return (
                   <React.Fragment key={field.name}>
                     <TableRow>

--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -103,17 +103,27 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = (props) => {
             </TableHead>
             <TableBody>
               {datasetFields.map((field) => {
+                console.log()
+                const hasColumnLineage = dataset?.columnLineage.find((f) => f.name === field.name)
                 return (
                   <React.Fragment key={field.name}>
                     <TableRow>
-                      <TableCell align='left'>{field.name}</TableCell>
+                      <TableCell align='left'>
+                        <MqText font={'mono'}>{field.name}</MqText>
+                      </TableCell>
                       {!showTags && (
                         <TableCell align='left'>
-                          <Chip size={'small'} label={field.type} variant={'outlined'} />
+                          <Chip
+                            size={'small'}
+                            label={<MqText font={'mono'}>{field.type}</MqText>}
+                            variant={'outlined'}
+                          />
                         </TableCell>
                       )}
                       {!showTags && (
-                        <TableCell align='left'>{field.description || 'no description'}</TableCell>
+                        <TableCell align='left'>
+                          <MqText subdued>{field.description || 'no description'}</MqText>
+                        </TableCell>
                       )}
                       {!showTags && (
                         <TableCell align='left'>
@@ -126,7 +136,7 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = (props) => {
                               }
                             >
                               <IconButton
-                                disabled={!dataset.columnLineage}
+                                disabled={!hasColumnLineage}
                                 size={'small'}
                                 component={Link}
                                 to={`/datasets/column-level/${dataset.namespace}/${

--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -2,15 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as Redux from 'redux'
 import { Box, Chip, Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material'
-import { Field, Run } from '../../types/api'
+import { Dataset, Field, Run } from '../../types/api'
 import { IState } from '../../store/reducers'
+import { Link } from 'react-router-dom'
 import { connect, useSelector } from 'react-redux'
+import { encodeQueryString } from '../../routes/column-level/ColumnLineageColumnNode'
 import { fetchJobFacets, resetFacets } from '../../store/actionCreators'
 import DatasetTags from './DatasetTags'
+import IconButton from '@mui/material/IconButton'
+import MQTooltip from '../core/tooltip/MQTooltip'
 import MqEmpty from '../core/empty/MqEmpty'
 import MqJsonView from '../core/json-view/MqJsonView'
 import MqText from '../core/text/MqText'
 import React, { FunctionComponent, useEffect } from 'react'
+import SplitscreenIcon from '@mui/icons-material/Splitscreen'
 
 export interface DispatchProps {
   fetchJobFacets: typeof fetchJobFacets
@@ -23,10 +28,8 @@ interface JobFacets {
 
 export interface JobFacetsProps {
   jobFacets: JobFacets
-}
-
-export interface SqlFacet {
-  query: string
+  isCurrentVersion?: boolean
+  dataset: Dataset
 }
 
 type DatasetInfoProps = {
@@ -38,7 +41,7 @@ type DatasetInfoProps = {
   DispatchProps
 
 const DatasetInfo: FunctionComponent<DatasetInfoProps> = (props) => {
-  const { datasetFields, facets, run, fetchJobFacets, resetFacets, showTags } = props
+  const { datasetFields, facets, run, dataset, fetchJobFacets, resetFacets, showTags } = props
   const i18next = require('i18next')
   const dsNamespace = useSelector(
     (state: IState) => state.datasetVersions.result.versions[0].namespace
@@ -88,6 +91,7 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = (props) => {
                     </MqText>
                   </TableCell>
                 )}
+                {!showTags && <TableCell align='left' />}
                 {showTags && (
                   <TableCell align='left'>
                     <MqText subheading inline>
@@ -110,6 +114,32 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = (props) => {
                       )}
                       {!showTags && (
                         <TableCell align='left'>{field.description || 'no description'}</TableCell>
+                      )}
+                      {!showTags && (
+                        <TableCell align='left'>
+                          {dataset && (
+                            <MQTooltip
+                              title={
+                                !dataset.columnLineage
+                                  ? 'No Column Lineage, check facet'
+                                  : i18next.t('dataset_info_columns.column_lineage')
+                              }
+                            >
+                              <IconButton
+                                disabled={!dataset.columnLineage}
+                                size={'small'}
+                                component={Link}
+                                to={`/datasets/column-level/${dataset.namespace}/${
+                                  dataset.name
+                                }?column=${encodeURIComponent(
+                                  encodeQueryString(dataset.namespace, dataset.name, field.name)
+                                )}&columnName=${field.name}`}
+                              >
+                                <SplitscreenIcon />
+                              </IconButton>
+                            </MQTooltip>
+                          )}
+                        </TableCell>
                       )}
                       {showTags && (
                         <TableCell align='left'>

--- a/web/src/components/datasets/DatasetTags.tsx
+++ b/web/src/components/datasets/DatasetTags.tsx
@@ -170,7 +170,7 @@ const DatasetTags: React.FC<IProps> = (props) => {
         message={'Tag updated.'}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
       />
-      <Box display={'flex'} alignItems='center' justifyContent='center'>
+      <Box display={'flex'} alignItems='center' justifyContent='center' width={'100%'}>
         {!datasetField && (
           <MQTooltip title='Edit a Tag' key='edit-tag'>
             <Button
@@ -189,7 +189,7 @@ const DatasetTags: React.FC<IProps> = (props) => {
           multiple
           disableCloseOnSelect
           id='dataset-tags'
-          sx={{ width: 516, flex: 1 }}
+          sx={{ flex: 1 }}
           limitTags={!datasetField ? 5 : 4}
           autoHighlight
           disableClearable

--- a/web/src/components/datasets/DatasetVersions.tsx
+++ b/web/src/components/datasets/DatasetVersions.tsx
@@ -3,7 +3,7 @@
 
 import { ArrowBackIosRounded } from '@mui/icons-material'
 import { Box, Chip, Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material'
-import { DatasetVersion } from '../../types/api'
+import { Dataset, DatasetVersion } from '../../types/api'
 import { alpha, createTheme } from '@mui/material/styles'
 import { formatUpdatedAt } from '../../helpers'
 import { useTheme } from '@emotion/react'
@@ -15,10 +15,11 @@ import React, { FunctionComponent, SetStateAction } from 'react'
 
 interface DatasetVersionsProps {
   versions: DatasetVersion[]
+  dataset: Dataset
 }
 
 const DatasetVersions: FunctionComponent<DatasetVersionsProps> = (props) => {
-  const { versions } = props
+  const { versions, dataset } = props
 
   const [infoView, setInfoView] = React.useState<DatasetVersion | null>(null)
   const handleClick = (newValue: SetStateAction<DatasetVersion | null>) => {
@@ -40,6 +41,7 @@ const DatasetVersions: FunctionComponent<DatasetVersionsProps> = (props) => {
           </IconButton>
         </Box>
         <DatasetInfo
+          dataset={dataset}
           datasetFields={infoView.fields}
           facets={infoView.facets}
           run={infoView.createdByRun}

--- a/web/src/components/jobs/JobDetailPage.tsx
+++ b/web/src/components/jobs/JobDetailPage.tsx
@@ -117,9 +117,16 @@ const JobDetailPage: FunctionComponent<IProps> = (props) => {
         mb={2}
       >
         <Box display={'flex'} alignItems={'center'} justifyContent={'space-between'}>
-          <MqText font={'mono'} heading>
-            {job.name}
-          </MqText>
+          <Box>
+            <MqText font={'mono'} heading>
+              {job.name}
+            </MqText>
+            {job.description && (
+              <Box mt={1}>
+                <MqText subdued>{job.description}</MqText>
+              </Box>
+            )}
+          </Box>
           <Box display={'flex'} alignItems={'center'}>
             <Box mr={1}>
               <Button
@@ -167,11 +174,6 @@ const JobDetailPage: FunctionComponent<IProps> = (props) => {
           </Box>
         </Box>
       </Box>
-      {job.description && (
-        <Box mt={1}>
-          <MqText subdued>{job.description}</MqText>
-        </Box>
-      )}
       <Grid container spacing={2}>
         <Grid item xs={4}>
           <MqInfo

--- a/web/src/components/jobs/JobDetailPage.tsx
+++ b/web/src/components/jobs/JobDetailPage.tsx
@@ -176,42 +176,42 @@ const JobDetailPage: FunctionComponent<IProps> = (props) => {
         <Grid item xs={4}>
           <MqInfo
             icon={<CalendarIcon color={'disabled'} />}
-            label={'Created at'}
+            label={'Created at'.toUpperCase()}
             value={formatUpdatedAt(job.createdAt)}
           />
         </Grid>
         <Grid item xs={4}>
           <MqInfo
             icon={<CalendarIcon color={'disabled'} />}
-            label={'Updated at'}
+            label={'Updated at'.toUpperCase()}
             value={formatUpdatedAt(job.updatedAt)}
           />
         </Grid>
         <Grid item xs={4}>
           <MqInfo
             icon={<SpeedRounded color={'disabled'} />}
-            label={'Last Runtime'}
+            label={'Last Runtime'.toUpperCase()}
             value={job.latestRun ? stopWatchDuration(job.latestRun.durationMs) : 'N/A'}
           />
         </Grid>
         <Grid item xs={4}>
           <MqInfo
             icon={<Start color={'disabled'} />}
-            label={'Last Started'}
+            label={'Last Started'.toUpperCase()}
             value={job.latestRun ? formatUpdatedAt(job.latestRun.startedAt) : 'N/A'}
           />
         </Grid>
         <Grid item xs={4}>
           <MqInfo
             icon={<SportsScore color={'disabled'} />}
-            label={'Last Finished'}
+            label={'Last Finished'.toUpperCase()}
             value={job.latestRun ? formatUpdatedAt(job.latestRun.endedAt) : 'N/A'}
           />
         </Grid>
         <Grid item xs={4}>
           <MqInfo
             icon={<DirectionsRun color={'disabled'} />}
-            label={'Running Status'}
+            label={'Running Status'.toUpperCase()}
             value={<MqStatus label={job.latestRun?.state} color={jobRunsStatus(runs)} />}
           />
         </Grid>

--- a/web/src/components/jobs/JobDetailPage.tsx
+++ b/web/src/components/jobs/JobDetailPage.tsx
@@ -106,63 +106,65 @@ const JobDetailPage: FunctionComponent<IProps> = (props) => {
   }
 
   return (
-    <Box
-      p={4}
-      display='flex'
-      flexDirection='column'
-      justifyContent='space-between'
-      sx={{
-        padding: theme.spacing(2),
-      }}
-    >
-      <Box display={'flex'} alignItems={'center'} justifyContent={'space-between'}>
-        <MqText font={'mono'} heading>
-          {job.name}
-        </MqText>
-        <Box display={'flex'} alignItems={'center'}>
-          <Box mr={1}>
-            <Button
-              variant='outlined'
-              size={'small'}
-              sx={{
-                borderColor: theme.palette.error.main,
-                color: theme.palette.error.main,
-                '&:hover': {
-                  borderColor: alpha(theme.palette.error.main, 0.3),
-                  backgroundColor: alpha(theme.palette.error.main, 0.3),
-                },
-              }}
-              onClick={() => {
-                props.dialogToggle('')
-              }}
-            >
-              {i18next.t('jobs.dialog_delete')}
-            </Button>
-            <Dialog
-              dialogIsOpen={display.dialogIsOpen}
-              dialogToggle={dialogToggle}
-              title={i18next.t('jobs.dialog_confirmation_title')}
-              ignoreWarning={() => {
-                deleteJob(job.name, job.namespace)
-                props.dialogToggle('')
-              }}
-            />
+    <Box px={2} display='flex' flexDirection='column' justifyContent='space-between'>
+      <Box
+        position={'sticky'}
+        top={'98px'}
+        bgcolor={theme.palette.background.default}
+        py={2}
+        zIndex={theme.zIndex.appBar}
+        sx={{ borderBottom: 1, borderColor: 'divider', width: '100%' }}
+        mb={2}
+      >
+        <Box display={'flex'} alignItems={'center'} justifyContent={'space-between'}>
+          <MqText font={'mono'} heading>
+            {job.name}
+          </MqText>
+          <Box display={'flex'} alignItems={'center'}>
+            <Box mr={1}>
+              <Button
+                variant='outlined'
+                size={'small'}
+                sx={{
+                  borderColor: theme.palette.error.main,
+                  color: theme.palette.error.main,
+                  '&:hover': {
+                    borderColor: alpha(theme.palette.error.main, 0.3),
+                    backgroundColor: alpha(theme.palette.error.main, 0.3),
+                  },
+                }}
+                onClick={() => {
+                  props.dialogToggle('')
+                }}
+              >
+                {i18next.t('jobs.dialog_delete')}
+              </Button>
+              <Dialog
+                dialogIsOpen={display.dialogIsOpen}
+                dialogToggle={dialogToggle}
+                title={i18next.t('jobs.dialog_confirmation_title')}
+                ignoreWarning={() => {
+                  deleteJob(job.name, job.namespace)
+                  props.dialogToggle('')
+                }}
+              />
+            </Box>
+            <Box mr={1}>
+              <Button
+                size={'small'}
+                variant='outlined'
+                color='primary'
+                target={'_blank'}
+                href={job.location}
+                disabled={!job.location}
+              >
+                {i18next.t('jobs.location')}
+              </Button>
+            </Box>
+            <IconButton onClick={() => setSearchParams({})} size='small'>
+              <CloseIcon fontSize={'small'} />
+            </IconButton>
           </Box>
-          <Box mr={1}>
-            <Button
-              size={'small'}
-              variant='outlined'
-              color='primary'
-              target={'_blank'}
-              href={job.location}
-              disabled={!job.location}
-            >
-              {i18next.t('jobs.location')}
-            </Button>
-          </Box>
-          <IconButton onClick={() => setSearchParams({})} size='small'>
-            <CloseIcon fontSize={'small'} />
-          </IconButton>
         </Box>
       </Box>
       {job.description && (
@@ -170,7 +172,6 @@ const JobDetailPage: FunctionComponent<IProps> = (props) => {
           <MqText subdued>{job.description}</MqText>
         </Box>
       )}
-      <Divider sx={{ mt: 2, mb: 1 }} />
       <Grid container spacing={2}>
         <Grid item xs={4}>
           <MqInfo

--- a/web/src/i18n/config.ts
+++ b/web/src/i18n/config.ts
@@ -131,6 +131,7 @@ i18next
             name: 'NAME',
             type: 'TYPE',
             description: 'DESCRIPTION',
+            column_lineage: 'Column Lineage',
           },
           dataset_versions_columns: {
             version: 'VERSION',

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -82,7 +82,22 @@ export interface Dataset {
   description: string
   facets: object
   deleted: boolean
-  columnLineage: object
+  columnLineage: InputFields[]
+}
+
+interface InputField {
+  namespace: string
+  dataset: string
+  field: string
+  transformationDescription: string | null
+  transformationType: string | null
+}
+
+interface InputFields {
+  name: string
+  inputFields: InputField[]
+  transformationDescription: string | null
+  transformationType: string | null
 }
 
 export interface DatasetVersions {


### PR DESCRIPTION
### Problem
Previously, we had a column lineage link at the top of the dataset. Now that has been moved to the column level and therefore will link to the column directly if available.

Also pegs the titles of jobs and datasets to the top of the drawer as an enhancement to keep context in focus for users of Marquez.

One-line summary: Sticky Titles and column lineage links in the table definition.

![image](https://github.com/MarquezProject/marquez/assets/7514204/040a1bbd-0e04-4868-8805-9493275cad9d)


### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
