### PR TITLE
Dataset Version call simplification

### DIFF
--- a/web/src/components/datasets/DatasetDetailPage.tsx
+++ b/web/src/components/datasets/DatasetDetailPage.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mui/material'
 import { CalendarIcon } from '@mui/x-date-pickers'
 import { CircularProgress } from '@mui/material'
-import { Dataset, DatasetVersion } from '../../types/api'
+import { Dataset } from '../../types/api'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { IState } from '../../store/reducers'
 import { LineageDataset } from '../../types/lineage'
@@ -28,7 +28,6 @@ import {
   deleteDataset,
   dialogToggle,
   fetchDataset,
-  fetchInitialDatasetVersions,
   resetDataset,
   resetDatasetVersions,
   setTabIndex,
@@ -57,15 +56,12 @@ interface StateProps {
   lineageDataset: LineageDataset
   dataset: Dataset
   isDatasetLoading: boolean
-  initVersions: DatasetVersion[]
-  initVersionsLoading: boolean
   datasets: IState['datasets']
   display: IState['display']
   tabIndex: IState['lineage']['tabIndex']
 }
 
 interface DispatchProps {
-  fetchInitialDatasetVersions: typeof fetchInitialDatasetVersions
   fetchDataset: typeof fetchDataset
   resetDatasetVersions: typeof resetDatasetVersions
   resetDataset: typeof resetDataset
@@ -92,11 +88,8 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
     fetchDataset,
     resetDataset,
     resetDatasetVersions,
-    fetchInitialDatasetVersions,
     deleteDataset,
     dialogToggle,
-    initVersions,
-    initVersionsLoading,
     lineageDataset,
     tabIndex,
     setTabIndex,
@@ -118,7 +111,6 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
 
   // might need to map first version to its own state
   useEffect(() => {
-    fetchInitialDatasetVersions(lineageDataset.namespace, lineageDataset.name)
     fetchDataset(lineageDataset.namespace, lineageDataset.name)
   }, [lineageDataset.name])
 
@@ -133,7 +125,7 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
     setTabIndex(newValue)
   }
 
-  if (!dataset || isDatasetLoading || (initVersionsLoading && initVersions.length === 0)) {
+  if (!dataset || isDatasetLoading) {
     return (
       <Box display={'flex'} justifyContent={'center'} mt={2}>
         <CircularProgress color='primary' />
@@ -141,11 +133,6 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
     )
   }
 
-  if (initVersions.length === 0) {
-    return null
-  }
-
-  const firstVersion = initVersions[0]
   const { name, tags, description } = dataset
   const facetsStatus = datasetFacetsStatus(dataset.facets)
   const assertions = datasetFacetsQualityAssertions(dataset.facets)
@@ -328,7 +315,7 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
                   checked={showTags}
                   onChange={() => setShowTags(!showTags)}
                   inputProps={{ 'aria-label': 'toggle show tags' }}
-                  disabled={initVersionsLoading}
+                  disabled={isDatasetLoading}
                 />
               }
               label={i18next.t('datasets.show_field_tags')}
@@ -341,7 +328,6 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
           dataset={dataset}
           datasetFields={dataset.fields}
           facets={dataset.facets}
-          run={firstVersion.createdByRun}
           showTags={showTags}
           isCurrentVersion
         />
@@ -356,15 +342,12 @@ const mapStateToProps = (state: IState) => ({
   dataset: state.dataset.result,
   isDatasetLoading: state.dataset.isLoading,
   display: state.display,
-  initVersions: state.datasetVersions.initDsVersion.versions,
-  initVersionsLoading: state.datasetVersions.isInitDsVerLoading,
   tabIndex: state.lineage.tabIndex,
 })
 
 const mapDispatchToProps = (dispatch: Redux.Dispatch) =>
   bindActionCreators(
     {
-      fetchInitialDatasetVersions: fetchInitialDatasetVersions,
       fetchDataset: fetchDataset,
       resetDatasetVersions: resetDatasetVersions,
       resetDataset: resetDataset,

--- a/web/src/components/datasets/DatasetDetailPage.tsx
+++ b/web/src/components/datasets/DatasetDetailPage.tsx
@@ -56,6 +56,7 @@ import StorageIcon from '@mui/icons-material/Storage'
 interface StateProps {
   lineageDataset: LineageDataset
   dataset: Dataset
+  isDatasetLoading: boolean
   initVersions: DatasetVersion[]
   initVersionsLoading: boolean
   datasets: IState['datasets']
@@ -86,6 +87,7 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
   const {
     datasets,
     dataset,
+    isDatasetLoading,
     display,
     fetchDataset,
     resetDataset,
@@ -118,7 +120,7 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
   useEffect(() => {
     fetchInitialDatasetVersions(lineageDataset.namespace, lineageDataset.name)
     fetchDataset(lineageDataset.namespace, lineageDataset.name)
-  }, [lineageDataset.name, showTags])
+  }, [lineageDataset.name])
 
   // if the dataset is deleted then redirect to datasets end point
   useEffect(() => {
@@ -131,7 +133,7 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
     setTabIndex(newValue)
   }
 
-  if (initVersionsLoading && initVersions.length === 0) {
+  if (!dataset || isDatasetLoading || (initVersionsLoading && initVersions.length === 0)) {
     return (
       <Box display={'flex'} justifyContent={'center'} mt={2}>
         <CircularProgress color='primary' />
@@ -144,10 +146,9 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
   }
 
   const firstVersion = initVersions[0]
-  const { name, tags, description } = firstVersion
-  const facetsStatus = datasetFacetsStatus(firstVersion.facets)
-
-  const assertions = datasetFacetsQualityAssertions(firstVersion.facets)
+  const { name, tags, description } = dataset
+  const facetsStatus = datasetFacetsStatus(dataset.facets)
+  const assertions = datasetFacetsQualityAssertions(dataset.facets)
 
   return (
     <Box px={2}>
@@ -229,21 +230,21 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
           <MqInfo
             icon={<CalendarIcon color={'disabled'} />}
             label={'Updated at'.toUpperCase()}
-            value={formatUpdatedAt(firstVersion.createdAt)}
+            value={formatUpdatedAt(dataset.createdAt)}
           />
         </Grid>
         <Grid item xs={6}>
           <MqInfo
             icon={<StorageIcon color={'disabled'} />}
             label={'Dataset Type'.toUpperCase()}
-            value={<MqText font={'mono'}>{firstVersion.type}</MqText>}
+            value={<MqText font={'mono'}>{dataset.type}</MqText>}
           />
         </Grid>
         <Grid item xs={6}>
           <MqInfo
             icon={<ListIcon color={'disabled'} />}
             label={'Fields'.toUpperCase()}
-            value={`${firstVersion.fields.length} columns`}
+            value={`${dataset.fields.length} columns`}
           />
         </Grid>
         <Grid item xs={6}>
@@ -338,8 +339,8 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
       {tabIndex === 0 && (
         <DatasetInfo
           dataset={dataset}
-          datasetFields={firstVersion.fields}
-          facets={firstVersion.facets}
+          datasetFields={dataset.fields}
+          facets={dataset.facets}
           run={firstVersion.createdByRun}
           showTags={showTags}
           isCurrentVersion
@@ -353,6 +354,7 @@ const DatasetDetailPage: FunctionComponent<IProps> = (props) => {
 const mapStateToProps = (state: IState) => ({
   datasets: state.datasets,
   dataset: state.dataset.result,
+  isDatasetLoading: state.dataset.isLoading,
   display: state.display,
   initVersions: state.datasetVersions.initDsVersion.versions,
   initVersionsLoading: state.datasetVersions.isInitDsVerLoading,

--- a/web/src/components/datasets/DatasetInfo.tsx
+++ b/web/src/components/datasets/DatasetInfo.tsx
@@ -1,33 +1,19 @@
 // Copyright 2018-2024 contributors to the Marquez project
 // SPDX-License-Identifier: Apache-2.0
-import * as Redux from 'redux'
 import { Box, Chip, Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material'
-import { Dataset, Field, Run } from '../../types/api'
-import { IState } from '../../store/reducers'
+import { Dataset, Field } from '../../types/api'
 import { Link } from 'react-router-dom'
-import { connect, useSelector } from 'react-redux'
 import { encodeQueryString } from '../../routes/column-level/ColumnLineageColumnNode'
-import { fetchJobFacets, resetFacets } from '../../store/actionCreators'
 import DatasetTags from './DatasetTags'
 import IconButton from '@mui/material/IconButton'
 import MQTooltip from '../core/tooltip/MQTooltip'
 import MqEmpty from '../core/empty/MqEmpty'
 import MqJsonView from '../core/json-view/MqJsonView'
 import MqText from '../core/text/MqText'
-import React, { FunctionComponent, useEffect } from 'react'
+import React, { FunctionComponent } from 'react'
 import SplitscreenIcon from '@mui/icons-material/Splitscreen'
 
-export interface DispatchProps {
-  fetchJobFacets: typeof fetchJobFacets
-  resetFacets: typeof resetFacets
-}
-
-interface JobFacets {
-  [key: string]: object
-}
-
 export interface JobFacetsProps {
-  jobFacets: JobFacets
   isCurrentVersion?: boolean
   dataset: Dataset
 }
@@ -35,31 +21,12 @@ export interface JobFacetsProps {
 type DatasetInfoProps = {
   datasetFields: Field[]
   facets?: object
-  run?: Run
   showTags?: boolean
-} & JobFacetsProps &
-  DispatchProps
+} & JobFacetsProps
 
 const DatasetInfo: FunctionComponent<DatasetInfoProps> = (props) => {
-  const { datasetFields, facets, run, dataset, fetchJobFacets, resetFacets, showTags } = props
+  const { datasetFields, facets, dataset, showTags } = props
   const i18next = require('i18next')
-  const dsNamespace = useSelector(
-    (state: IState) => state.datasetVersions.initDsVersion.versions[0].namespace
-  )
-  const dsName = useSelector(
-    (state: IState) => state.datasetVersions.initDsVersion.versions[0].name
-  )
-
-  useEffect(() => {
-    run && fetchJobFacets(run.id)
-  }, [run])
-
-  useEffect(
-    () => () => {
-      resetFacets()
-    },
-    []
-  )
 
   return (
     <Box>
@@ -159,8 +126,8 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = (props) => {
                       {showTags && (
                         <TableCell align='left'>
                           <DatasetTags
-                            namespace={dsNamespace}
-                            datasetName={dsName}
+                            namespace={dataset.namespace}
+                            datasetName={dataset.name}
                             datasetTags={field.tags}
                             datasetField={field.name}
                           />
@@ -186,17 +153,4 @@ const DatasetInfo: FunctionComponent<DatasetInfoProps> = (props) => {
   )
 }
 
-const mapStateToProps = (state: IState) => ({
-  jobFacets: state.facets.result,
-})
-
-const mapDispatchToProps = (dispatch: Redux.Dispatch) =>
-  Redux.bindActionCreators(
-    {
-      fetchJobFacets: fetchJobFacets,
-      resetFacets: resetFacets,
-    },
-    dispatch
-  )
-
-export default connect(mapStateToProps, mapDispatchToProps)(DatasetInfo)
+export default DatasetInfo

--- a/web/src/components/datasets/DatasetVersions.tsx
+++ b/web/src/components/datasets/DatasetVersions.tsx
@@ -96,7 +96,6 @@ const DatasetVersions: FunctionComponent<DatasetVersionsProps & DispatchProps> =
           dataset={dataset}
           datasetFields={infoView.fields}
           facets={infoView.facets}
-          run={infoView.createdByRun}
         />
       </>
     )


### PR DESCRIPTION
### Problem

We previously called both job facets and dataset versions with a limit of 1 to render the dataset info panel. This simplifies our logic to use the dataset by name and namespace for panel information, and rely on the dataset version endpoint for version listing.

One-line summary: Simplify dataset panel and remove extra calls.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
