### PR TITLE
Remove search from gitpod cmd

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,6 @@
 tasks:
   - command: |
-      DOCKER_BUILDKIT=1 ./docker/up.sh --seed
+      DOCKER_BUILDKIT=1 ./docker/up.sh --seed --no-search
 ports:
   - port: 3000
     visibility: public


### PR DESCRIPTION
This PR removes search from `gitpod` cmd until search is made generally available.