### PR TITLE
Fix bug in the airflow example docs

### DIFF
--- a/examples/airflow/airflow.md
+++ b/examples/airflow/airflow.md
@@ -30,7 +30,7 @@ git clone https://github.com/MarquezProject/marquez && cd marquez/examples/airfl
 To make sure the latest [`openlineage-airflow`](https://pypi.org/project/openlineage-airflow) library is downloaded and installed when starting Airflow, you'll need to create a `requirements.txt` file with the following content:
 
 ```
-openlineage-airflow
+apache-airflow-providers-openlineage
 ```
 
 Next, we'll need to specify where we want Airflow to send DAG metadata. To do so, create a config file named `openlineage.env` with the following environment variables and values:


### PR DESCRIPTION
The requirements.txt contents specified in the airflow example docs results in no data being sent to the marquez ui.

### Problem

When specifying `openlineage-airflow` in the requirements.txt for the airflow example, no metadata from the dags is sent to the marquez ui. I may have misunderstood the docs, but using `apache-airflow-providers-openlineage` fixed this issue for me.

### Solution

changed the requirements.txt in the docs to contain `apache-airflow-providers-openlineage` instead of `openlineage-airflow`

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
-  [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [x] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
