### PR TITLE
feat: add get_lineage() to Python client

### DIFF
--- a/clients/python/marquez_client/client.py
+++ b/clients/python/marquez_client/client.py
@@ -343,6 +343,32 @@ class MarquezClient:
         Utils.is_valid_uuid(run_id, 'run_id')
         return self._get(self._url('/jobs/runs/{0}', run_id))
 
+    def get_lineage(self, node_id, depth=None):
+        """Fetch the lineage graph for a given node.
+
+        Returns the lineage graph (upstream and downstream datasets and jobs)
+        for the specified node ID. The node ID format is:
+            - For datasets: "dataset:<namespace>:<name>"
+            - For jobs: "job:<namespace>:<name>"
+
+        Args:
+            node_id: The node identifier to fetch lineage for.
+            depth: The maximum depth of the lineage graph (default: 20).
+
+        Returns:
+            A dict representing the lineage graph with nodes and edges.
+        """
+        if not node_id:
+            raise ValueError('node_id must not be None')
+
+        return self._get(
+            self._url('/lineage'),
+            params={
+                'nodeId': node_id,
+                'depth': depth or DEFAULT_DEPTH
+            }
+        )
+
     def get_column_lineage_by_dataset(
             self,
             namespace,


### PR DESCRIPTION
## Summary

Adds the missing `get_lineage(node_id, depth)` method to the Python client, allowing users to fetch the lineage graph for any node directly from Python without resorting to raw `curl` calls.

Closes #1798 (Python client portion)

## What Changed

Added `MarquezClient.get_lineage()` that calls `GET /api/v1/lineage?nodeId=&depth=`.

The method follows the same patterns as existing client methods:
- Input validation (`node_id` must not be None)
- Uses `DEFAULT_DEPTH` (20) when depth is not specified
- Returns the parsed JSON response

## Usage

```python
from marquez_client import MarquezClient

client = MarquezClient(url='http://localhost:8080')

# Get lineage for a dataset
lineage = client.get_lineage('dataset:my_namespace:my_dataset')

# Get lineage for a job with custom depth
lineage = client.get_lineage('job:my_namespace:my_job', depth=5)
```

## Note

This PR covers the Python client. The Java client portion of #1798 will be a separate PR.

## Checklist
- [x] Follows existing client patterns
- [x] Includes docstring with node_id format examples
- [x] Input validation for required parameters
- [x] DCO sign-off included