### PR TITLE
fix: Correct SQL query pagination for DatasetVersion findAll method

### DIFF
--- a/api/src/main/java/marquez/db/DatasetVersionDao.java
+++ b/api/src/main/java/marquez/db/DatasetVersionDao.java
@@ -277,7 +277,6 @@ public interface DatasetVersionDao extends BaseDao {
       	) f ON f.dataset_version_uuid = dv.uuid
       	WHERE dv.namespace_name = :namespaceName
             AND dv.dataset_name = :datasetName
-      	LIMIT :limit OFFSET :offset
         ),
         dataset_symlinks_names as (
           SELECT DISTINCT dataset_uuid, name
@@ -295,6 +294,7 @@ public interface DatasetVersionDao extends BaseDao {
             created_at, version, dataset_schema_version_uuid, fields, createdByRunUuid, schema_location,
             tags, dataset_version_uuid
         ORDER BY created_at DESC
+        LIMIT :limit OFFSET :offset
   """)
   List<DatasetVersion> findAll(String namespaceName, String datasetName, int limit, int offset);
 


### PR DESCRIPTION
### Problem
https://github.com/MarquezProject/marquez/issues/2944

Closes: #2944 

### Solution
Moved the misplaced LIMIT and OFFSET statements.

### Checklist

- [✅] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [✅ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
