### PR TITLE
Static Job Event handling

### DIFF
--- a/web/src/components/jobs/JobDetailPage.tsx
+++ b/web/src/components/jobs/JobDetailPage.tsx
@@ -127,12 +127,12 @@ const JobDetailPage: FunctionComponent<IProps> = (props) => {
   }
 
   const lastFinished = (() => {
-    const last = job.latestRuns.find((run) => run.state !== 'RUNNING')
+    const last = job.latestRuns?.find((run) => run.state !== 'RUNNING')
     return last ? formatUpdatedAt(last.endedAt) : 'N/A'
   })()
 
   const lastRuntime = (() => {
-    const last = job.latestRuns.find((run) => run.state !== 'RUNNING')
+    const last = job.latestRuns?.find((run) => run.state !== 'RUNNING')
     return last ? stopWatchDuration(last.durationMs) : 'N/A'
   })()
 
@@ -274,7 +274,7 @@ const JobDetailPage: FunctionComponent<IProps> = (props) => {
             label={'Running Status'.toUpperCase()}
             value={
               <MqStatus
-                label={job.latestRun?.state}
+                label={job.latestRun?.state || 'N/A'}
                 color={
                   job.latestRun?.state
                     ? runStateColor(job.latestRun.state)

--- a/web/src/routes/table-level/TableLineageJobNode.tsx
+++ b/web/src/routes/table-level/TableLineageJobNode.tsx
@@ -88,7 +88,7 @@ const TableLineageJobNode = ({ node }: TableLineageJobNodeProps & StateProps) =>
               color={
                 job.latestRun?.state
                   ? runStateColor(job.latestRun?.state)
-                  : theme.palette.primary.main
+                  : theme.palette.secondary.main
               }
             />
           </Box>


### PR DESCRIPTION
### Problem

Handling static job event rendering on dashboard and lineage page.

```
{
    "eventTime": "2024-10-10T19:16:27.607287Z",
    "job": {
        "namespace": "my-namespace",
        "name": "my-job"
    },
    "inputs": [],
    "outputs": [],
    "schemaURL": "https://openlineage.io/spec/2-0-0/OpenLineage.json#/definitions/JobEvent",
    "producer": "https://github.com/MarquezProject/marquez/blob/main/docker/metadata.json"
}
```

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
