### PR TITLE
Add `GET` `/api/v1/jobs`

### DIFF
--- a/api/src/main/java/marquez/db/JobDao.java
+++ b/api/src/main/java/marquez/db/JobDao.java
@@ -143,7 +143,7 @@ public interface JobDao extends BaseDao {
     Optional<Job> job = findJobByName(namespaceName, jobName);
     job.ifPresent(
         j -> {
-          List<Run> runs = createRunDao().findByLatestJob(namespaceName, jobName, 1, 0);
+          List<Run> runs = createRunDao().findByLatestJob(namespaceName, jobName, 10, 0);
           this.setJobData(runs, j);
           this.setJobDataset(
               createJobVersionDao().findCurrentInputOutputDatasetsFor(namespaceName, jobName), j);
@@ -179,7 +179,7 @@ public interface JobDao extends BaseDao {
           FROM
             jobs_view AS j
           WHERE
-            j.namespace_name = :namespaceName
+            (:namespaceName IS NULL OR j.namespace_name = :namespaceName)
         ),
         job_versions_temp AS (
           SELECT
@@ -187,7 +187,7 @@ public interface JobDao extends BaseDao {
           FROM
             job_versions AS j
           WHERE
-            j.namespace_name = :namespaceName
+            (:namespaceName IS NULL OR j.namespace_name = :namespaceName)
         ),
         facets_temp AS (
         SELECT
@@ -219,7 +219,7 @@ public interface JobDao extends BaseDao {
           ON
               jtm.job_uuid = j.uuid
           AND
-              j.namespace_name = :namespaceName
+              (:namespaceName IS NULL OR j.namespace_name = :namespaceName)
           INNER JOIN
               tags t
           ON
@@ -271,7 +271,7 @@ public interface JobDao extends BaseDao {
   int countJobRuns(String namespaceName, String job);
 
   @SqlQuery(
-      "SELECT count(*) FROM jobs_view AS j WHERE j.namespace_name = :namespaceName\n"
+      "SELECT count(*) FROM jobs_view AS j WHERE (:namespaceName IS NULL OR j.namespace_name = :namespaceName)\n"
           + "AND symlink_target_uuid IS NULL")
   int countFor(String namespaceName);
 
@@ -281,7 +281,9 @@ public interface JobDao extends BaseDao {
     return findAll(namespaceName, lastRunStates, limit, offset).stream()
         .peek(
             j -> {
-              List<Run> runs = runDao.findByLatestJob(namespaceName, j.getName().getValue(), 10, 0);
+              List<Run> runs =
+                  runDao.findByLatestJob(
+                      j.getNamespace().getValue(), j.getName().getValue(), 10, 0);
               this.setJobData(runs, j);
             })
         .toList();

--- a/api/src/test/java/marquez/db/JobDaoTest.java
+++ b/api/src/test/java/marquez/db/JobDaoTest.java
@@ -5,8 +5,10 @@
 
 package marquez.db;
 
+import static marquez.common.models.CommonModelGenerator.newJobName;
 import static marquez.db.DbTestUtils.createJobWithSymlinkTarget;
 import static marquez.db.DbTestUtils.createJobWithoutSymlinkTarget;
+import static marquez.db.DbTestUtils.newJob;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -22,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import marquez.common.models.JobName;
 import marquez.common.models.JobType;
 import marquez.common.models.RunState;
 import marquez.db.models.DbModelGenerator;
@@ -122,6 +125,32 @@ public class JobDaoTest {
         .containsExactlyInAnyOrder(
             DbModelGenerator.jobIdFor(namespace.getName(), targetJob.getName()),
             DbModelGenerator.jobIdFor(namespace.getName(), anotherJobSameNamespace.getName()));
+  }
+
+  @Test
+  public void testFindAllWithNoNamespace() {
+    String nullNamespace = null;
+
+    List<RunState> runStates = new ArrayList<>();
+    Collections.addAll(runStates, RunState.values());
+
+    final List<Job> jobsWillBeEmpty = jobDao.findAll(nullNamespace, runStates, 10, 0);
+    assertThat(jobsWillBeEmpty).isEmpty();
+
+    JobName jobName0 = newJobName();
+    JobName jobName1 = newJobName();
+    JobName jobName2 = newJobName();
+
+    JobRow job0 = newJob(jdbi, jobName0.getValue());
+    JobRow job1 = newJob(jdbi, jobName1.getValue());
+    JobRow job2 = newJob(jdbi, jobName2.getValue());
+
+    final List<Job> jobsWillNotBeEmpty = jobDao.findAll(nullNamespace, runStates, 10, 0);
+    assertThat(jobsWillNotBeEmpty)
+        .isNotEmpty()
+        .hasSize(3)
+        .extracting(Job::getName)
+        .containsExactlyInAnyOrder(jobName0, jobName1, jobName2);
   }
 
   @Test


### PR DESCRIPTION
This PR adds the endpoint `GET` `/api/v1/jobs`, no longer requiring a namespace. You can still list jobs for a given namesake via `GET` `/api/v1/namespaces/{namespace}/jobs`