### PR TITLE
Allow commas in namespace names

### DIFF
--- a/api/src/main/java/marquez/common/models/NamespaceName.java
+++ b/api/src/main/java/marquez/common/models/NamespaceName.java
@@ -24,7 +24,7 @@ public final class NamespaceName {
   private static final int MIN_SIZE = 1;
   private static final int MAX_SIZE = 1024;
   private static final Pattern PATTERN =
-      Pattern.compile(String.format("^[a-zA-Z:;=/0-9_\\-\\.@+]{%d,%d}$", MIN_SIZE, MAX_SIZE));
+      Pattern.compile(String.format("^[a-zA-Z:;=/0-9_\\-\\.@+,]{%d,%d}$", MIN_SIZE, MAX_SIZE));
 
   @Getter private final String value;
 
@@ -32,8 +32,8 @@ public final class NamespaceName {
     checkArgument(
         PATTERN.matcher(value).matches(),
         "namespace '%s' must contain only letters (a-z, A-Z), numbers (0-9), "
-            + "underscores (_), at (@), plus (+), dashes (-), colons (:), equals (=), semicolons (;), slashes (/) "
-            + "or dots (.) with a maximum length of %s characters.",
+            + "underscores (_), at (@), plus (+), dashes (-), colons (:), equals (=), semicolons (;), slashes (/), "
+            + "commas (,) or dots (.) with a maximum length of %s characters.",
         value,
         MAX_SIZE);
     this.value = value;

--- a/api/src/test/java/marquez/common/models/NamespaceNameTest.java
+++ b/api/src/test/java/marquez/common/models/NamespaceNameTest.java
@@ -25,7 +25,10 @@ public class NamespaceNameTest {
         "\u003D",
         "@",
         "abfss://something@.something-else.core.windows.net",
-        "databricks+connector://asdf-123456-7890.cloud.databricks.com"
+        "databricks+connector://asdf-123456-7890.cloud.databricks.com",
+        "sqlserver://synapse-test-test001.sql.azuresynapse.net;databaseName=TESTPOOL1,SCHEMA1",
+        "my,namespace",
+        ","
       })
   void testValidNamespaceName(String name) {
     assertThat(NamespaceName.of(name).getValue()).isEqualTo(name);


### PR DESCRIPTION
Namespace values that contain a comma get rejected with `IllegalArgumentException`. Showed up in practice with SQL Server/JDBC connection-string style namespaces, which use commas to separate options — e.g. `sqlserver://host;databaseName=DB1,DB2`.

Root cause is boring: `NamespaceName`'s validation regex just never allowed `,` in the character class:

```java
Pattern.compile(String.format("^[a-zA-Z:;=/0-9_\\-\\.@+]{%d,%d}$", MIN_SIZE, MAX_SIZE));
```

Before adding it I checked whether `,` is used as a delimiter anywhere that a newly-permitted comma could break something — namespace lists in query params, `NodeId`-style token splitting, that sort of thing. `NodeId` only parses on `:` and `#`, and there's no comma-delimited namespace query param anywhere, so there's nothing for this to collide with.

```mermaid
flowchart TD
    In["Namespace value containing a comma
e.g. sqlserver://host;databaseName=DB1,DB2"]
    In --> Old["Old PATTERN: comma not in allowed char class"]
    Old --> OldOut["No match -> IllegalArgumentException"]
    In --> New["New PATTERN: comma added to allowed char class"]
    New --> NewOut["Match -> NamespaceName created"]
```

**Fix:** added `,` to `NamespaceName.PATTERN` and updated the validation error message to mention commas as an allowed character.

**Testing:** added three regression cases to `NamespaceNameTest#testValidNamespaceName` — a comma-containing name, a bare `,`, and a realistic SQL Server connection-string namespace. Confirmed all three throw before the fix and pass after:

```
./gradlew :api:test --tests "marquez.common.models.NamespaceNameTest"
```

3 failures before the fix, 15/15 passing after.

Fixes #3110.
