### PR TITLE
Web: Fixing job node color for running and other states.

### DIFF
--- a/web/src/routes/table-level/TableLineageJobNode.tsx
+++ b/web/src/routes/table-level/TableLineageJobNode.tsx
@@ -16,6 +16,7 @@ import MQTooltip from '../../components/core/tooltip/MQTooltip'
 import MqStatus from '../../components/core/status/MqStatus'
 import MqText from '../../components/core/text/MqText'
 import React from 'react'
+import {runStateColor} from "../../helpers/nodes";
 
 interface StateProps {
   lineage: LineageGraph
@@ -84,11 +85,7 @@ const TableLineageJobNode = ({ node }: TableLineageJobNodeProps & StateProps) =>
             </MqText>
             <MqStatus
               label={job.latestRun?.state || 'N/A'}
-              color={
-                job.latestRun?.state === 'COMPLETED'
-                  ? theme.palette.primary.main
-                  : theme.palette.error.main
-              }
+              color={job.latestRun?.state ? runStateColor(job.latestRun?.state) : theme.palette.primary.main}
             />
           </Box>
         </Box>


### PR DESCRIPTION
### Problem
Job node color should use the color generator instead of just being red if the job is not completed.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
