### PR TITLE
feat: add `nodeId` to Dataset, DatasetVersion, and Job API response models

### DIFF
--- a/api/src/main/java/marquez/service/models/Dataset.java
+++ b/api/src/main/java/marquez/service/models/Dataset.java
@@ -93,6 +93,11 @@ public abstract class Dataset {
     this.isDeleted = isDeleted;
   }
 
+  /** Returns the {@link NodeId} for this dataset, allowing direct queries to the Lineage API. */
+  public NodeId getNodeId() {
+    return NodeId.of(id);
+  }
+
   public Optional<Instant> getLastModifiedAt() {
     return Optional.ofNullable(lastModifiedAt);
   }

--- a/api/src/main/java/marquez/service/models/DatasetVersion.java
+++ b/api/src/main/java/marquez/service/models/DatasetVersion.java
@@ -23,6 +23,7 @@ import lombok.ToString;
 import marquez.common.models.DatasetId;
 import marquez.common.models.DatasetName;
 import marquez.common.models.DatasetType;
+import marquez.common.models.DatasetVersionId;
 import marquez.common.models.Field;
 import marquez.common.models.NamespaceName;
 import marquez.common.models.SourceName;
@@ -87,6 +88,16 @@ public abstract class DatasetVersion {
     this.currentSchemaVersion = currentSchemaVersion;
     this.createdByRun = createdByRun;
     this.facets = (facets == null) ? ImmutableMap.of() : facets;
+  }
+
+  /**
+   * Returns the {@link NodeId} for this dataset version, allowing direct queries to the Lineage
+   * API. The returned nodeId includes the version UUID (e.g., {@code
+   * dataset:namespace:name#version}).
+   */
+  public NodeId getNodeId() {
+    return NodeId.of(
+        new DatasetVersionId(id.getNamespace(), id.getName(), version.getValue()));
   }
 
   public Optional<String> getDescription() {

--- a/api/src/main/java/marquez/service/models/Job.java
+++ b/api/src/main/java/marquez/service/models/Job.java
@@ -90,6 +90,11 @@ public final class Job {
     this.tags = (tags == null) ? ImmutableSet.of() : tags;
   }
 
+  /** Returns the {@link NodeId} for this job, allowing direct queries to the Lineage API. */
+  public NodeId getNodeId() {
+    return NodeId.of(id);
+  }
+
   public Optional<URL> getLocation() {
     return Optional.ofNullable(location);
   }

--- a/api/src/test/java/marquez/service/models/NodeIdOnModelsTest.java
+++ b/api/src/test/java/marquez/service/models/NodeIdOnModelsTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.service.models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.net.URL;
+import java.time.Instant;
+import java.util.UUID;
+import marquez.common.models.DatasetId;
+import marquez.common.models.DatasetName;
+import marquez.common.models.DatasetType;
+import marquez.common.models.JobId;
+import marquez.common.models.JobName;
+import marquez.common.models.JobType;
+import marquez.common.models.NamespaceName;
+import marquez.common.models.SourceName;
+import marquez.common.models.Version;
+import org.junit.jupiter.api.Test;
+
+/** Tests that the {@code getNodeId()} method returns the correct {@link NodeId} for API models. */
+class NodeIdOnModelsTest {
+
+  private static final NamespaceName NAMESPACE = NamespaceName.of("test-namespace");
+  private static final Instant NOW = Instant.now();
+
+  @Test
+  void datasetNodeIdHasCorrectFormat() {
+    DatasetName datasetName = DatasetName.of("test-dataset");
+    DatasetId datasetId = new DatasetId(NAMESPACE, datasetName);
+
+    DbTable dataset =
+        new DbTable(
+            datasetId,
+            datasetName,
+            DatasetName.of("public.test_dataset"),
+            NOW,
+            NOW,
+            SourceName.of("test-source"),
+            ImmutableList.of(),
+            ImmutableSet.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            ImmutableMap.of(),
+            false);
+
+    NodeId nodeId = dataset.getNodeId();
+    assertThat(nodeId).isNotNull();
+    assertThat(nodeId.isDatasetType()).isTrue();
+    assertThat(nodeId.getValue()).isEqualTo("dataset:test-namespace:test-dataset");
+  }
+
+  @Test
+  void datasetVersionNodeIdIncludesVersion() {
+    DatasetName datasetName = DatasetName.of("test-dataset");
+    DatasetId datasetId = new DatasetId(NAMESPACE, datasetName);
+    UUID versionUuid = UUID.randomUUID();
+
+    DbTableVersion datasetVersion =
+        new DbTableVersion(
+            datasetId,
+            datasetName,
+            DatasetName.of("public.test_dataset"),
+            NOW,
+            new Version(versionUuid),
+            SourceName.of("test-source"),
+            ImmutableList.of(),
+            ImmutableSet.of(),
+            null,
+            null,
+            null,
+            null,
+            ImmutableMap.of());
+
+    NodeId nodeId = datasetVersion.getNodeId();
+    assertThat(nodeId).isNotNull();
+    assertThat(nodeId.hasVersion()).isTrue();
+    assertThat(nodeId.getValue())
+        .isEqualTo("dataset:test-namespace:test-dataset#" + versionUuid);
+  }
+
+  @Test
+  void jobNodeIdHasCorrectFormat() {
+    JobName jobName = JobName.of("test-job");
+    JobId jobId = new JobId(NAMESPACE, jobName);
+
+    Job job =
+        new Job(
+            jobId,
+            JobType.BATCH,
+            jobName,
+            "test-job",
+            null,
+            null,
+            NOW,
+            NOW,
+            ImmutableSet.of(),
+            ImmutableSet.of(),
+            null,
+            null,
+            null,
+            null,
+            ImmutableMap.of(),
+            null,
+            null,
+            null);
+
+    NodeId nodeId = job.getNodeId();
+    assertThat(nodeId).isNotNull();
+    assertThat(nodeId.isJobType()).isTrue();
+    assertThat(nodeId.getValue()).isEqualTo("job:test-namespace:test-job");
+  }
+}


### PR DESCRIPTION
## Summary

Adds a computed `nodeId` field to the `Dataset`, `DatasetVersion`, and `Job` API response models. This allows API consumers to directly use the `nodeId` to query the [Lineage API](https://marquezproject.github.io/marquez/openapi.html#tag/Lineage/paths/~1lineage/get) without having to manually construct it.

Closes #1461

## Changes

### `Dataset.java`
Added `getNodeId()` method that returns `NodeId.of(id)`, producing a nodeId in the format:
```
dataset:<namespace>:<name>
```

### `DatasetVersion.java`
Added `getNodeId()` method that returns a version-qualified nodeId:
```
dataset:<namespace>:<name>#<version_uuid>
```

### `Job.java`
Added `getNodeId()` method that returns `NodeId.of(id)`, producing a nodeId in the format:
```
job:<namespace>:<name>
```

## Example API Response (before vs. after)

**Before:**
```json
{
  "id": { "namespace": "my-namespace", "name": "my-dataset" },
  "type": "DB_TABLE",
  "name": "my-dataset",
  ...
}
```

**After:**
```json
{
  "id": { "namespace": "my-namespace", "name": "my-dataset" },
  "type": "DB_TABLE",
  "name": "my-dataset",
  "nodeId": "dataset:my-namespace:my-dataset",
  ...
}
```

## Design Decisions

- **Computed, not stored**: `nodeId` is derived from existing fields (`id`, `namespace`, `name`, `version`) via `getNodeId()`, so no database changes are needed.
- **Reuses `NodeId` class**: Leverages the existing `NodeId.of()` factory methods that are already used in the lineage graph construction.
- **JobVersion**: The issue also mentions `JobVersion`, but there is no dedicated `JobVersion` service model — job version data is served through the `Job` model. The `nodeId` on `Job` covers this use case.

## Tests

Added `NodeIdOnModelsTest.java` with tests verifying:
- Dataset nodeId format: `dataset:namespace:name`
- DatasetVersion nodeId includes version: `dataset:namespace:name#uuid`
- Job nodeId format: `job:namespace:name`