### PR TITLE
Web: Source Code Facets

### DIFF
--- a/web/src/components/core/code/MqCode.tsx
+++ b/web/src/components/core/code/MqCode.tsx
@@ -15,6 +15,9 @@ interface OwnProps {
 }
 
 const MqCode: React.FC<OwnProps> = ({ code, description, language }) => {
+  if (!code) {
+    return null
+  }
   return (
     <Box>
       {description && (

--- a/web/src/components/jobs/RunInfo.tsx
+++ b/web/src/components/jobs/RunInfo.tsx
@@ -28,6 +28,13 @@ export interface SqlFacet {
   query: string
 }
 
+export interface SourceCodeFacet {
+  language: string
+  sourceCode: string
+  _producer: string
+  _schemaURL: string
+}
+
 type RunInfoProps = {
   run: Run
 } & JobFacetsProps &
@@ -52,6 +59,12 @@ const RunInfo: FunctionComponent<RunInfoProps> = (props) => {
   return (
     <Box>
       {<MqCode code={(jobFacets?.sql as SqlFacet)?.query} language={'sql'} />}
+      {
+        <MqCode
+          code={(jobFacets.sourceCode as SourceCodeFacet)?.sourceCode}
+          language={(jobFacets.sourceCode as SourceCodeFacet)?.language}
+        />
+      }
       {run.facets && (
         <Box mt={2}>
           <Box mb={1}>


### PR DESCRIPTION
### Problem
Render source code facet for any PL in UI
![image](https://github.com/MarquezProject/marquez/assets/7514204/1177abed-2c0b-4b5b-a348-eb63113f1145)

One-line summary: Typedef and render sourceCode facet for job if available.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
