### PR TITLE
[FIX] Column lineage query with null namespace and name

### DIFF
--- a/api/src/main/java/marquez/db/ColumnLineageDao.java
+++ b/api/src/main/java/marquez/db/ColumnLineageDao.java
@@ -187,22 +187,22 @@ public interface ColumnLineageDao extends BaseDao {
         dataset_fields_view AS (
             SELECT
                 d.namespace_name AS namespace_name,
-                d.name AS dataset_name,
+                d.dataset_name AS dataset_name,
                 df.name AS field_name,
                 df.type,
                 df.uuid
             FROM dataset_fields df
             INNER JOIN (
-                SELECT uuid, namespace_name, name
-                FROM datasets_view
-                WHERE current_version_uuid IN (
+                SELECT DISTINCT dataset_uuid, namespace_name, dataset_name
+                FROM dataset_versions
+                WHERE uuid IN (
                     SELECT DISTINCT output_dataset_version_uuid
                     FROM selected_column_lineage
                     UNION
                     SELECT DISTINCT input_dataset_version_uuid
                     FROM selected_column_lineage
                 )
-            ) d ON d.uuid = df.dataset_uuid
+            ) d ON d.dataset_uuid = df.dataset_uuid
         )
         SELECT
           output_fields.namespace_name,


### PR DESCRIPTION
### Problem

Closes: [#2875](https://github.com/MarquezProject/marquez/issues/2875)

In some case the input dataset used seems not to be in dataset_views table so when joining the two tables it results in null for namespace and name and make the list dataset endpoint fail. 
dataset_views only contains the latest dataset version so if the column lineage is created with an old version, this old version will ne be in the dataset_view and then results in an empty namespace and name.

### Solution

We can get the namespace and name in the dataset_versions table to make sure to have all the version of a dataset.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
