### PR TITLE
add common labels to replicasets

### DIFF
--- a/chart/templates/marquez/deployment.yaml
+++ b/chart/templates/marquez/deployment.yaml
@@ -22,6 +22,9 @@ spec:
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.commonLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 8 }}
+        {{- end }}
         app.kubernetes.io/component: marquez
     spec:
       {{- if .Values.marquez.serviceAccount }}

--- a/chart/templates/web/deployment.yaml
+++ b/chart/templates/web/deployment.yaml
@@ -19,6 +19,9 @@ spec:
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.commonLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 8 }}
+        {{- end }}
         app.kubernetes.io/component: web
     spec:
       containers:


### PR DESCRIPTION
### Problem
Replicasets were missing common labels. This PR adds them to deployments.

### Solution

Replicasets were missing common labels. This PR adds them to deployments.

One-line summary:
Replicasets were missing common labels. This PR adds them to deployments.