### PR TITLE
feature: Better handling of missing environment variables in setupProxy.js file

### DIFF
--- a/web/setupProxy.js
+++ b/web/setupProxy.js
@@ -3,13 +3,23 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 const express = require('express')
 const router = express.Router()
 
+const environmentVariable = (variableName) => {
+  const value = process.env[variableName]
+  if (!value) {
+      console.error(`Error: ${variableName} environment variable is not defined.`)
+      console.error(`Please set ${variableName} and restart the application.`)
+      process.exit(1)
+  }
+  return value
+}
+
 const apiOptions = {
-  target: `http://${process.env.MARQUEZ_HOST}:${process.env.MARQUEZ_PORT}/`
+  target: `http://${(environmentVariable("MARQUEZ_HOST"))}:${environmentVariable("MARQUEZ_PORT")}/`
 }
 const app = express()
 const path = __dirname + '/dist'
 
-const port = process.env.WEB_PORT
+const port = environmentVariable("WEB_PORT")
 
 app.use('/', express.static(path))
 app.use('/datasets', express.static(path))


### PR DESCRIPTION

### Problem

At some point (August 2024) setupProxy.js started using `WEB_PORT`. The related docker compose configuration files not always have it updated. Without this variable set, the containers start but listen on `undefined` port. The users can't use the stack and are confused why. Here's an example of a fix of this king of problem https://github.com/OpenLineage/OpenLineage/pull/3192

### Solution

When some important environment variable is missing the application should stop and the user should stay informed about that they should do next.

One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
