### PR TITLE
Set `POSTGRES_HOST=db` for `marquez-api` container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - MARQUEZ_PORT=${API_PORT}
       - MARQUEZ_ADMIN_PORT=${API_ADMIN_PORT}
+      - POSTGRES_HOST=db
       - SEARCH_ENABLED=${SEARCH_ENABLED}
     ports:
       - "${API_PORT}:${API_PORT}"


### PR DESCRIPTION
This PR set `POSTGRES_HOST=db` for `marquez-api` container to fix CI job `migrate-db`:

<img width="739" alt="Screenshot 2024-10-30 at 2 45 13 PM" src="https://github.com/user-attachments/assets/c21058dd-2523-4d2f-89f8-8d85970d5860">
