### PR TITLE
Various dataset tags improvements

### DIFF
--- a/web/src/components/datasets/DatasetTags.tsx
+++ b/web/src/components/datasets/DatasetTags.tsx
@@ -189,8 +189,8 @@ const DatasetTags: React.FC<IProps> = (props) => {
           multiple
           disableCloseOnSelect
           id='dataset-tags'
-          sx={{ flex: 1 }}
-          limitTags={!datasetField ? 5 : 4}
+          sx={{ flex : 1,  width: datasetField ? 494 : 'auto' }}
+          limitTags={!datasetField ?  8 : 6}
           autoHighlight
           disableClearable
           disablePortal
@@ -252,6 +252,9 @@ const DatasetTags: React.FC<IProps> = (props) => {
             options={tagData.map((option) => option.name)}
             autoSelect
             freeSolo
+            fullWidth
+            autoFocus
+            forcePopupIcon
             onChange={handleTagDescChange}
             renderInput={(params) => (
               <TextField
@@ -260,7 +263,6 @@ const DatasetTags: React.FC<IProps> = (props) => {
                 autoFocus
                 margin='dense'
                 id='tag'
-                fullWidth
                 variant='outlined'
                 InputLabelProps={{
                   ...params.InputProps,
@@ -273,7 +275,6 @@ const DatasetTags: React.FC<IProps> = (props) => {
             Description
           </MQText>
           <TextField
-            autoFocus
             multiline
             id='tag-description'
             name='tag-description'


### PR DESCRIPTION
### Problem

A few suggestions from the Marquez crew re the tags

- change text focus from description to the autocomplete drop down when the edit tags dialog is opened
- show that the auto complete is a drop down by using a carat.
- stop the dataset tags column resizing in dataset field mode (may need to think about column name width)

Closes: #2811 

### Solution

<img width="606" alt="Screenshot 2024-05-14 at 18 48 55" src="https://github.com/MarquezProject/marquez/assets/34074888/637784aa-5f36-41b2-a07b-b0ec53a0b9ce">

<img width="796" alt="Screenshot 2024-05-14 at 18 51 01" src="https://github.com/MarquezProject/marquez/assets/34074888/3185731a-d290-4ac3-a5d4-ef9975b4a9ee">

One-line summary:

Various tag improvements

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [x] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
