### PR TITLE
feat: include `outputFacets` and `inputFacets` in Dataset API responses

### DIFF
--- a/api/src/main/java/marquez/db/DatasetDao.java
+++ b/api/src/main/java/marquez/db/DatasetDao.java
@@ -87,7 +87,7 @@ public interface DatasetDao extends BaseDao {
                   JSONB_AGG(df.facet ORDER BY df.lineage_event_time ASC) AS facets
               FROM dataset_facets AS df
               WHERE df.facet IS NOT NULL AND
-               (df.type ILIKE 'dataset' OR df.type ILIKE 'unknown' OR df.type ILIKE 'input') AND
+               (df.type ILIKE 'dataset' OR df.type ILIKE 'unknown' OR df.type ILIKE 'input' OR df.type ILIKE 'output') AND
                 df.dataset_uuid = (SELECT uuid FROM datasets WHERE name = :datasetName AND namespace_name = :namespaceName)
               GROUP BY df.dataset_version_uuid
           ) f ON f.dataset_version_uuid = d.current_version_uuid
@@ -132,7 +132,8 @@ public interface DatasetDao extends BaseDao {
           WHERE df.facet IS NOT NULL
              AND (df.type ILIKE 'dataset'
                   OR df.type ILIKE 'unknown'
-                  OR df.type ILIKE 'input')
+                  OR df.type ILIKE 'input'
+                  OR df.type ILIKE 'output')
              AND df.dataset_uuid IN
                (SELECT UUID
                 FROM datasets_view

--- a/api/src/main/java/marquez/db/DatasetVersionDao.java
+++ b/api/src/main/java/marquez/db/DatasetVersionDao.java
@@ -203,7 +203,7 @@ public interface DatasetVersionDao extends BaseDao {
       ), selected_dataset_version_facets AS (
           SELECT dv.uuid, dv.dataset_name, dv.namespace_name, df.run_uuid, df.lineage_event_time, df.facet
           FROM selected_dataset_versions dv
-          LEFT JOIN dataset_facets_view df ON df.dataset_version_uuid = dv.uuid  AND (df.type ILIKE 'dataset' OR df.type ILIKE 'unknown' OR df.type ILIKE 'input')
+          LEFT JOIN dataset_facets_view df ON df.dataset_version_uuid = dv.uuid  AND (df.type ILIKE 'dataset' OR df.type ILIKE 'unknown' OR df.type ILIKE 'input' OR df.type ILIKE 'output')
       )
       SELECT d.type, d.name, d.physical_name, d.namespace_name, d.source_name, d.description, dv.lifecycle_state,\s
           dv.created_at, dv.uuid AS current_version_uuid, dv.version, dv.dataset_schema_version_uuid, dv.fields, dv.run_uuid AS createdByRunUuid,
@@ -273,7 +273,7 @@ public interface DatasetVersionDao extends BaseDao {
 				facet as facets,lineage_event_time
 			FROM dataset_facets_view
 			WHERE
-				(type ILIKE 'dataset' OR type ILIKE 'unknown' OR type ILIKE 'input')
+				(type ILIKE 'dataset' OR type ILIKE 'unknown' OR type ILIKE 'input' OR type ILIKE 'output')
       	) f ON f.dataset_version_uuid = dv.uuid
       	WHERE dv.namespace_name = :namespaceName
             AND dv.dataset_name = :datasetName


### PR DESCRIPTION
## Summary

Updates the `DatasetDao` and `DatasetVersionDao` SQL queries to include facets of type `'output'` in API responses, in addition to the existing `'dataset'`, `'unknown'`, and `'input'` types.

Supersedes #3103 (recreated to fix DCO sign-off).

Closes #1746

## Problem

Marquez stores `outputFacets` and `inputFacets` correctly in the `dataset_facets` table. However, the read queries filtered with:
```sql
(df.type ILIKE 'dataset' OR df.type ILIKE 'unknown' OR df.type ILIKE 'input')
```
This excluded `'output'` type facets (e.g., `OutputStatistics`) from API responses.

## Fix

Added `OR df.type ILIKE 'output'` to the facet type filter in:
- `DatasetDao.findDatasetByName`
- `DatasetDao.findAll`
- `DatasetVersionDao.findByUuid`
- `DatasetVersionDao.findAll`

## Checklist
- [x] Minimal change (4 SQL query updates)
- [x] No schema changes
- [x] DCO sign-off included