### PR TITLE
Fix tutorial preview card

### DIFF
--- a/docs/v2/docs/tutorials/_category_.json
+++ b/docs/v2/docs/tutorials/_category_.json
@@ -3,6 +3,6 @@
   "position": 3,
   "link": {
     "type": "generated-index",
-    "description": "Learn how to use Marquez"
+    "description": "Learn how to integrate Marquez into your data ecosystem."
   }
 }

--- a/docs/v2/docs/tutorials/airflow_tutorial/index.mdx
+++ b/docs/v2/docs/tutorials/airflow_tutorial/index.mdx
@@ -2,7 +2,7 @@
 title: Apache Airflow® Tutorial
 template: basepage
 sidebar_position: 2
-description: Getting started with Marquez and Airflow
+description: Get started with Marquez and Airflow.
 ---
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';

--- a/docs/v2/docs/tutorials/airflow_tutorial/index.mdx
+++ b/docs/v2/docs/tutorials/airflow_tutorial/index.mdx
@@ -2,6 +2,7 @@
 title: Apache Airflow® Tutorial
 template: basepage
 sidebar_position: 2
+description: Getting started with Marquez and Airflow
 ---
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';

--- a/docs/v2/docs/tutorials/airflow_tutorial/index.mdx
+++ b/docs/v2/docs/tutorials/airflow_tutorial/index.mdx
@@ -42,7 +42,7 @@ Before you begin, make sure you have installed:
 
 ## Get and start Marquez {#get-marquez}
 
-1. To checkout the Marquez source code, run:
+1. To check out the Marquez source code, run:
 
 	<Tabs groupId="os">
 	<TabItem value="macos" label="MacOS/Linux">
@@ -223,7 +223,7 @@ Before you begin, make sure you have installed:
 
 	```
 
-7. Add another DAG that updates (and then drops) the Postgres table:
+7. Add another DAG that updates and then drops the Postgres table:
 
 	```py
 	from __future__ import annotations


### PR DESCRIPTION
### Problem

The preview card for the new Airflow tutorial is missing a description.

### Solution

This adds a description plus another one on the auto-generated tutorials page.

One-line summary: fix tutorial preview card in docs

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
