### PR TITLE
Web: encode job name in API requests

### DIFF
--- a/web/src/store/requests/datasets.ts
+++ b/web/src/store/requests/datasets.ts
@@ -6,9 +6,8 @@ import { Dataset, DatasetVersions, Datasets } from '../../types/api'
 import { genericFetchWrapper } from './index'
 
 export const getDatasets = async (namespace: string, limit = 20, offset = 0) => {
-  const url = `${API_URL}/namespaces/${encodeURIComponent(
-    namespace
-  )}/datasets?limit=${limit}&offset=${offset}`
+  const encodedNamespace = encodeURIComponent(namespace)
+  const url = `${API_URL}/namespaces/${encodedNamespace}/datasets?limit=${limit}&offset=${offset}`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchDatasets').then((r: Datasets) => {
     return {
       datasets: r.datasets.map((d) => ({ ...d, namespace: namespace })),
@@ -19,13 +18,13 @@ export const getDatasets = async (namespace: string, limit = 20, offset = 0) => 
 
 export const getDatasetVersions = async (
   namespace: string,
-  dataset: string,
+  datasetName: string,
   limit: number,
   offset: number
 ) => {
-  const url = `${API_URL}/namespaces/${encodeURIComponent(namespace)}/datasets/${encodeURIComponent(
-    dataset
-  )}/versions?limit=${limit}&offset=${offset}`
+  const encodedNamespace = encodeURIComponent(namespace)
+  const encodedDataset = encodeURIComponent(datasetName)
+  const url = `${API_URL}/namespaces/${encodedNamespace}/datasets/${encodedDataset}/versions?limit=${limit}&offset=${offset}`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchDatasetVersions').then(
     (r: DatasetVersions) => {
       return { versions: r.versions, totalCount: r.totalCount }
@@ -33,52 +32,60 @@ export const getDatasetVersions = async (
   )
 }
 
-export const getDataset = async (namespace: string, dataset: string) => {
-  const url = `${API_URL}/namespaces/${encodeURIComponent(namespace)}/datasets/${encodeURIComponent(
-    dataset
-  )}`
+export const getDataset = async (namespace: string, datasetName: string) => {
+  const encodedNamespace = encodeURIComponent(namespace)
+  const encodedDataset = encodeURIComponent(datasetName)
+  const url = `${API_URL}/namespaces/${encodedNamespace}/datasets/${encodedDataset}`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchDataset').then((d: Dataset) => d)
 }
 
-export const deleteDataset = async (datasetName: string, namespace: string) => {
-  const url = `${API_URL}/namespaces/${encodeURIComponent(namespace)}/datasets/${datasetName}`
+export const deleteDataset = async (namespace: string, datasetName: string) => {
+  const encodedNamespace = encodeURIComponent(namespace)
+  const encodedDataset = encodeURIComponent(datasetName)
+  const url = `${API_URL}/namespaces/${encodedNamespace}/datasets/${encodedDataset}`
   return genericFetchWrapper(url, { method: 'DELETE' }, 'deleteDataset')
 }
 
 export const deleteDatasetTag = async (namespace: string, datasetName: string, tag: string) => {
-  const url = `${API_URL}/namespaces/${encodeURIComponent(
-    namespace
-  )}/datasets/${datasetName}/tags/${tag}`
+  const encodedNamespace = encodeURIComponent(namespace)
+  const encodedDataset = encodeURIComponent(datasetName)
+  const encodedTag = encodeURIComponent(tag)
+  const url = `${API_URL}/namespaces/${encodedNamespace}/datasets/${encodedDataset}/tags/${encodedTag}`
   return genericFetchWrapper(url, { method: 'DELETE' }, 'deleteDatasetTag')
 }
 
 export const addDatasetTag = async (namespace: string, datasetName: string, tag: string) => {
-  const url = `${API_URL}/namespaces/${encodeURIComponent(
-    namespace
-  )}/datasets/${datasetName}/tags/${tag}`
+  const encodedNamespace = encodeURIComponent(namespace)
+  const encodedDataset = encodeURIComponent(datasetName)
+  const encodedTag = encodeURIComponent(tag)
+  const url = `${API_URL}/namespaces/${encodedNamespace}/datasets/${encodedDataset}/tags/${encodedTag}`
   return genericFetchWrapper(url, { method: 'POST' }, 'addDatasetTag')
 }
 
 export const deleteDatasetFieldTag = async (
   namespace: string,
   datasetName: string,
-  tag: string,
-  field: string
+  field: string,
+  tag: string
 ) => {
-  const url = `${API_URL}/namespaces/${encodeURIComponent(
-    namespace
-  )}/datasets/${datasetName}/fields/${field}/tags/${tag}`
+  const encodedNamespace = encodeURIComponent(namespace)
+  const encodedDataset = encodeURIComponent(datasetName)
+  const encodedField = encodeURIComponent(field)
+  const encodedTag = encodeURIComponent(tag)
+  const url = `${API_URL}/namespaces/${encodedNamespace}/datasets/${encodedDataset}/fields/${encodedField}/tags/${encodedTag}`
   return genericFetchWrapper(url, { method: 'DELETE' }, 'deleteDatasetFieldTag')
 }
 
 export const addDatasetFieldTag = async (
   namespace: string,
   datasetName: string,
-  tag: string,
-  field: string
+  field: string,
+  tag: string
 ) => {
-  const url = `${API_URL}/namespaces/${encodeURIComponent(
-    namespace
-  )}/datasets/${datasetName}/fields/${field}/tags/${tag}`
+  const encodedNamespace = encodeURIComponent(namespace)
+  const encodedDataset = encodeURIComponent(datasetName)
+  const encodedField = encodeURIComponent(field)
+  const encodedTag = encodeURIComponent(tag)
+  const url = `${API_URL}/namespaces/${encodedNamespace}/datasets/${encodedDataset}/fields/${encodedField}/tags/${encodedTag}`
   return genericFetchWrapper(url, { method: 'POST' }, 'addDatasetFieldTag')
 }

--- a/web/src/store/requests/jobs.ts
+++ b/web/src/store/requests/jobs.ts
@@ -6,16 +6,17 @@ import { Jobs } from '../../types/api'
 import { genericFetchWrapper } from './index'
 
 export const getJobs = async (namespace: string, limit = 25, offset = 0) => {
-  const url = `${API_URL}/namespaces/${encodeURIComponent(
-    namespace
-  )}/jobs?limit=${limit}&offset=${offset}`
+  const encodedNamespace = encodeURIComponent(namespace)
+  const url = `${API_URL}/namespaces/${encodedNamespace}/jobs?limit=${limit}&offset=${offset}`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchJobs').then((r: Jobs) => {
     return { totalCount: r.totalCount, jobs: r.jobs.map((j) => ({ ...j, namespace: namespace })) }
   })
 }
 
-export const deleteJob = async (jobName: string, namespace: string) => {
-  const url = `${API_URL}/namespaces/${encodeURIComponent(namespace)}/jobs/${jobName}`
+export const deleteJob = async (namespace: string, jobName: string) => {
+  const encodedNamespace = encodeURIComponent(namespace)
+  const encodedJob = encodeURIComponent(jobName)
+  const url = `${API_URL}/namespaces/${encodedNamespace}/jobs/${encodedJob}`
   return genericFetchWrapper(url, { method: 'DELETE' }, 'deleteJob')
 }
 
@@ -25,23 +26,31 @@ export const getRuns = async (
   limit: number,
   offset: number
 ) => {
-  const url = `${API_URL}/namespaces/${encodeURIComponent(namespace)}/jobs/${encodeURIComponent(
-    jobName
-  )}/runs?limit=${limit}&offset=${offset}`
+  const encodedNamespace = encodeURIComponent(namespace)
+  const encodedJob = encodeURIComponent(jobName)
+  const url = `${API_URL}/namespaces/${encodedNamespace}/jobs/${encodedJob}/runs?limit=${limit}&offset=${offset}`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchRuns')
 }
 
-export const getJob = async (namespace: string, job: string) => {
-  const url = `${API_URL}/namespaces/${encodeURIComponent(namespace)}/jobs/${job}`
+export const getJob = async (namespace: string, jobName: string) => {
+  const encodedNamespace = encodeURIComponent(namespace)
+  const encodedJob = encodeURIComponent(jobName)
+  const url = `${API_URL}/namespaces/${encodedNamespace}/jobs/${encodedJob}`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchJob')
 }
 
 export const deleteJobTag = async (namespace: string, jobName: string, tag: string) => {
-  const url = `${API_URL}/namespaces/${encodeURIComponent(namespace)}/jobs/${jobName}/tags/${tag}`
+  const encodedNamespace = encodeURIComponent(namespace)
+  const encodedJob = encodeURIComponent(jobName)
+  const encodedTag = encodeURIComponent(tag)
+  const url = `${API_URL}/namespaces/${encodedNamespace}/jobs/${encodedJob}/tags/${encodedTag}`
   return genericFetchWrapper(url, { method: 'DELETE' }, 'deleteJobTag')
 }
 
 export const addJobTag = async (namespace: string, jobName: string, tag: string) => {
-  const url = `${API_URL}/namespaces/${encodeURIComponent(namespace)}/jobs/${jobName}/tags/${tag}`
+  const encodedNamespace = encodeURIComponent(namespace)
+  const encodedJob = encodeURIComponent(jobName)
+  const encodedTag = encodeURIComponent(tag)
+  const url = `${API_URL}/namespaces/${encodedNamespace}/jobs/${encodedJob}/tags/${encodedTag}`
   return genericFetchWrapper(url, { method: 'POST' }, 'addJobTag')
 }

--- a/web/src/store/sagas/index.ts
+++ b/web/src/store/sagas/index.ts
@@ -226,7 +226,7 @@ export function* deleteJobSaga() {
   while (true) {
     try {
       const { payload } = yield take(DELETE_JOB)
-      const job: Job = yield call(deleteJob, payload.jobName, payload.namespace)
+      const job: Job = yield call(deleteJob, payload.namespace, payload.jobName)
       yield put(deleteJobSuccess(job.name))
     } catch (e) {
       yield put(applicationError('Something went wrong while removing job'))
@@ -285,7 +285,7 @@ export function* deleteDatasetSaga() {
   while (true) {
     try {
       const { payload } = yield take(DELETE_DATASET)
-      const dataset: Dataset = yield call(deleteDataset, payload.datasetName, payload.namespace)
+      const dataset: Dataset = yield call(deleteDataset, payload.namespace, payload.datasetName)
       yield put(deleteDatasetSuccess(dataset.name))
     } catch (e) {
       yield put(applicationError('Something went wrong while removing job'))
@@ -325,8 +325,8 @@ export function* deleteDatasetFieldTagSaga() {
         deleteDatasetFieldTag,
         payload.namespace,
         payload.datasetName,
-        payload.tag,
-        payload.field
+        payload.field,
+        payload.tag
       )
       yield put(
         deleteDatasetFieldTagSuccess(
@@ -374,8 +374,8 @@ export function* addDatasetFieldTagSaga() {
         addDatasetFieldTag,
         payload.namespace,
         payload.datasetName,
-        payload.tag,
-        payload.field
+        payload.field,
+        payload.tag
       )
       yield put(
         addDatasetFieldTagSuccess(


### PR DESCRIPTION
### Problem

After upgrading to 0.48 opening some job details lead to 404 errors.
This is because I have job names with slashes, like `my/session/name`, resulting API query to look like this:
`http://localhost:8080/api/v1/namespaces/yarn%3A%2F%2Fsomecluster/jobs/my/session/name.execute_insert_into_hadoop_fs_relation_command`

But it should be:
`http://localhost:8080/api/v1/namespaces/yarn%3A%2F%2Fsomecluster/jobs/my%2Fsession%2Fname.execute_insert_into_hadoop_fs_relation_command`

Same could be applied to dataset, tag or field names.

### Solution

One-line summary:

Urlencode job, dataset, tag and field names while sending API request.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
