### PR TITLE
Add cors support for docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,19 @@
 version: "3.7"
 services:
+  nginx:
+    image: nginx:latest
+    container_name: nginx
+    ports:
+      - "80:80"
+    volumes:
+      - nginx-conf:/etc/nginx
+    environment:
+      - MARQUEZ_HOST=api
+      - MARQUEZ_PORT=${API_PORT}
+    depends_on:
+      - api
+    entrypoint: ["./etc/nginx/entrypoint.sh"]
+
   api:
     image: "marquezproject/marquez:${TAG}"
     container_name: marquez-api
@@ -37,6 +51,7 @@ services:
     # command: ["postgres", "-c", "log_statement=all"]
 
 volumes:
+  nginx-conf:
   data:
   db-conf:
   db-init:

--- a/docker/nginx/entrypoint.sh
+++ b/docker/nginx/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Copyright 2018-2024 contributors to the Marquez project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Usage: $ ./entrypoint.sh
+
+# Replace environment variables in the Nginx template
+envsubst '$MARQUEZ_HOST,$MARQUEZ_PORT' < /etc/nginx/nginx.template > /etc/nginx/nginx.conf
+
+# Start Nginx
+nginx -g 'daemon off;'

--- a/docker/nginx/nginx.template
+++ b/docker/nginx/nginx.template
@@ -13,21 +13,10 @@ http {
 
             # Allow access from any origin:
             add_header 'Access-Control-Allow-Origin' '*';
-            # Or, configure access to a specific origin:
-            # Access-Control-Allow-Origin: https://example.com
+            # Or, configure access from a specific origin:
+            # add_header 'Access-Control-Allow-Origin' 'https://example.com';
             add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, DELETE, PUT';
             add_header 'Access-Control-Allow-Headers' 'Origin, X-Requested-With, Content-Type, Accept, Authorization';
-
-            # Handle preflight requests
-            if ($request_method = OPTIONS ) {
-                add_header 'Access-Control-Allow-Origin' '*';
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, DELETE, PUT';
-                add_header 'Access-Control-Allow-Headers' 'Origin, X-Requested-With, Content-Type, Accept, Authorization';
-                add_header 'Access-Control-Max-Age' 1728000;
-                add_header 'Content-Type' 'text/plain charset=UTF-8';
-                add_header 'Content-Length' 0;
-                return 204;
-            }
         }
     }
 }

--- a/docker/nginx/nginx.template
+++ b/docker/nginx/nginx.template
@@ -1,0 +1,33 @@
+events {}
+
+http {
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://${MARQUEZ_HOST}:${MARQUEZ_PORT};
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Allow access from any origin:
+            add_header 'Access-Control-Allow-Origin' '*';
+            # Or, configure access to a specific origin:
+            # Access-Control-Allow-Origin: https://example.com
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, DELETE, PUT';
+            add_header 'Access-Control-Allow-Headers' 'Origin, X-Requested-With, Content-Type, Accept, Authorization';
+
+            # Handle preflight requests
+            if ($request_method = OPTIONS ) {
+                add_header 'Access-Control-Allow-Origin' '*';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, DELETE, PUT';
+                add_header 'Access-Control-Allow-Headers' 'Origin, X-Requested-With, Content-Type, Accept, Authorization';
+                add_header 'Access-Control-Max-Age' 1728000;
+                add_header 'Content-Type' 'text/plain charset=UTF-8';
+                add_header 'Content-Length' 0;
+                return 204;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds cors support for docker compose by:
* Adding `nginx` to base `docker-compose.yml`
* Adding `docker/nginx/nginx.template` to override `Access-Control-Allow-Origin` default `*` (= any origins)

### Example 

Proxy all API calls to Marquez (any origin):

```
# Allow access from any origin:
add_header 'Access-Control-Allow-Origin' '*';
```

```
marquez-api                 | 172.18.0.6 - - [14/May/2024:17:53:50 +0000] "POST /api/v1/lineage HTTP/1.0" 201 0 "-" "RapidAPI/4.2.0 (Macintosh; OS X/12.6.3) GCDHTTPRequest" 103
nginx                       | 192.168.65.1 - - [14/May/2024:17:53:50 +0000] "POST /api/v1/lineage HTTP/1.1" 201 5 "-" "RapidAPI/4.2.0 (Macintosh; OS X/12.6.3) GCDHTTPRequest"
```

```
HTTP/1.1 201 Created
Server: nginx/1.25.5
Date: Tue, 14 May 2024 17:53:50 GMT
Transfer-Encoding: chunked
Connection: close
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET, POST, OPTIONS, DELETE, PUT
Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization
```