### PR TITLE
Ignore `**/stats/**`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,5 +23,5 @@
       "addLabels": ["dependencies", "renovate"]
     }
   ],
-  "ignorePaths": ["**/chart/**", "**/dev/**"]
+  "ignorePaths": ["**/chart/**", "**/dev/**", "**/stats/**"]
 }


### PR DESCRIPTION
Let's filter out renovate deps management for our OSS stats script.