### PR TITLE
Fixing no runs list rendering.

### DIFF
--- a/web/src/routes/dashboard/JobRunItem.tsx
+++ b/web/src/routes/dashboard/JobRunItem.tsx
@@ -61,7 +61,7 @@ const JobRunItem: React.FC<Props> = ({ job }) => {
           <MqText subdued>LAST 10 RUNS</MqText>
           <Box display={'flex'} height={40} alignItems={'flex-end'}>
             {/*pad 10 - latestRuns length with a small grey bar*/}
-            {Array.from({ length: 10 - job.latestRuns?.length || 0 }, (_, i) => (
+            {Array.from({ length: 10 - (job.latestRuns?.length || 0) }, (_, i) => (
               <Box
                 key={i}
                 bgcolor={'divider'}


### PR DESCRIPTION
### Problem

<img width="959" alt="image" src="https://github.com/user-attachments/assets/9b1deac5-c7e7-4283-822b-707546348d86">

This pull request includes a small but important change to the `JobRunItem` component in the `web/src/routes/dashboard/JobRunItem.tsx` file. The change corrects the logic used to calculate the length of the array for displaying the last 10 job runs.

* [`web/src/routes/dashboard/JobRunItem.tsx`](diffhunk://#diff-3ae4af8292f89e94ed82e90c8e4f1116754440491bdc41c07459b0b6c4542f84L64-R64): Fixed the calculation of the array length for displaying the last 10 job runs by adding parentheses around the `job.latestRuns?.length` expression.
* 


### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
