### PR TITLE
Usage for `--db-port`

### DIFF
--- a/docker/up.sh
+++ b/docker/up.sh
@@ -36,12 +36,15 @@ usage() {
   echo "  # Set HTTP API server port"
   echo "  ./up.sh --api-port 9000"
   echo
+  echo "  # Set database port"
+  echo "  ./up.sh --db-port 2345"
+  echo
   title "ARGUMENTS:"
   echo "  -a, --api-port int          api port (default: 5000)"
   echo "  -m, --api-admin-port int    api admin port (default: 5001)"
   echo "  -w, --web-port int          web port (default: 3000)"
   echo "  -d, --db-port int           database port (default: 5432)"
-  echo "  -e --search-port int        search port (default: 9200)"
+  echo "  -e, --search-port int       search port (default: 9200)"
   echo "  -t, --tag string            docker image tag (default: ${VERSION})"
   echo "  --args string               docker arguments"
   echo


### PR DESCRIPTION
```
 % ./docker/up.sh --sh
usage: ./up.sh [FLAGS] [ARG...]
A script used to run Marquez via Docker

EXAMPLES:
...

  # Set database port
  ./up.sh --db-port 2345

ARGUMENTS:
  -a, --api-port int          api port (default: 5000)
  -m, --api-admin-port int    api admin port (default: 5001)
  -w, --web-port int          web port (default: 3000)
  -d, --db-port int           database port (default: 5432)
...
```