### PR TITLE
encodeURIComponent namespace and name in GET (column)lineage requests

### DIFF
--- a/web/src/store/requests/columnlineage.ts
+++ b/web/src/store/requests/columnlineage.ts
@@ -15,8 +15,9 @@ export const getColumnLineage = async (
   name: string,
   depth: number
 ) => {
-  const nodeId = generateNodeId(nodeType, namespace, name)
-  // Node ID cannot be URL encoded
+  const encodedNamespace = encodeURIComponent(namespace)
+  const encodedName = encodeURIComponent(name)
+  const nodeId = generateNodeId(nodeType, encodedNamespace, encodedName)
   const url = `${API_URL}/column-lineage?nodeId=${nodeId}&depth=${depth}&withDownstream=true`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchColumnLineage')
 }

--- a/web/src/store/requests/lineage.ts
+++ b/web/src/store/requests/lineage.ts
@@ -12,7 +12,9 @@ export const getLineage = async (
   name: string,
   depth: number
 ) => {
-  const nodeId = generateNodeId(nodeType, encodeURIComponent(namespace), encodeURIComponent(name))
+  const encodedNamespace = encodeURIComponent(namespace)
+  const encodedName = encodeURIComponent(name)
+  const nodeId = generateNodeId(nodeType, encodedNamespace, encodedName)
   const url = `${API_URL}/lineage?nodeId=${nodeId}&depth=${depth}`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchLineage')
 }

--- a/web/src/store/requests/lineage.ts
+++ b/web/src/store/requests/lineage.ts
@@ -12,8 +12,7 @@ export const getLineage = async (
   name: string,
   depth: number
 ) => {
-  const nodeId = generateNodeId(nodeType, namespace, name)
-  // Node ID cannot be URL encoded
+  const nodeId = generateNodeId(nodeType, encodeURIComponent(namespace), encodeURIComponent(name))
   const url = `${API_URL}/lineage?nodeId=${nodeId}&depth=${depth}`
   return genericFetchWrapper(url, { method: 'GET' }, 'fetchLineage')
 }


### PR DESCRIPTION
### Problem
When a jobname contains special characters (such as `+`) the (column)lineage GET requests breaks because the URL used for the request isn't URL encoded. This leads to the lineage page not loading properly when clicking a job in the job pages that contains any of such special characters that break the request URL.

### Solution
Use the `encodeURIComponent` function on both the `namespace` and `name` arguments so that special characters like `+` get encoded to `%2B`. This approach is also used in the datasets and jobs requests.

### Checklist

- [X] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
