### PR TITLE
Docs: replace bitly links

### DIFF
--- a/CODE_QUALITY_AND_SECURITY.md
+++ b/CODE_QUALITY_AND_SECURITY.md
@@ -26,7 +26,7 @@ The specific security and analysis methodologies that we employ include but are 
 
 For more information about our approach to quality and security, feel free to reach out to the Marquez development team:
 
-- Slack: [Marquezproject.slack.com](https://bit.ly/Marquez_Slack_invite)
+- Slack: [Marquezproject.slack.com](https://join.slack.com/t/marquezproject/shared_invite/zt-2iylxasbq-GG_zXNcJdNrhC9uUMr3B7A)
 - Twitter: [@MarquezProject](https://twitter.com/MarquezProject)
 
 ----

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,14 +3,14 @@
 We're excited you're interested in contributing to Marquez! We'd love your help, and there are plenty of ways to contribute:
 
 * Give the repo a star
-* Join our [slack](https://bit.ly/Marquez_Slack_invite) channel and leave us feedback or help with answering questions from the community
+* Join our [slack](https://join.slack.com/t/marquezproject/shared_invite/zt-2iylxasbq-GG_zXNcJdNrhC9uUMr3B7A) channel and leave us feedback or help with answering questions from the community
 * Fix or [report](https://github.com/MarquezProject/marquez/issues/new) a bug
 * Fix or improve documentation
 * For newcomers, pick up a ["good first issue"](https://github.com/MarquezProject/marquez/labels/good%20first%20issue), then send a pull request our way (see the [resources](#resources) section below for helpful links to get started)
 
 We feel that a welcoming community is important and we ask that you follow the [Contributor Covenant Code of Conduct](https://github.com/MarquezProject/marquez/blob/main/CODE_OF_CONDUCT.md) in all interactions with the community.
 
-If you’re interested in using or learning more about Marquez, reach out to us on our [slack](https://bit.ly/Marquez_Slack_invite) channel and follow [@MarquezProject](https://twitter.com/MarquezProject) for updates. We also encourage new comers to [join](https://lists.lfaidata.foundation/g/marquez-technical-discuss/ics/invite.ics?repeatid=32038) our monthly community meeting!
+If you’re interested in using or learning more about Marquez, reach out to us on our [slack](https://join.slack.com/t/marquezproject/shared_invite/zt-2iylxasbq-GG_zXNcJdNrhC9uUMr3B7A) channel and follow [@MarquezProject](https://twitter.com/MarquezProject) for updates. We also encourage new comers to [join](https://lists.lfaidata.foundation/g/marquez-technical-discuss/ics/invite.ics?repeatid=32038) our monthly community meeting!
 
 # Getting Your Changes Approved
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -100,7 +100,7 @@ Or a meeting may be at an organization's offices that are required to maintain a
 
 ## Marquez on Slack
 
-Marquez uses [a Slack community](https://bit.ly/Marquez_Slack_invite) to provide an ongoing dialogue between members.
+Marquez uses [a Slack community](https://join.slack.com/t/marquezproject/shared_invite/zt-2iylxasbq-GG_zXNcJdNrhC9uUMr3B7A) to provide an ongoing dialogue between members.
 This creates a recorded discussion of design decisions and discussions that complement the project meetings.
 
 Follow the link above and register with the Slack service using your email address.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Marquez is an open source **metadata service** for the **collection**, **aggrega
 [![CircleCI](https://circleci.com/gh/MarquezProject/marquez/tree/main.svg?style=shield)](https://circleci.com/gh/MarquezProject/marquez/tree/main)
 [![codecov](https://codecov.io/gh/MarquezProject/marquez/branch/main/graph/badge.svg)](https://codecov.io/gh/MarquezProject/marquez/branch/main)
 [![status](https://img.shields.io/badge/status-active-brightgreen.svg)](#status)
-[![Slack](https://img.shields.io/badge/slack-chat-blue.svg)](https://bit.ly/Marquez_Slack_invite)
+[![Slack](https://img.shields.io/badge/slack-chat-blue.svg)](https://join.slack.com/t/marquezproject/shared_invite/zt-2iylxasbq-GG_zXNcJdNrhC9uUMr3B7A)
 [![license](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](https://raw.githubusercontent.com/MarquezProject/marquez/main/LICENSE)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 [![maven](https://img.shields.io/maven-central/v/io.github.marquezproject/marquez-api.svg)](https://search.maven.org/search?q=g:io.github.marquezproject)
@@ -179,7 +179,7 @@ Marquez listens on port `8080` for all API calls and port `8081` for the admin i
 
 * Website: https://marquezproject.ai
 * Source: https://github.com/MarquezProject/marquez
-* Chat: [MarquezProject Slack](https://bit.ly/Marquez_Slack_invite)
+* Chat: [MarquezProject Slack](https://join.slack.com/t/marquezproject/shared_invite/zt-2iylxasbq-GG_zXNcJdNrhC9uUMr3B7A)
 * X: [@MarquezProject](https://twitter.com/MarquezProject)
 
 ## Contributing

--- a/docs/v2/docs/quickstart/index.mdx
+++ b/docs/v2/docs/quickstart/index.mdx
@@ -150,4 +150,4 @@ In this simple example, we showed you how to write sample lineage metadata to a 
 
 ## Feedback {#feedback}
 
-What did you think of this guide? You can reach out to us on [slack](https://bit.ly/Marquez_Slack_invite) and leave us feedback, or [open a pull request](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#submitting-a-pull-request) with your suggestions!
+What did you think of this guide? You can reach out to us on [slack](https://join.slack.com/t/marquezproject/shared_invite/zt-2iylxasbq-GG_zXNcJdNrhC9uUMr3B7A) and leave us feedback, or [open a pull request](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#submitting-a-pull-request) with your suggestions!

--- a/docs/v2/docusaurus.config.js
+++ b/docs/v2/docusaurus.config.js
@@ -139,7 +139,7 @@ const config = {
                         items: [
                             {
                                 label: 'Slack',
-                                href: 'https://bit.ly/Marquez_Slack_invite',
+                                href: 'https://join.slack.com/t/marquezproject/shared_invite/zt-2iylxasbq-GG_zXNcJdNrhC9uUMr3B7A',
                             },
                             {
                                 label: 'YouTube',

--- a/docs/v2/src/pages/about/index.mdx
+++ b/docs/v2/src/pages/about/index.mdx
@@ -57,5 +57,5 @@ We're excited you're interested in contributing to Marquez! We'd love your help,
 
 We feel that a welcoming community is important and we ask that you follow the [Contributor Covenant Code of Conduct](https://github.com/MarquezProject/marquez/blob/main/CODE_OF_CONDUCT.md) in all interactions with the community.
 
-If you're interested in using or learning more about Marquez, reach out to us on our [slack](https://bit.ly/Marquez_Slack_invite) channel and follow [@MarquezProject](https://twitter.com/MarquezProject) for updates. We also encourage new comers to [join](https://lists.lfaidata.foundation/g/marquez-technical-discuss/ics/invite.ics?repeatid=32038) our monthly community meeting!
+If you're interested in using or learning more about Marquez, reach out to us on our [slack](https://join.slack.com/t/marquezproject/shared_invite/zt-2iylxasbq-GG_zXNcJdNrhC9uUMr3B7A) channel and follow [@MarquezProject](https://twitter.com/MarquezProject) for updates. We also encourage new comers to [join](https://lists.lfaidata.foundation/g/marquez-technical-discuss/ics/invite.ics?repeatid=32038) our monthly community meeting!
 

--- a/docs/v2/src/pages/index.tsx
+++ b/docs/v2/src/pages/index.tsx
@@ -34,7 +34,7 @@ function HomepageHeader() {
                     </Link>
                     <Link
                         className="button button--secondary button--md margin-left--md"
-                        href="https://bit.ly/Marquez_Slack_invite">
+                        href="https://join.slack.com/t/marquezproject/shared_invite/zt-2iylxasbq-GG_zXNcJdNrhC9uUMr3B7A">
                         <img 
                             className={styles.btn_logos} 
                             src="img/slack.svg" 

--- a/docs/v2/src/pages/resources/index.mdx
+++ b/docs/v2/src/pages/resources/index.mdx
@@ -21,4 +21,4 @@ template: basepage
 
 ---
 
-If you would like your blog post, video, or resource to be included on this list, please reach out to us on [Marquez Slack](https://bit.ly/MarquezSlack)
+If you would like your blog post, video, or resource to be included on this list, please reach out to us on [Marquez Slack](https://join.slack.com/t/marquezproject/shared_invite/zt-2iylxasbq-GG_zXNcJdNrhC9uUMr3B7A)

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -20,7 +20,7 @@ Once your proposal has been _`accepted`_, and has been associated with a milesto
 
 ## Questions?
 
-If you need help with the proposal process, please reach out to us on our [slack](https://bit.ly/Marquez_Slack_invite) channel.
+If you need help with the proposal process, please reach out to us on our [slack](https://join.slack.com/t/marquezproject/shared_invite/zt-2iylxasbq-GG_zXNcJdNrhC9uUMr3B7A) channel.
 
 ----
 SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
### Problem

The Slack links use bitly, which we don't need as permanent links are available. The bitly subscription is expiring soon.

### Solution

This replaces the bitly invite links with permanent ones.

> **Note:** All database schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

One-line summary: replace bitly links with permanent invites

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
