### PR TITLE
Web Error Handling

### DIFF
--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -1,50 +1,65 @@
-// Copyright 2018-2023 contributors to the Marquez project
+// Copyright 2018-2024 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react'
+import * as Redux from 'redux'
 import { IState } from '../store/reducers'
+import { Snackbar, SnackbarCloseReason } from '@mui/material'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
-import { createTheme } from '@mui/material'
-import { useTheme } from '@emotion/react'
-import Box from '@mui/material/Box'
+import { dialogToggle } from '../store/actionCreators'
+import CloseIcon from '@mui/icons-material/Close'
+import IconButton from '@mui/material/IconButton'
 
 interface IProps {
   error?: string
   success?: string
+  isOpen: boolean
 }
 
-const Toast = ({ error, success }: IProps) => {
-  const theme = createTheme(useTheme())
+interface IDispatchProps {
+  dialogToggle: typeof dialogToggle
+}
 
-  return error || success ? (
-    <Box
-      sx={Object.assign(
-        {
-          position: 'fixed',
-          bottom: 0,
-          left: '30%',
-          borderRadius: theme.shape.borderRadius,
-          color: theme.palette.common.white,
-          padding: theme.spacing(2),
-          maxWidth: '40%',
-          minWidth: '40%',
-          textAlign: 'center',
-          border: `2px dashed ${theme.palette.secondary.main}`,
-          borderBottom: 'none',
-          backgroundColor: theme.palette.background.default,
-        },
-        error ? { color: theme.palette.error.main } : { color: theme.palette.primary.main }
-      )}
-      className={'shadow animated faster bounceInUp'}
-    >
-      <p>{error || success}</p>
-    </Box>
-  ) : null
+const Toast = ({ error, success, isOpen, dialogToggle }: IProps & IDispatchProps) => {
+  const handleClose = (_: React.SyntheticEvent | Event, reason?: SnackbarCloseReason) => {
+    if (reason === 'clickaway') {
+      return
+    }
+
+    dialogToggle('error')
+  }
+
+  const action = (
+    <IconButton size='small' aria-label='close' color='inherit' onClick={handleClose}>
+      <CloseIcon fontSize='small' />
+    </IconButton>
+  )
+
+  return (
+    <Snackbar
+      open={isOpen}
+      autoHideDuration={5000}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      onClose={handleClose}
+      message={error || success}
+      action={action}
+    />
+  )
 }
 
 const mapStateToProps = (state: IState) => ({
   error: state.display.error,
   success: state.display.success,
+  isOpen: state.display.dialogIsOpen,
 })
 
-export default connect(mapStateToProps)(Toast)
+const mapDispatchToProps = (dispatch: Redux.Dispatch) =>
+  bindActionCreators(
+    {
+      dialogToggle: dialogToggle,
+    },
+    dispatch
+  )
+
+export default connect(mapStateToProps, mapDispatchToProps)(Toast)

--- a/web/src/store/reducers/display.ts
+++ b/web/src/store/reducers/display.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 contributors to the Marquez project
+// Copyright 2018-2024 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
 
 import { APPLICATION_ERROR, DIALOG_TOGGLE } from '../actionCreators/actionTypes'
@@ -34,7 +34,7 @@ export default (state = initialState, action: IToggleExpandAction) => {
   }
   switch (action.type) {
     case APPLICATION_ERROR:
-      return { ...state, error: action.payload.message, success: '' }
+      return { ...state, error: action.payload.message, dialogIsOpen: true, success: '' }
     case DIALOG_TOGGLE:
       return { ...state, dialogIsOpen: !state.dialogIsOpen, editWarningField: action.payload.field }
     default:


### PR DESCRIPTION
### Problem

Error state never went away without a hard refresh and users did not really like this experience.

Example: 
![image](https://github.com/user-attachments/assets/9d284d45-7576-4c24-a5ba-bf3aebcd9464)

Closes: https://github.com/MarquezProject/marquez/issues/2888

### Solution

Several Enhancements here including:
1. Using core library <Snackbar /> component for rendering that is more in line with a canonical UX for this purpose.
2. Auto dismiss after 5 seconds
3. Manual dismiss available.

One-line summary: Error Handling Resolution

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [x] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
