### PR TITLE
Update HTTP API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ By default, Marquez uses the following ports:
 
 > **Note:** All of the configuration settings in `marquez.yml` can be specified either in the configuration file or in an environment variable.
 
-## Running the [HTTP API](https://github.com/MarquezProject/marquez/blob/main/src/main/java/marquez/MarquezApp.java) Server
+## Running the [HTTP API](https://github.com/MarquezProject/marquez/blob/main/api/src/main/java/marquez/MarquezApp.java) Server
 
 ```bash
 $ ./gradlew :api:runShadow


### PR DESCRIPTION
### Problem

Commit cda41ccec27e697a81d495fb2ffb2ae888fc143f moved `MarquezApp.java` and lead to broken reference in `README.md`.

### Solution
This PR adjusts sources to changes. 

One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
