### PR TITLE
fix/encode-uri-column-lineage-link

### DIFF
--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -140,11 +140,11 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = (props) => {
                                 disabled={!hasColumnLineage}
                                 size={'small'}
                                 component={Link}
-                                to={`/datasets/column-level/${dataset.namespace}/${
-                                  dataset.name
+                                to={`/datasets/column-level/${encodeURIComponent(dataset.namespace)}/${
+                                  encodeURIComponent(dataset.name)
                                 }?column=${encodeURIComponent(
                                   encodeQueryString(dataset.namespace, dataset.name, field.name)
-                                )}&columnName=${field.name}`}
+                                )}&columnName=${encodeURIComponent(field.name)}`}
                               >
                                 <SplitscreenIcon />
                               </IconButton>


### PR DESCRIPTION
### Problem

Name and Namespace must be encoded since many are query strings that include prefixes like host://example.com... which cannot be in a url directly.


One-line summary: Encodes name and namespace in corresponding link.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
