### PR TITLE
[FIX] Dataset query to get only the latest facet for each version

### DIFF
--- a/api/src/main/java/marquez/db/DatasetDao.java
+++ b/api/src/main/java/marquez/db/DatasetDao.java
@@ -126,7 +126,7 @@ public interface DatasetDao extends BaseDao {
                   df.facet,
                   df."name",
                   df.created_at,
-                  rank() OVER (PARTITION BY "name"
+                  rank() OVER (PARTITION BY df.dataset_version_uuid, "name"
                                ORDER BY created_at DESC) AS r
           FROM dataset_facets AS df
           WHERE df.facet IS NOT NULL

--- a/api/src/main/java/marquez/db/DatasetDao.java
+++ b/api/src/main/java/marquez/db/DatasetDao.java
@@ -121,30 +121,51 @@ public interface DatasetDao extends BaseDao {
 
   @SqlQuery(
       """
-          SELECT d.*, dv.fields, dv.lifecycle_state, sv.schema_location, t.tags, facets
-          FROM datasets_view d
-          LEFT JOIN dataset_versions dv ON d.current_version_uuid = dv.uuid
-          LEFT JOIN stream_versions AS sv ON sv.dataset_version_uuid = dv.uuid
-          LEFT JOIN (
-              SELECT ARRAY_AGG(t.name) AS tags, m.dataset_uuid
-              FROM tags AS t
-              INNER JOIN datasets_tag_mapping AS m ON m.tag_uuid = t.uuid
-              GROUP BY m.dataset_uuid
-          ) t ON t.dataset_uuid = d.uuid
-          LEFT JOIN (
-              SELECT
-                  df.dataset_version_uuid,
-                  JSONB_AGG(df.facet ORDER BY df.lineage_event_time ASC) AS facets
-                FROM dataset_facets AS df
-                WHERE df.facet IS NOT NULL AND
-                 (df.type ILIKE 'dataset' OR df.type ILIKE 'unknown' OR df.type ILIKE 'input') AND
-                  df.dataset_uuid IN (SELECT uuid FROM datasets_view WHERE namespace_name = :namespaceName ORDER BY name LIMIT :limit OFFSET :offset)
-              GROUP BY df.dataset_version_uuid
-          ) f ON f.dataset_version_uuid = d.current_version_uuid
-          WHERE d.namespace_name = :namespaceName
-          ORDER BY d.name
-          LIMIT :limit OFFSET :offset
-          """)
+      WITH facets_t AS
+          (SELECT df.dataset_version_uuid,
+                  df.facet,
+                  df."name",
+                  df.created_at,
+                  rank() OVER (PARTITION BY "name"
+                               ORDER BY created_at DESC) AS r
+          FROM dataset_facets AS df
+          WHERE df.facet IS NOT NULL
+             AND (df.type ILIKE 'dataset'
+                  OR df.type ILIKE 'unknown'
+                  OR df.type ILIKE 'input')
+             AND df.dataset_uuid IN
+               (SELECT UUID
+                FROM datasets_view
+                WHERE namespace_name = :namespaceName
+                ORDER BY name
+                LIMIT 10
+                OFFSET :offset))
+      SELECT d.*,
+          dv.fields,
+          dv.lifecycle_state,
+          sv.schema_location,
+          t.tags,
+          facets
+      FROM datasets_view d
+      LEFT JOIN dataset_versions dv ON d.current_version_uuid = dv.uuid
+      LEFT JOIN stream_versions AS sv ON sv.dataset_version_uuid = dv.uuid
+      LEFT JOIN
+        (SELECT ARRAY_AGG(t.name) AS tags,
+                m.dataset_uuid
+            FROM tags AS t
+            INNER JOIN datasets_tag_mapping AS m ON m.tag_uuid = t.uuid
+            GROUP BY m.dataset_uuid) t ON t.dataset_uuid = d.uuid
+      LEFT JOIN
+        (SELECT df.dataset_version_uuid,
+                JSONB_AGG(df.facet) AS facets
+          FROM facets_t AS df
+          WHERE r = 1
+          GROUP BY df.dataset_version_uuid) f ON f.dataset_version_uuid = d.current_version_uuid
+      WHERE d.namespace_name = :namespaceName
+      ORDER BY d.name
+      LIMIT :limit
+      OFFSET :offset
+      """)
   List<Dataset> findAll(String namespaceName, int limit, int offset);
 
   @SqlQuery("SELECT count(*) FROM datasets_view")


### PR DESCRIPTION
### Problem

Closes: https://github.com/MarquezProject/marquez/issues/2860

### Solution

Since the same facet type is replicated a lot of times, we can rank the facet partition by dataset version and facet name ands so as we can take only the most recent facet for each dataset uuid and type.
The UI seems to display only one facet per type (facet name) and dataset version anyway so we don't need to query as much facet (which are just duplicates anyway).

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
