### PR TITLE
Allow customization of Apache HTTP in Java client

### DIFF
--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -27,35 +27,31 @@ implementation 'io.github.marquezproject:marquez-java:0.47.0
 // Connect to http://localhost:5000
 MarquezClient client = MarquezClient.builder()
   .baseUrl("http://localhost:5000")
-  .build()
+  .build();
 
 // List namespaces
 List<Namespace> namespaces = client.listNamespaces();
 ```
-### Writing Metadata
-To collect OpenLineage events using Marquez, please use the [openlineage-java](https://search.maven.org/artifact/io.openlineage/openlineage-java) library. OpenLineage is an Open Standard for lineage metadata collection designed to collect metadata for a job in execution.
 
-## HTTPS
+### Customization
+
+The client uses Apache's `httpclient` under the hood. The defaults can be a bit limiting, but you can optionally provide a function that accepts the `HttpClientBuilder` so you can customize it before it's finalised:
 
 ```java
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import marquez.client.MarquezClient;
-.
-.
-KeyManager[] keyManager = setUpKeyManagers();
-TrustManager[] trustManager = setUpTrustManagers();
-
 SSLContext sslContext = SSLContext.getInstance("TLS");
-sslContext.init(keyManager, trustManager, null);
+HttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager(...);
 
-// Connect to https://localhost:5000
 MarquezClient client = MarquezClient.builder()
-  .sslContext(sslContext)
-  .baseUrl("https://localhost:5000")
+  .baseUrl("http://localhost:5000")
+  .httpCustomizer(httpClientBuilder -> {
+    httpClientBuilder.setSSLContext(sslContext);
+    httpClientBuilder.setConnectionManager(connectionManager);
+  })
   .build();
 ```
+
+### Writing Metadata
+To collect OpenLineage events using Marquez, please use the [openlineage-java](https://search.maven.org/artifact/io.openlineage/openlineage-java) library. OpenLineage is an Open Standard for lineage metadata collection designed to collect metadata for a job in execution.
 
 ----
 SPDX-License-Identifier: Apache-2.0

--- a/clients/java/src/main/java/marquez/client/MarquezClient.java
+++ b/clients/java/src/main/java/marquez/client/MarquezClient.java
@@ -24,6 +24,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import lombok.AllArgsConstructor;
@@ -54,6 +55,7 @@ import marquez.client.models.SearchSort;
 import marquez.client.models.Source;
 import marquez.client.models.SourceMeta;
 import marquez.client.models.Tag;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 @Slf4j
 public class MarquezClient {
@@ -506,6 +508,7 @@ public class MarquezClient {
     @VisibleForTesting URL baseUrl;
     @VisibleForTesting @Nullable String apiKey;
     @VisibleForTesting @Nullable SSLContext sslContext;
+    @VisibleForTesting @Nullable Consumer<HttpClientBuilder> httpCustomizer;
 
     private Builder() {
       this.baseUrl = DEFAULT_BASE_URL;
@@ -530,10 +533,15 @@ public class MarquezClient {
       return this;
     }
 
+    public Builder customize(@Nullable Consumer<HttpClientBuilder> httpCustomizer) {
+      this.httpCustomizer = httpCustomizer;
+      return this;
+    }
+
     public MarquezClient build() {
       return new MarquezClient(
           MarquezUrl.create(baseUrl),
-          MarquezHttp.create(sslContext, MarquezClient.Version.get(), apiKey));
+          MarquezHttp.create(sslContext, httpCustomizer, MarquezClient.Version.get(), apiKey));
     }
   }
 

--- a/clients/java/src/main/java/marquez/client/MarquezHttp.java
+++ b/clients/java/src/main/java/marquez/client/MarquezHttp.java
@@ -17,6 +17,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import lombok.Getter;
@@ -59,15 +60,17 @@ class MarquezHttp implements Closeable {
 
   static MarquezHttp create(
       @Nullable SSLContext sslContext,
+      @Nullable Consumer<HttpClientBuilder> httpCustomizer,
       @NonNull final MarquezClient.Version version,
       @Nullable final String apiKey) {
     final UserAgent userAgent = UserAgent.of(version);
-    final CloseableHttpClient http =
-        HttpClientBuilder.create()
-            .setUserAgent(userAgent.getValue())
-            .setSSLContext(sslContext)
-            .build();
-    return new MarquezHttp(http, apiKey);
+    final HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+    httpClientBuilder.setUserAgent(userAgent.getValue());
+    httpClientBuilder.setSSLContext(sslContext);
+    if (httpCustomizer != null) {
+      httpCustomizer.accept(httpClientBuilder);
+    }
+    return new MarquezHttp(httpClientBuilder.build(), apiKey);
   }
 
   String post(URL url) {

--- a/clients/java/src/test/java/marquez/client/MarquezClientTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezClientTest.java
@@ -548,6 +548,17 @@ public class MarquezClientTest {
   }
 
   @Test
+  public void testClientBuilder_httpCustomizer() {
+    MarquezClient.Builder builder = MarquezClient.builder();
+    assertThat(builder.httpCustomizer == null);
+
+    builder.customize(httpClientBuilder -> httpClientBuilder.setMaxConnTotal(30));
+    assertThat(builder.httpCustomizer != null);
+
+    builder.build();
+  }
+
+  @Test
   public void testCreateNamespace() throws Exception {
     final URL url = buildUrlFor("/namespaces/%s", NAMESPACE_NAME);
 

--- a/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
+++ b/clients/java/src/test/java/marquez/client/MarquezHttpTest.java
@@ -85,9 +85,9 @@ public class MarquezHttpTest {
     assertThatNullPointerException().isThrownBy(() -> MarquezHttp.create(null));
     assertThatNullPointerException().isThrownBy(() -> MarquezHttp.create(null, API_KEY));
     assertThatNullPointerException().isThrownBy(() -> MarquezHttp.create(null, null));
-    assertThatNullPointerException().isThrownBy(() -> MarquezHttp.create(null, null, null));
+    assertThatNullPointerException().isThrownBy(() -> MarquezHttp.create(null, null, null, null));
     assertThatNullPointerException()
-        .isThrownBy(() -> MarquezHttp.create(SSLContext.getDefault(), null, API_KEY));
+        .isThrownBy(() -> MarquezHttp.create(SSLContext.getDefault(), null, null, API_KEY));
   }
 
   @Test


### PR DESCRIPTION
### Problem

`MarquezClient` uses the Apache HTTP client under the hood, and its defaults have some limitations around e.g. connection management. I'd like to be able to customize the client to my needs.

### Solution

Add a builder method so you can provide a `Consumer<HttpClientBuilder>` allowing full customization of the Apache client without replicating its entire API on the Marquez side.

One-line summary: Allow customization of Apache HTTP in Java client

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
