### PR TITLE
Add db retention policy to helm chart

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -45,28 +45,32 @@ helm delete marquez
 
 ### [Marquez](https://github.com/MarquezProject/marquez) **parameters**
 
-| Parameter                    | Description                            | Default                  |
-|------------------------------|----------------------------------------|--------------------------|
-| `marquez.serviceAccount`     | K8s service account for Marquez Deploy | `default`                |
-| `marquez.replicaCount`       | Number of desired replicas             | `1`                      |
-| `marquez.image.registry`     | Marquez image registry                 | `docker.io`              |
-| `marquez.image.repository`   | Marquez image repository               | `marquezproject/marquez` |
-| `marquez.image.tag`          | Marquez image tag                      | `0.15.0`                 |
-| `marquez.image.pullPolicy`   | Image pull policy                      | `IfNotPresent`           |
-| `marquez.existingSecretName` | Name of an existing secret containing db password ('marquez-db-password' key) | `nil` |
-| `marquez.db.host`            | PostgreSQL host                        | `localhost`              |
-| `marquez.db.port`            | PostgreSQL port                        | `5432`                   |
-| `marquez.db.name`            | PostgreSQL database                    | `marquez`                |
-| `marquez.db.user`            | PostgreSQL user                        | `buendia`                |
-| `marquez.db.password`        | PostgreSQL password                    | `macondo`                |
-| `marquez.migrateOnStartup`   | Execute Flyway migration               | `true`                   |
-| `marquez.hostname`           | Marquez hostname                       | `localhost`              |
-| `marquez.port`               | API host port                          | `5000`                   |
-| `marquez.adminPort`          | Heath/Liveness host port               | `5001`                   |
-| `marquez.resources.limits`   | K8s resource limit overrides           | `nil`                    |
-| `marquez.resources.requests` | K8s resource requests overrides        | `nil`                    |
-| `marquez.podAnnotations`     | Additional pod annotations for Marquez | `{}`                     |
-| `marquez.extraContainers`    | Additional container definitions to include inside Marquez Pod | `[]` |
+| Parameter                    | Description                                                 | Default                  |
+|------------------------------|-------------------------------------------------------------|--------------------------|
+| `marquez.serviceAccount`     | K8s service account for Marquez Deploy                      | `default`                |
+| `marquez.replicaCount`       | Number of desired replicas                                  | `1`                      |
+| `marquez.image.registry`     | Marquez image registry                                      | `docker.io`              |
+| `marquez.image.repository`   | Marquez image repository                                    | `marquezproject/marquez` |
+| `marquez.image.tag`          | Marquez image tag                                           | `0.15.0`                 |
+| `marquez.image.pullPolicy`   | Image pull policy                                           | `IfNotPresent`           |
+| `marquez.existingSecretName` | Name of an existing secret containing db password ('marquez-db-password' key) | `nil`                    |
+| `marquez.db.host`            | PostgreSQL host                                             | `localhost`              |
+| `marquez.db.port`            | PostgreSQL port                                             | `5432`                   |
+| `marquez.db.name`            | PostgreSQL database                                         | `marquez`                |
+| `marquez.db.user`            | PostgreSQL user                                             | `buendia`                |
+| `marquez.db.password`        | PostgreSQL password                                         | `macondo`                |
+| `marquez.dbRetention.enabled`| Enable retention policy                                     | `false`                  |
+| `marquez.dbRetention.frequencyMins`| Apply retention policy at a frequency of every 'X' minutes  | `15`                     |
+| `marquez.dbRetention.numberOfRowsPerBatch`| Maximum number of rows deleted per batch       | `1000`                   |
+| `marquez.dbRetention.retentionDays`| Maximum retention days                                | `7`                      |
+| `marquez.migrateOnStartup`   | Execute Flyway migration                                    | `true`                   |
+| `marquez.hostname`           | Marquez hostname                                            | `localhost`              |
+| `marquez.port`               | API host port                                               | `5000`                   |
+| `marquez.adminPort`          | Heath/Liveness host port                                    | `5001`                   |
+| `marquez.resources.limits`   | K8s resource limit overrides                                | `nil`                    |
+| `marquez.resources.requests` | K8s resource requests overrides                             | `nil`                    |
+| `marquez.podAnnotations`     | Additional pod annotations for Marquez                      | `{}`                     |
+| `marquez.extraContainers`    | Additional container definitions to include inside Marquez Pod | `[]`                     |
 
 ### [Marquez Web UI](https://github.com/MarquezProject/marquez-web) **parameters**
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -45,32 +45,32 @@ helm delete marquez
 
 ### [Marquez](https://github.com/MarquezProject/marquez) **parameters**
 
-| Parameter                    | Description                                                 | Default                  |
-|------------------------------|-------------------------------------------------------------|--------------------------|
-| `marquez.serviceAccount`     | K8s service account for Marquez Deploy                      | `default`                |
-| `marquez.replicaCount`       | Number of desired replicas                                  | `1`                      |
-| `marquez.image.registry`     | Marquez image registry                                      | `docker.io`              |
-| `marquez.image.repository`   | Marquez image repository                                    | `marquezproject/marquez` |
-| `marquez.image.tag`          | Marquez image tag                                           | `0.15.0`                 |
-| `marquez.image.pullPolicy`   | Image pull policy                                           | `IfNotPresent`           |
+| Parameter                    | Description                                                                   | Default                  |
+|------------------------------|-------------------------------------------------------------------------------|--------------------------|
+| `marquez.serviceAccount`     | K8s service account for Marquez Deploy                                        | `default`                |
+| `marquez.replicaCount`       | Number of desired replicas                                                    | `1`                      |
+| `marquez.image.registry`     | Marquez image registry                                                        | `docker.io`              |
+| `marquez.image.repository`   | Marquez image repository                                                      | `marquezproject/marquez` |
+| `marquez.image.tag`          | Marquez image tag                                                             | `0.15.0`                 |
+| `marquez.image.pullPolicy`   | Image pull policy                                                             | `IfNotPresent`           |
 | `marquez.existingSecretName` | Name of an existing secret containing db password ('marquez-db-password' key) | `nil`                    |
