### PR TITLE
feat: add support for External Secrets Operator in Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/MarquezProject/marquez/compare/0.50.0...HEAD)
 
+### Added
+
+* Chart: Add External Secrets Operator (ESO) integration to manage PostgreSQL passwords
+
 ## [0.50.0](https://github.com/MarquezProject/marquez/compare/0.49.0...0.50.0) - 2024-10-23
 
 ### Added

--- a/chart/README.md
+++ b/chart/README.md
@@ -122,10 +122,22 @@ helm delete marquez
 |-----------------------|------------------------------------|---------|
 | `ingress.enabled`     | Enables ingress settings           | `false` |
 | `ingress.annotations` | Annotations applied to ingress     | `nil`   |
-| `ingress.hosts`       | Hostname applied to ingress routes | `nil`   |
-| `ingress.tls`         | TLS settings for hostname          | `nil`   |
+| `ingress.hosts`       | Hostname applied to ingress routes | `nil`       |
+| `ingress.tls`         | TLS settings for hostname          | `nil`       |
+
+### [External Secrets Operator](https://external-secrets.io/) **parameters**
+
+| Parameter                                     | Description                                                             | Default             |
+|-----------------------------------------------|-------------------------------------------------------------------------|---------------------|
+| `externalSecrets.enabled`                     | Enable ExternalSecret resource creation                                 | `false`             |
+| `externalSecrets.secretStoreName`             | Name of the SecretStore or ClusterSecretStore                           | `my-secret-store`   |
+| `externalSecrets.secretStoreKind`             | Kind of the SecretStore (SecretStore or ClusterSecretStore)             | `SecretStore`       |
+| `externalSecrets.refreshInterval`             | How often the secret should be refreshed                                | `1h`                |
+| `externalSecrets.auth.password.remoteKey`     | Remote key in the external secret store for the database password       | `marquez/db/password` |
+| `externalSecrets.auth.password.remoteProperty`| Property in the external secret store (if the key is a JSON object)     | `""`                |
 
 ## Local Installation Guide
+
 
 ### Helm Managed Postgres
 

--- a/chart/templates/marquez/external-secret.yaml
+++ b/chart/templates/marquez/external-secret.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.externalSecrets.enabled -}}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "marquez.postgresql.secretName" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | default "1h" | quote }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreName }}
+    kind: {{ .Values.externalSecrets.secretStoreKind | default "SecretStore" }}
+  target:
+    name: {{ include "marquez.postgresql.secretName" . }}
+    creationPolicy: Owner
+  data:
+  - secretKey: {{ include "marquez.database.existingsecret.key" . }}
+    remoteRef:
+      key: {{ .Values.externalSecrets.auth.password.remoteKey }}
+      {{- if .Values.externalSecrets.auth.password.remoteProperty }}
+      property: {{ .Values.externalSecrets.auth.password.remoteProperty }}
+      {{- end }}
+{{- end -}}

--- a/chart/templates/marquez/secret.yaml
+++ b/chart/templates/marquez/secret.yaml
@@ -1,4 +1,4 @@
-{{- if (not .Values.marquez.existingSecretName) -}}
+{{- if and (not .Values.marquez.existingSecretName) (not .Values.externalSecrets.enabled) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -212,3 +212,23 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+
+## External Secrets Operator integration
+## ref: https://external-secrets.io/
+externalSecrets:
+  ## @param externalSecrets.enabled Enable ExternalSecret resource creation
+  enabled: false
+  ## @param externalSecrets.secretStoreName Name of the SecretStore or ClusterSecretStore
+  secretStoreName: "my-secret-store"
+  ## @param externalSecrets.secretStoreKind Kind of the SecretStore (SecretStore or ClusterSecretStore)
+  secretStoreKind: "SecretStore"
+  ## @param externalSecrets.refreshInterval How often the secret should be refreshed
+  refreshInterval: "1h"
+  ## Authentication parameters to be fetched from external secret store
+  auth:
+    ## @param externalSecrets.auth.password.remoteKey Remote key in the external secret store for the database password
+    password:
+      remoteKey: "marquez/db/password"
+      ## @param externalSecrets.auth.password.remoteProperty Property in the external secret store (if the key is a JSON object)
+      remoteProperty: ""


### PR DESCRIPTION
### Problem

Currently, the Marquez Helm chart requires the PostgreSQL password to be provided either as a plaintext value in values.yaml or through a manually created Kubernetes Secret. This makes it difficult for users
  who rely on the External Secrets Operator (ESO) to manage sensitive credentials via external providers like AWS Secrets Manager, HashiCorp Vault, or Google Secret Manager.

### Solution

I have integrated support for the External Secrets Operator (ESO) into the Helm chart. This was achieved by:
   1. Adding a new externalSecrets configuration block in values.yaml to define the connection to a SecretStore.
   2. Creating a new ExternalSecret template (templates/marquez/external-secret.yaml) that dynamically maps remote keys to the internal secret structure used by Marquez.
   3. Updating the existing templates/marquez/secret.yaml to conditionally disable local secret creation when ESO is enabled, preventing resource conflicts.
   4. Utilizing existing helper functions (marquez.postgresql.secretName and marquez.database.existingsecret.key) to ensure that the Deployment automatically picks up the password regardless of whether an
      internal or external database is used.

One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
