### PR TITLE
Use `OSSRH_USERNAME` and `OSSRH_PASSWORD` for `jvm` release

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -130,8 +130,8 @@ publishing {
             def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             credentials {
-                username = System.getenv('SONATYPE_NEXUS_USERNAME')
-                password = System.getenv('SONATYPE_NEXUS_PASSWORD')
+                username = System.getenv('OSSRH_USERNAME')
+                password = System.getenv('OSSRH_PASSWORD')
             }
         }
     }

--- a/clients/java/build.gradle
+++ b/clients/java/build.gradle
@@ -86,8 +86,8 @@ publishing {
             def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             credentials {
-                username = System.getenv('SONATYPE_NEXUS_USERNAME')
-                password = System.getenv('SONATYPE_NEXUS_PASSWORD')
+                username = System.getenv('OSSRH_USERNAME')
+                password = System.getenv('OSSRH_PASSWORD')
             }
         }
     }


### PR DESCRIPTION
This PR updates our `jvm` release process to use OSSRH sonatype nexus token based auth for publishing artificats, see [Generate a Token on OSSRH Sonatype Nexus Repository Manager servers](https://central.sonatype.org/publish/generate-token/?__hstc=31049440.03f408c2abdd684f90b07119cce7be37.1722467505696.1722535612396.1722880325996.3&__hssc=31049440.3.1722880325996&__hsfp=448416320).