### PR TITLE
Fix a bug where dataset will not load if s3 prefix starts with a digit

### DIFF
--- a/api/src/main/java/marquez/service/models/NodeId.java
+++ b/api/src/main/java/marquez/service/models/NodeId.java
@@ -222,7 +222,7 @@ public final class NodeId implements Comparable<NodeId> {
       return parts;
     } else {
       // try to avoid matching colons in URIs- e.g., scheme://authority and host:port patterns
-      Pattern p = Pattern.compile("(?:" + ID_DELIM + "(?!//|\\d+))");
+      Pattern p = Pattern.compile("(?:" + ID_DELIM + "(?!//|\\d+(?:/|$)))");
       Matcher matcher = p.matcher(value);
       String[] returnParts = new String[expectedParts];
 

--- a/api/src/test/java/marquez/service/models/NodeIdTest.java
+++ b/api/src/test/java/marquez/service/models/NodeIdTest.java
@@ -71,6 +71,7 @@ class NodeIdTest {
       value = {
         "my-namespace$my-dataset",
         "gs://bucket$/path/to/data",
+        "s3://mybucket$3d801.temp/table",
         "postgresql://hostname:5432/database$my_table",
         "my-namespace$my_struct<a:bigint,b:bigint,c:string>"
       },
@@ -95,6 +96,8 @@ class NodeIdTest {
       value = {
         "my-namespace$my-dataset#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
         "gs://bucket$/path/to/data#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "s3://mybucket$3d801.temp/table#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "s3://mybucket$/3d801.temp/table#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
         "postgresql://hostname:5432/database$my_table#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
         "my-namespace$my_struct<a:bigint,b:bigint,c:string>#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
       },

--- a/clients/java/src/main/java/marquez/client/models/NodeId.java
+++ b/clients/java/src/main/java/marquez/client/models/NodeId.java
@@ -150,7 +150,7 @@ public final class NodeId implements Comparable<NodeId> {
       return parts;
     } else {
       // try to avoid matching colons in URIs- e.g., scheme://authority and host:port patterns
-      Pattern p = Pattern.compile("(?:" + ID_DELIM + "(?!//|\\d+))");
+      Pattern p = Pattern.compile("(?:" + ID_DELIM + "(?!//|\\d+(?:/|$)))");
       Matcher matcher = p.matcher(value);
       String[] returnParts = new String[expectedParts];
 

--- a/clients/java/src/test/java/marquez/client/models/NodeIdTest.java
+++ b/clients/java/src/test/java/marquez/client/models/NodeIdTest.java
@@ -21,6 +21,7 @@ public class NodeIdTest {
       value = {
         "my-namespace$my-dataset",
         "gs://bucket$/path/to/data",
+        "s3://mybucket$3d801.temp/table",
         "postgresql://hostname:5432/database$my_table",
         "my-namespace$my_struct<a:bigint,b:bigint,c:string>"
       },
@@ -38,7 +39,9 @@ public class NodeIdTest {
       value = {
         "my-namespace$my-dataset$colA",
         "gs://bucket$/path/to/data$colA",
-        "gs://bucket$/path/to/data$col_A"
+        "gs://bucket$/path/to/data$col_A",
+        "s3://mybucket$3d801.temp/table$colA",
+        "s3://mybucket$3d801.temp/table$col_A"
       },
       delimiter = '$')
   public void testDatasetField(String namespace, String dataset, String field) {
@@ -90,6 +93,8 @@ public class NodeIdTest {
       value = {
         "my-namespace$my-dataset#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
         "gs://bucket$/path/to/data#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "s3://mybucket$3d801.temp/table#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "s3://mybucket$/3d801.temp/table#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
         "postgresql://hostname:5432/database$my_table#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
         "my-namespace$my_struct<a:bigint,b:bigint,c:string>#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
       },
@@ -113,7 +118,9 @@ public class NodeIdTest {
       value = {
         "my-namespace$my-dataset$colA#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
         "gs://bucket$/path/to/data$colA#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-        "gs://bucket$/path/to/data$col_A#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        "gs://bucket$/path/to/data$col_A#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "s3://mybucket$3d801.temp/table$colA#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "s3://mybucket$/3d801.temp/table$col_A#aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
       },
       delimiter = '$')
   public void testDatasetFieldWithVersion(


### PR DESCRIPTION
### Problem
If a dataset s3 prefix path starts with a digit, it fails to load in Marquez.

Closes: #3108 

### Solution

Updated Pattern to match this case.


### Checklist

- [x] You've [signed-off](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#sign-your-work) your work
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've included a one-line summary of your change for the [`CHANGELOG.md`](https://github.com/MarquezProject/marquez/blob/main/CHANGELOG.md#unreleased) (_Depending on the change, this may not be necessary_).
- [ ] You've versioned your `.sql` database schema migration according to [Flyway's naming convention](https://flywaydb.org/documentation/concepts/migrations#naming) (_if relevant_)
- [ ] You've included a [header](https://github.com/MarquezProject/marquez/blob/main/CONTRIBUTING.md#copyright--license) in any source code files (_if relevant_)