-| `marquez.db.host`            | PostgreSQL host                                             | `localhost`              |
-| `marquez.db.port`            | PostgreSQL port                                             | `5432`                   |
-| `marquez.db.name`            | PostgreSQL database                                         | `marquez`                |
-| `marquez.db.user`            | PostgreSQL user                                             | `buendia`                |
-| `marquez.db.password`        | PostgreSQL password                                         | `macondo`                |
-| `marquez.dbRetention.enabled`| Enable retention policy                                     | `false`                  |
-| `marquez.dbRetention.frequencyMins`| Apply retention policy at a frequency of every 'X' minutes  | `15`                     |
-| `marquez.dbRetention.numberOfRowsPerBatch`| Maximum number of rows deleted per batch       | `1000`                   |
-| `marquez.dbRetention.retentionDays`| Maximum retention days                                | `7`                      |
-| `marquez.migrateOnStartup`   | Execute Flyway migration                                    | `true`                   |
-| `marquez.hostname`           | Marquez hostname                                            | `localhost`              |
-| `marquez.port`               | API host port                                               | `5000`                   |
-| `marquez.adminPort`          | Heath/Liveness host port                                    | `5001`                   |
-| `marquez.resources.limits`   | K8s resource limit overrides                                | `nil`                    |
-| `marquez.resources.requests` | K8s resource requests overrides                             | `nil`                    |
-| `marquez.podAnnotations`     | Additional pod annotations for Marquez                      | `{}`                     |
-| `marquez.extraContainers`    | Additional container definitions to include inside Marquez Pod | `[]`                     |
+| `marquez.db.host`            | PostgreSQL host                                                               | `localhost`              |
+| `marquez.db.port`            | PostgreSQL port                                                               | `5432`                   |
+| `marquez.db.name`            | PostgreSQL database                                                           | `marquez`                |
+| `marquez.db.user`            | PostgreSQL user                                                               | `buendia`                |
+| `marquez.db.password`        | PostgreSQL password                                                           | `macondo`                |
+| `marquez.dbRetention.enabled`| Enables retention policy                                                      | `false`                  |
+| `marquez.dbRetention.frequencyMins`| Apply retention policy at a frequency of every 'X' minutes              | `15`                     |
+| `marquez.dbRetention.numberOfRowsPerBatch`| Maximum number of rows deleted per batch                         | `1000`                   |
+| `marquez.dbRetention.retentionDays`| Maximum retention days                                                  | `7`                      |
+| `marquez.migrateOnStartup`   | Execute Flyway migration                                                      | `true`                   |
+| `marquez.hostname`           | Marquez hostname                                                              | `localhost`              |
+| `marquez.port`               | API host port                                                                 | `5000`                   |
+| `marquez.adminPort`          | Heath/Liveness host port                                                      | `5001`                   |
+| `marquez.resources.limits`   | K8s resource limit overrides                                                  | `nil`                    |
+| `marquez.resources.requests` | K8s resource requests overrides                                               | `nil`                    |
+| `marquez.podAnnotations`     | Additional pod annotations for Marquez                                        | `{}`                     |
+| `marquez.extraContainers`    | Additional container definitions to include inside Marquez Pod                | `[]`                     |
 
 ### [Marquez Web UI](https://github.com/MarquezProject/marquez-web) **parameters**
 

--- a/chart/templates/marquez/configmap.yaml
+++ b/chart/templates/marquez/configmap.yaml
@@ -33,6 +33,13 @@ data:
       url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
       user: ${POSTGRES_USER}
       password: ${POSTGRES_PASSWORD}
+    # Enables retention policy configuration for database (default: disabled)
+    {{- if .Values.marquez.dbRetention }}
+    dbRetention:
+      frequencyMins: {{ .Values.marquez.dbRetention.frequencyMins }}
+      numberOfRowsPerBatch: {{ .Values.marquez.dbRetention.numberOfRowsPerBatch }}
+      retentionDays: {{ .Values.marquez.dbRetention.retentionDays }}
+    {{- end }}
 
     # Enables database migration on startup (default: true)
     migrateOnStartup: ${MIGRATE_ON_STARTUP}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -34,6 +34,15 @@ marquez:
     name: marquez
     user: buendia
     password: macondo
+  dbRetention:
+    enabled: false
+    # Apply retention policy at a frequency of every 'X' minutes (default: 15)
+    frequencyMins: 15
+#    Maximum number of rows deleted per batch (default: 1000)
+    numberOfRowsPerBatch:  1000
+#    Maximum retention days (default: 7)
+    retentionDays: 7
+
   ## Indicates if Flyway database migration will execute upon deployment
   ##
   migrateOnStartup: true


### PR DESCRIPTION
### Problem

The dbRetention policy cannot be configured from the helm chart. 

Closes: #2642

One-line summary:

Add dbRetention policy to the helm chart.

### Checklist

- [ ] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
