### PR TITLE
Fix null pointer on Dataset facets

### DIFF
--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -815,6 +815,9 @@ public interface OpenLineageDao extends BaseDao {
   }
 
   default String getUrlOrNull(String uri) {
+    if (uri == null) {
+      return "";
+    }
     try {
       return new URI(uri).toASCIIString();
     } catch (URISyntaxException e) {

--- a/api/src/test/java/marquez/db/OpenLineageDaoTest.java
+++ b/api/src/test/java/marquez/db/OpenLineageDaoTest.java
@@ -311,6 +311,11 @@ class OpenLineageDaoTest {
   }
 
   @Test
+  void testGetUrlOrNullReturnsEmptyString() {
+    assertEquals("", dao.getUrlOrNull(null));
+  }
+
+  @Test
   /**
    * When trying to insert new column level lineage data, do not create additional row if triad
    * (dataset_version_uuid, output_column_name and input_field) is the same. Upsert instead.


### PR DESCRIPTION
### Problem

Currently a POST such as this 

```
{
  "eventType": "START",
  "eventTime": "2022-03-02T18:09:08.621531103+01:00",
  "run": {
    "runId": "28b5c373-1eef-4845-82a6-98bba8f7541c",
    "facets": {}
  },
  "job": {
    "namespace": "my-namespace",
    "name": "a-job",
    "facets": {}
  },
  "inputs": [
    {
      "namespace": "imdb",
      "name": "movies",
      "facets": {
        "dataSource": {
          "_producer": "",
          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/0.5.2/spec/facets/DatasourceDatasetFacet.json",
          "name": "movies.csv"
        }
      },
      "inputFacets": {}
    }
  ],
  "outputs": [],
  "producer": "my-producer",
  "schemaUrl": "https://openlineage.io/spec/1-0-2/OpenLineage.json"
}
```


will result in a null pointer exception as null is not a valid value to pass to URI.

Closes: #1890 

### Solution

If the uri is null return an empty string

One-line summary:

Fix null pointer exception for Dataset Source Facets

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [x] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [x] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
