### PR TITLE
Web: Allow nullable columns and handle it accordingly

### DIFF
--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -116,7 +116,7 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = (props) => {
                         <TableCell align='left'>
                           <Chip
                             size={'small'}
-                            label={<MqText font={'mono'}>{field.type}</MqText>}
+                            label={<MqText font={'mono'} small>{field.type || 'N/A'}</MqText>}
                             variant={'outlined'}
                           />
                         </TableCell>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { JobOrDataset, LineageNode } from './lineage'
+import {Nullable} from "./util/Nullable";
 
 export interface Tag {
   name: string
@@ -150,7 +151,7 @@ export type DatasetType = 'DB_TABLE' | 'STREAM'
 
 export interface Field {
   name: string
-  type: string
+  type: Nullable<string>
   tags: string[]
   description: string
 }


### PR DESCRIPTION
### Problem
We would display and empty oval in the case that column types were missing, this will display `N/A` in the case that we encounter it.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
