### PR TITLE
Upgrade postgres to 16

### DIFF
--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   db:
-    image: postgres:14
+    image: postgres:16
     container_name: marquez-db
     ports:
       - "${POSTGRES_PORT}:${POSTGRES_PORT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     entrypoint: ["/opt/marquez/wait-for-it.sh", "db:${POSTGRES_PORT}", "--", "./entrypoint.sh"]
 
   db:
-    image: postgres:14
+    image: postgres:16
     container_name: marquez-db
     ports:
       - "${POSTGRES_PORT}:${POSTGRES_PORT}"


### PR DESCRIPTION
### Problem

We are still on Postgres 14 but can easily upgrade the required images to 16.

### Solution

Upgrade the images in the relevant docker-compose YML files to 16.

One-line summary: upgrade postgres to 16

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
