### PR TITLE
Set WEB_PORT in Helm chart

### DIFF
--- a/chart/templates/web/deployment.yaml
+++ b/chart/templates/web/deployment.yaml
@@ -45,6 +45,8 @@ spec:
               value: {{ include "common.names.fullname" . }}
             - name: MARQUEZ_PORT
               value: {{ .Values.service.port | quote }}
+            - name: WEB_PORT
+              value: {{ .Values.web.port | quote }}
           {{- if .Values.web.resources }}
           resources: {{- toYaml .Values.web.resources | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
### Problem

Closes: #2962 

### Solution

Set the `WEB_PORT` environment variable for web deployment to the value specified in `values.yaml`. 

### Checklist

- [x]] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [x] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
