### PR TITLE
Fixing `latestRun` on `/lineage` endpoint

### DIFF
--- a/api/src/main/java/marquez/api/OpenLineageResource.java
+++ b/api/src/main/java/marquez/api/OpenLineageResource.java
@@ -119,7 +119,7 @@ public class OpenLineageResource extends BaseResource {
       @QueryParam("nodeId") @NotNull NodeId nodeId,
       @QueryParam("depth") @DefaultValue(DEFAULT_DEPTH) int depth) {
     throwIfNotExists(nodeId);
-    return Response.ok(lineageService.lineage(nodeId, depth, true)).build();
+    return Response.ok(lineageService.lineage(nodeId, depth)).build();
   }
 
   @Timed

--- a/api/src/main/java/marquez/db/RunDao.java
+++ b/api/src/main/java/marquez/db/RunDao.java
@@ -515,7 +515,7 @@ public interface RunDao extends BaseDao {
         INNER JOIN jobs_view j ON j.namespace_name=r.namespace_name AND j.name=r.job_name
         WHERE j.namespace_name=:namespace AND (j.name=:jobName OR j.name=ANY(j.aliases))
       )
-      ORDER BY transitioned_at DESC
+      ORDER BY transitioned_at DESC, started_at DESC
       LIMIT :limit OFFSET :offset
       """)
   List<Run> findByLatestJob(String namespace, String jobName, int limit, int offset);

--- a/api/src/main/java/marquez/service/LineageService.java
+++ b/api/src/main/java/marquez/service/LineageService.java
@@ -64,7 +64,7 @@ public class LineageService extends DelegatingLineageDao {
   }
 
   // TODO make input parameters easily extendable if adding more options like 'withJobFacets'
-  public Lineage lineage(NodeId nodeId, int depth, boolean withRunFacets) {
+  public Lineage lineage(NodeId nodeId, int depth) {
     log.debug("Attempting to get lineage for node '{}' with depth '{}'", nodeId.getValue(), depth);
     Optional<UUID> optionalUUID = getJobUuid(nodeId);
     if (optionalUUID.isEmpty()) {
@@ -90,10 +90,7 @@ public class LineageService extends DelegatingLineageDao {
     }
 
     List<Run> runs =
-        withRunFacets
-            ? getCurrentRunsWithFacets(
-                jobData.stream().map(JobData::getUuid).collect(Collectors.toSet()))
-            : getCurrentRuns(jobData.stream().map(JobData::getUuid).collect(Collectors.toSet()));
+        getCurrentRuns(jobData.stream().map(JobData::getUuid).collect(Collectors.toSet()));
 
     for (JobData j : jobData) {
       if (j.getLatestRun().isEmpty()) {

--- a/api/src/test/java/marquez/api/OpenLineageResourceTest.java
+++ b/api/src/test/java/marquez/api/OpenLineageResourceTest.java
@@ -7,7 +7,6 @@ package marquez.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -46,7 +45,7 @@ class OpenLineageResourceTest {
             OpenLineageResourceTest.class.getResourceAsStream("/lineage/node.json"),
             new TypeReference<>() {});
     LINEAGE = new Lineage(ImmutableSortedSet.of(testNode));
-    when(lineageService.lineage(any(NodeId.class), anyInt(), anyBoolean())).thenReturn(LINEAGE);
+    when(lineageService.lineage(any(NodeId.class), anyInt())).thenReturn(LINEAGE);
 
     ServiceFactory serviceFactory =
         ApiTestUtils.mockServiceFactory(

--- a/api/src/test/java/marquez/service/LineageServiceTest.java
+++ b/api/src/test/java/marquez/service/LineageServiceTest.java
@@ -137,8 +137,7 @@ public class LineageServiceTest {
         dataset);
     String jobName = writeJob.getJob().getName();
     Lineage lineage =
-        lineageService.lineage(
-            NodeId.of(new NamespaceName(NAMESPACE), new JobName(jobName)), 2, true);
+        lineageService.lineage(NodeId.of(new NamespaceName(NAMESPACE), new JobName(jobName)), 2);
 
     // 1 writeJob           + 1 commonDataset
     // 20 readJob           + 20 outputData
@@ -273,8 +272,7 @@ public class LineageServiceTest {
 
     String jobName = writeJob.getJob().getName();
     Lineage lineage =
-        lineageService.lineage(
-            NodeId.of(new NamespaceName(NAMESPACE), new JobName(jobName)), 2, true);
+        lineageService.lineage(NodeId.of(new NamespaceName(NAMESPACE), new JobName(jobName)), 2);
 
     // 1 writeJob           + 0 commonDataset is hidden
     // 20 readJob           + 20 outputData
@@ -326,8 +324,7 @@ public class LineageServiceTest {
     jobDao.delete(NAMESPACE, "downstreamJob0<-outputData<-readJob0<-commonDataset");
 
     lineage =
-        lineageService.lineage(
-            NodeId.of(new NamespaceName(NAMESPACE), new JobName(jobName)), 2, true);
+        lineageService.lineage(NodeId.of(new NamespaceName(NAMESPACE), new JobName(jobName)), 2);
 
     // 1 writeJob           + 0 commonDataset is hidden
     // 20 readJob           + 20 outputData
@@ -357,9 +354,7 @@ public class LineageServiceTest {
             openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList());
     Lineage lineage =
         lineageService.lineage(
-            NodeId.of(new NamespaceName(NAMESPACE), new JobName(writeJob.getJob().getName())),
-            5,
-            true);
+            NodeId.of(new NamespaceName(NAMESPACE), new JobName(writeJob.getJob().getName())), 5);
     assertThat(lineage.getGraph())
         .hasSize(1)
         .first()
@@ -410,8 +405,7 @@ public class LineageServiceTest {
         lineageService.lineage(
             NodeId.of(
                 new NamespaceName(NAMESPACE), new JobName(intermediateJob.getJob().getName())),
-            5,
-            true);
+            5);
     assertThat(lineage.getGraph()).extracting(Node::getId).hasSize(6);
     ObjectAssert<Node> datasetNode =
         assertThat(lineage.getGraph())
@@ -493,15 +487,13 @@ public class LineageServiceTest {
         lineageService.lineage(
             NodeId.of(
                 new DatasetId(new NamespaceName(NAMESPACE), new DatasetName("input-dataset"))),
-            5,
-            true);
+            5);
 
     Lineage lineageFromOutput =
         lineageService.lineage(
             NodeId.of(
                 new DatasetId(new NamespaceName(NAMESPACE), new DatasetName("output-dataset"))),
-            5,
-            true);
+            5);
 
     assertThat(lineageFromInput.getGraph()).hasSize(3); // 2 datasets + 1 job
     assertThat(lineageFromInput.getGraph()).isEqualTo(lineageFromOutput.getGraph());
@@ -546,15 +538,13 @@ public class LineageServiceTest {
         lineageService.lineage(
             NodeId.of(
                 new DatasetId(new NamespaceName(NAMESPACE), new DatasetName("input-dataset"))),
-            5,
-            true);
+            5);
 
     Lineage lineageFromOutput =
         lineageService.lineage(
             NodeId.of(
                 new DatasetId(new NamespaceName(NAMESPACE), new DatasetName("output-dataset"))),
-            5,
-            true);
+            5);
 
     assertThat(lineageFromInput.getGraph()).hasSize(5); // 2 datasets + 3 jobs
     assertThat(lineageFromInput.getGraph()).isEqualTo(lineageFromOutput.getGraph());
@@ -589,8 +579,7 @@ public class LineageServiceTest {
         lineageService.lineage(
             NodeId.of(
                 new DatasetId(new NamespaceName(NAMESPACE), new DatasetName("output-dataset"))),
-            5,
-            true);
+            5);
 
     assertThat(lineage.getGraph()).hasSize(3); // 1 job + 2 datasets
   }
@@ -608,7 +597,7 @@ public class LineageServiceTest {
 
     NodeId datasetNodeId =
         NodeId.of(new NamespaceName(dataset.getNamespace()), new DatasetName(dataset.getName()));
-    Lineage lineage = lineageService.lineage(datasetNodeId, 2, false);
+    Lineage lineage = lineageService.lineage(datasetNodeId, 2);
     assertThat(lineage.getGraph())
         .hasSize(2)
         .extracting(Node::getId)
@@ -620,7 +609,7 @@ public class LineageServiceTest {
         LineageTestUtils.createLineageRow(
             openLineageDao, "writeJob", "COMPLETE", jobFacet, Arrays.asList(), Arrays.asList());
 
-    lineage = lineageService.lineage(datasetNodeId, 2, false);
+    lineage = lineageService.lineage(datasetNodeId, 2);
     assertThat(lineage.getGraph())
         .hasSize(1)
         .extracting(Node::getId)
@@ -685,8 +674,7 @@ public class LineageServiceTest {
         lineageService.lineage(
             NodeId.of(
                 new DatasetId(new NamespaceName(NAMESPACE), new DatasetName("symlinkDataset"))),
-            5,
-            true);
+            5);
 
     assertThat(lineage.getGraph()).hasSize(2);
   }

--- a/api/src/test/java/marquez/service/LineageServiceTest.java
+++ b/api/src/test/java/marquez/service/LineageServiceTest.java
@@ -28,7 +28,6 @@ import marquez.common.models.InputDatasetVersion;
 import marquez.common.models.JobId;
 import marquez.common.models.JobName;
 import marquez.common.models.NamespaceName;
-import marquez.common.models.OutputDatasetVersion;
 import marquez.common.models.RunState;
 import marquez.db.DatasetDao;
 import marquez.db.JobDao;
@@ -172,11 +171,6 @@ public class LineageServiceTest {
         .extracting(
             Run::getInputDatasetVersions, InstanceOfAssertFactories.list(InputDatasetVersion.class))
         .hasSize(0);
-    runAssert
-        .extracting(
-            Run::getOutputDatasetVersions,
-            InstanceOfAssertFactories.list(OutputDatasetVersion.class))
-        .hasSize(1);
 
     // check the output edges for the commonDataset node
     assertThat(lineage.getGraph())
@@ -307,11 +301,6 @@ public class LineageServiceTest {
         .extracting(
             Run::getInputDatasetVersions, InstanceOfAssertFactories.list(InputDatasetVersion.class))
         .hasSize(0);
-    runAssert
-        .extracting(
-            Run::getOutputDatasetVersions,
-            InstanceOfAssertFactories.list(InputDatasetVersion.class))
-        .hasSize(1);
 
     // check the output edges for the commonDataset node
     assertThat(lineage.getGraph())


### PR DESCRIPTION
### Problem

Simplify our query to render lineage and not include facets. Correctly attribute runs of jobs that are currently in `RUNNING` status.

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
