### PR TITLE
version history: deduplicate the versions displayed

### DIFF
--- a/api/src/main/java/marquez/db/DatasetVersionDao.java
+++ b/api/src/main/java/marquez/db/DatasetVersionDao.java
@@ -278,6 +278,11 @@ public interface DatasetVersionDao extends BaseDao {
       	WHERE dv.namespace_name = :namespaceName
             AND dv.dataset_name = :datasetName
       	LIMIT :limit OFFSET :offset
+        ),
+        dataset_symlinks_names as (
+          SELECT DISTINCT dataset_uuid, name
+          FROM dataset_symlinks
+          WHERE NOT is_primary
         )
         SELECT
 	        type, name, physical_name, namespace_name, source_name, description, lifecycle_state,
@@ -285,6 +290,7 @@ public interface DatasetVersionDao extends BaseDao {
             tags, dataset_version_uuid,
 	        JSONB_AGG(facets ORDER BY lineage_event_time ASC) AS facets
         FROM dataset_info
+        WHERE name NOT IN (SELECT name FROM dataset_symlinks_names)
         GROUP BY type, name, physical_name, namespace_name, source_name, description, lifecycle_state,
             created_at, version, dataset_schema_version_uuid, fields, createdByRunUuid, schema_location,
             tags, dataset_version_uuid

--- a/api/src/test/java/marquez/DatasetIntegrationTest.java
+++ b/api/src/test/java/marquez/DatasetIntegrationTest.java
@@ -620,7 +620,6 @@ public class DatasetIntegrationTest extends BaseIntegrationTest {
                         .build()))
             .outputs(Collections.emptyList())
             .build();
-    System.out.println("event is " + lineageEvent);
     final CompletableFuture<Integer> resp = sendEvent(lineageEvent);
     assertThat(resp.join()).isEqualTo(201);
     List<DatasetVersion> versions = client.listDatasetVersions(NAMESPACE_NAME, DB_TABLE_NAME);


### PR DESCRIPTION
### Problem

In the version history, a dataset will sometimes have the same version displayed multiple times. 
<img width="802" alt="Capture d’écran 2024-07-16 à 10 55 07" src="https://github.com/user-attachments/assets/bea078c3-33c0-4d78-ab43-a0096a5641a1">

After investigating, i found out that this comes from the join clause between the dataset_versions and datasets_view in [this](https://github.com/MarquezProject/marquez/blob/fcfebc55c80b412e975d3b70e487bd9898f2097f/api/src/main/java/marquez/db/DatasetVersionDao.java#L254-L293) function. The symlinks are included in the datasets_view using the same uuid as the dataset and so are displayed in the same logic as the primary dataset. 

### Solution

- Exclude the symlinks from the result of the query to display the version history
- this will be done by creating a CTE 'dataset_symlinks_names' with all the symlinks name. Then we check that all the datasets name included in the list of version does not have a symlink name (and so is not a symlink)

For the same dataset in the above example we have now this display
<img width="800" alt="Capture d’écran 2024-07-16 à 11 14 47" src="https://github.com/user-attachments/assets/62fbc0d5-1fde-49ac-9681-fa5ef8097602">


One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
