### PR TITLE
Add missing proxy for jobs route

### DIFF
--- a/web/setupProxy.js
+++ b/web/setupProxy.js
@@ -22,6 +22,7 @@ const path = __dirname + '/dist'
 const port = environmentVariable("WEB_PORT")
 
 app.use('/', express.static(path))
+app.use('/jobs', express.static(path))
 app.use('/datasets', express.static(path))
 app.use('/events', express.static(path))
 app.use('/lineage/:type/:namespace/:name', express.static(path))


### PR DESCRIPTION
### Problem

Reported in https://github.com/MarquezProject/marquez/issues/2988

One-line summary: Adding the `/jobs` route in the proxy to allow navigation.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
