### PR TITLE
Remove Daily LE View

### DIFF
--- a/api/src/main/java/marquez/jobs/MaterializeViewRefresherJob.java
+++ b/api/src/main/java/marquez/jobs/MaterializeViewRefresherJob.java
@@ -56,14 +56,6 @@ public class MaterializeViewRefresherJob extends AbstractScheduledService implem
           });
       log.info("Materialized view `lineage_events_by_type_hourly_view` refreshed.");
 
-      if (java.time.LocalTime.now().getHour() == 0) {
-        jdbi.useHandle(
-            handle -> {
-              handle.execute("REFRESH MATERIALIZED VIEW lineage_events_by_type_daily_view");
-            });
-        log.info("Materialized view `lineage_events_by_type_daily_view` refreshed.");
-      }
-
     } catch (Exception error) {
       log.error("Failed to materialize views. Retrying on next run...", error);
     }

--- a/api/src/main/resources/marquez/db/migration/V72__remove_daily_mat_view_lineage_metrics.sql
+++ b/api/src/main/resources/marquez/db/migration/V72__remove_daily_mat_view_lineage_metrics.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW IF EXISTS lineage_events_by_type_daily_view;


### PR DESCRIPTION
### Problem

We no longer need this view because we use the hourly view as an aggregation to move across timezones.

One-line summary: Removes view and refresh task

> Note: This PR will fail tests until #2919 is merged.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
