### PR TITLE
feat: add jobVersion field to Run in Java client

### DIFF
--- a/clients/java/src/main/java/marquez/client/models/Run.java
+++ b/clients/java/src/main/java/marquez/client/models/Run.java
@@ -28,6 +28,7 @@ public final class Run extends RunMeta {
   @Nullable private final Instant startedAt;
   @Nullable private final Long durationMs;
   @Nullable private final Instant endedAt;
+  @Nullable private final JobVersionId jobVersion;
   @Getter private final Map<String, Object> facets;
   @Getter private final List<InputDatasetVersion> inputDatasetVersions;
   @Getter private final List<OutputDatasetVersion> outputDatasetVersions;
@@ -43,6 +44,7 @@ public final class Run extends RunMeta {
       @Nullable final Instant endedAt,
       @Nullable final Long durationMs,
       @Nullable final Map<String, String> args,
+      @Nullable final JobVersionId jobVersion,
       @Nullable final Map<String, Object> facets,
       @Nullable final List<InputDatasetVersion> inputDatasetVersions,
       @Nullable final List<OutputDatasetVersion> outputDatasetVersions) {
@@ -53,6 +55,7 @@ public final class Run extends RunMeta {
     this.startedAt = startedAt;
     this.durationMs = durationMs;
     this.endedAt = endedAt;
+    this.jobVersion = jobVersion;
     this.facets = (facets == null) ? ImmutableMap.of() : ImmutableMap.copyOf(facets);
     this.inputDatasetVersions =
         (inputDatasetVersions == null) ? Collections.emptyList() : inputDatasetVersions;
@@ -70,6 +73,10 @@ public final class Run extends RunMeta {
 
   public Optional<Long> getDurationMs() {
     return Optional.ofNullable(durationMs);
+  }
+
+  public Optional<JobVersionId> getJobVersion() {
+    return Optional.ofNullable(jobVersion);
   }
 
   public boolean hasFacets() {

--- a/clients/java/src/test/java/marquez/client/MarquezClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezClientTest.java
@@ -87,6 +87,7 @@ import marquez.client.models.Job;
 import marquez.client.models.JobId;
 import marquez.client.models.JobMeta;
 import marquez.client.models.JobType;
+import marquez.client.models.JobVersionId;
 import marquez.client.models.JsonGenerator;
 import marquez.client.models.LineageEvent;
 import marquez.client.models.Namespace;
@@ -243,6 +244,8 @@ public class MarquezClientTest {
   private static final URL LOCATION = newLocation();
   private static final JobType JOB_TYPE = newJobType();
   private static final String JOB_DESCRIPTION = newDescription();
+  private static final JobVersionId JOB_VERSION =
+      new JobVersionId(JOB_ID.getNamespace(), JOB_ID.getName(), CURRENT_VERSION);
   private static final Job JOB =
       new Job(
           JOB_ID,
@@ -287,6 +290,7 @@ public class MarquezClientTest {
           ENDED_AT,
           DURATION,
           RUN_ARGS,
+          JOB_VERSION,
           null,
           INPUT_RUN_DATASET_FACETS,
           OUTPUT_RUN_DATASET_FACETS);
@@ -302,6 +306,7 @@ public class MarquezClientTest {
           ENDED_AT,
           DURATION,
           RUN_ARGS,
+          JOB_VERSION,
           null,
           INPUT_RUN_DATASET_FACETS,
           OUTPUT_RUN_DATASET_FACETS);
@@ -317,6 +322,7 @@ public class MarquezClientTest {
           ENDED_AT,
           DURATION,
           RUN_ARGS,
+          JOB_VERSION,
           null,
           INPUT_RUN_DATASET_FACETS,
           OUTPUT_RUN_DATASET_FACETS);
@@ -332,6 +338,7 @@ public class MarquezClientTest {
           ENDED_AT,
           DURATION,
           RUN_ARGS,
+          JOB_VERSION,
           null,
           INPUT_RUN_DATASET_FACETS,
           OUTPUT_RUN_DATASET_FACETS);
@@ -347,6 +354,7 @@ public class MarquezClientTest {
           ENDED_AT,
           DURATION,
           RUN_ARGS,
+          JOB_VERSION,
           null,
           INPUT_RUN_DATASET_FACETS,
           OUTPUT_RUN_DATASET_FACETS);
@@ -377,6 +385,7 @@ public class MarquezClientTest {
               ENDED_AT,
               DURATION,
               RUN_ARGS,
+              JOB_VERSION,
               null,
               INPUT_RUN_DATASET_FACETS,
               OUTPUT_RUN_DATASET_FACETS),

--- a/clients/java/src/test/java/marquez/client/models/JsonGenerator.java
+++ b/clients/java/src/test/java/marquez/client/models/JsonGenerator.java
@@ -319,6 +319,18 @@ public final class JsonGenerator {
     obj.put("startedAt", run.getStartedAt().map(ISO_INSTANT::format).orElse(null));
     obj.put("endedAt", run.getEndedAt().map(ISO_INSTANT::format).orElse(null));
     obj.put("durationMs", run.getDurationMs().orElse(null));
+    obj.set(
+        "jobVersion",
+        run.getJobVersion()
+            .map(
+                jobVersionId -> {
+                  final ObjectNode jobVersion = MAPPER.createObjectNode();
+                  jobVersion.put("namespace", jobVersionId.getNamespace());
+                  jobVersion.put("name", jobVersionId.getName());
+                  jobVersion.put("version", jobVersionId.getVersion().toString());
+                  return jobVersion;
+                })
+            .orElse(null));
     obj.putArray("inputDatasetVersions").addAll(inputDatasetVersions);
     obj.putArray("outputDatasetVersions").addAll(outputDatasetVersions);
 

--- a/clients/java/src/test/java/marquez/client/models/ModelGenerator.java
+++ b/clients/java/src/test/java/marquez/client/models/ModelGenerator.java
@@ -250,6 +250,7 @@ public final class ModelGenerator {
         newRunArgs(),
         null,
         null,
+        null,
         null);
   }
 


### PR DESCRIPTION
### Problem

The Java client for the `getRun` method currently does not include the `jobVersion` in the response DTO.

### Solution

This PR adds `jobVersion` to the `Run` class so it can be successfully deserialised and accessed by consumers.

One-line summary: Add jobVersion field to Run in Java client

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
