### PR TITLE
feature/404-page

### DIFF
--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -5,6 +5,7 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import { Box, Container, CssBaseline } from '@mui/material'
 import { Helmet, HelmetProvider } from 'react-helmet-async'
 import { LocalizationProvider } from '@mui/x-date-pickers'
+import { NotFound } from '../routes/not-found/NotFound'
 import { Provider } from 'react-redux'
 import { ReduxRouter, createRouterMiddleware } from '@lagunovsky/redux-react-router'
 import { Route, Routes } from 'react-router-dom'
@@ -69,6 +70,7 @@ const App = (): ReactElement => {
                       element={<ColumnLevel />}
                     />
                     <Route path={'/lineage/:nodeType/:namespace/:name'} element={<TableLevel />} />
+                    <Route path='*' element={<NotFound />} />
                   </Routes>
                   <Toast />
                 </Box>

--- a/web/src/routes/not-found/NotFound.tsx
+++ b/web/src/routes/not-found/NotFound.tsx
@@ -1,0 +1,23 @@
+// Copyright 2018-2024 contributors to the Marquez project
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react'
+import { Box } from '@mui/system'
+import { Button } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
+import MqEmpty from '../../components/core/empty/MqEmpty'
+
+export const NotFound = () => {
+  return (
+    <Box pt={4} display={'flex'} justifyContent={'center'}>
+      <MqEmpty title={'Not Found'}>
+        <>
+          Sorry, the page you are looking for does not exist.
+          <Button size={'small'} component={RouterLink} to={'/'}>
+            Go Home
+          </Button>
+        </>
+      </MqEmpty>
+    </Box>
+  )
+}


### PR DESCRIPTION
### Problem

We're missing a basic catch all 404 page and this adds it.

![image](https://github.com/user-attachments/assets/61419193-44f1-45ce-bca9-faedfcdf68bc)


### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
