### PR TITLE
Fix dataset_fields duplication for NULL type causing column_lineage explosion

### DIFF
--- a/api/src/main/java/marquez/db/DatasetFieldDao.java
+++ b/api/src/main/java/marquez/db/DatasetFieldDao.java
@@ -251,6 +251,24 @@ public interface DatasetFieldDao extends BaseDao {
           """)
   List<InputFieldData> findInputFieldsDataAssociatedWithRun(UUID runUuid);
 
+  /**
+   * Upserts a {@code dataset_fields} row.
+   *
+   * <p>The {@code type} column participates in the {@code (dataset_uuid, name, type)} unique
+   * constraint used as the {@code ON CONFLICT} target below. In standard SQL, {@code NULL} is
+   * never considered equal to another {@code NULL} for uniqueness purposes, so a field with an
+   * unknown/omitted {@code type} (a legitimate, common case for OpenLineage events that don't
+   * report column types) would never match an existing row and a brand new {@code dataset_fields}
+   * row - with a new {@code uuid} - would be inserted on every single upsert. Since each distinct
+   * {@code dataset_fields} row independently accumulates its own {@code column_lineage} edges,
+   * this caused an unbounded, combinatorial explosion of duplicate rows in both {@code
+   * dataset_fields} and {@code column_lineage} for any field with a null type (see #3083).
+   *
+   * <p>To fix this without weakening the constraint, a null {@code type} is normalized to the
+   * literal sentinel value {@code 'UNKNOWN'} before insertion, so that repeated upserts of a
+   * field with no known type reliably collide with the previously-inserted row (which also stored
+   * {@code 'UNKNOWN'}) and are treated as an update instead of a fresh insert.
+   */
   @SqlQuery(
       "INSERT INTO dataset_fields ("
           + "uuid, "
@@ -262,7 +280,7 @@ public interface DatasetFieldDao extends BaseDao {
           + "description"
           + ") VALUES ("
           + ":uuid, "
-          + ":type, "
+          + "COALESCE(:type, 'UNKNOWN'), "
           + ":now, "
           + ":now, "
           + ":datasetUuid, "

--- a/api/src/test/java/marquez/MarquezAppIntegrationTest.java
+++ b/api/src/test/java/marquez/MarquezAppIntegrationTest.java
@@ -191,6 +191,11 @@ public class MarquezAppIntegrationTest extends BaseIntegrationTest {
     // (3) Create db table with invalid field type
     final Field field0 = Field.builder().name("field0").type(newFieldType()).build();
     final Field field1 = Field.builder().name("field1").type(null).build();
+    // A null/unknown field type is normalized to "UNKNOWN" on write so that repeated upserts of
+    // the same field reliably collide on the (dataset_uuid, name, type) unique constraint instead
+    // of creating a new dataset_fields row (and therefore a new column_lineage edge) every time
+    // (see #3083).
+    final Field expectedField1 = Field.builder().name("field1").type("UNKNOWN").build();
     final DatasetName datasetName = newDatasetName();
     final DbTableMeta dbTableMeta =
         DbTableMeta.builder()
@@ -200,7 +205,45 @@ public class MarquezAppIntegrationTest extends BaseIntegrationTest {
             .build();
     final Dataset dataset =
         client.createDataset(NAMESPACE_NAME, datasetName.getValue(), dbTableMeta);
-    assertThat(dataset.getFields()).containsExactly(field0, field1);
+    assertThat(dataset.getFields()).containsExactly(field0, expectedField1);
+  }
+
+  @Test
+  public void testDatasetWithUnknownFieldType_repeatedUpsertsDoNotDuplicateField() {
+    // Regression test for https://github.com/MarquezProject/marquez/issues/3083: upserting the
+    // same dataset with a field that has a null/unknown type multiple times must not create
+    // multiple dataset_fields rows for that field.
+    final NamespaceMeta namespaceMeta =
+        NamespaceMeta.builder().ownerName(OWNER_NAME).description(NAMESPACE_DESCRIPTION).build();
+    client.createNamespace(NAMESPACE_NAME, namespaceMeta);
+
+    final SourceMeta sourceMeta =
+        SourceMeta.builder()
+            .type(STREAM_SOURCE_TYPE)
+            .connectionUrl(STREAM_CONNECTION_URL)
+            .description(STREAM_SOURCE_DESCRIPTION)
+            .build();
+    client.createSource(DB_TABLE_SOURCE_NAME, sourceMeta);
+
+    final Field unknownTypeField = Field.builder().name("modified_at").type(null).build();
+    final DatasetName datasetName = newDatasetName();
+    final DbTableMeta dbTableMeta =
+        DbTableMeta.builder()
+            .physicalName(datasetName.getValue())
+            .sourceName(DB_TABLE_SOURCE_NAME)
+            .fields(ImmutableList.of(unknownTypeField))
+            .build();
+
+    // Emit the same dataset (and therefore the same null-type field) multiple times, as described
+    // in the issue's reproduction steps.
+    Dataset dataset = null;
+    for (int i = 0; i < 5; i++) {
+      dataset = client.createDataset(NAMESPACE_NAME, datasetName.getValue(), dbTableMeta);
+    }
+
+    // Only a single field should exist for 'modified_at', not five duplicates.
+    assertThat(dataset.getFields()).hasSize(1);
+    assertThat(dataset.getFields().get(0).getName()).isEqualTo("modified_at");
   }
 
   @Test

--- a/api/src/test/java/marquez/db/DatasetFieldDaoTest.java
+++ b/api/src/test/java/marquez/db/DatasetFieldDaoTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.UUID;
+import marquez.db.models.DatasetFieldRow;
+import marquez.db.models.DatasetRow;
+import marquez.jdbi.MarquezJdbiExternalPostgresExtension;
+import marquez.service.models.Dataset;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Regression tests for https://github.com/MarquezProject/marquez/issues/3083: a {@code
+ * dataset_fields} row whose {@code type} is {@code null} must not be duplicated on repeated
+ * upserts, since duplicate {@code dataset_fields} rows each independently accumulate their own
+ * {@code column_lineage} edges, causing a combinatorial explosion.
+ */
+@ExtendWith(MarquezJdbiExternalPostgresExtension.class)
+class DatasetFieldDaoTest {
+
+  private static DatasetFieldDao datasetFieldDao;
+  private static DatasetDao datasetDao;
+  private static Jdbi jdbi;
+
+  @BeforeAll
+  public static void setUpOnce(Jdbi jdbi) {
+    DatasetFieldDaoTest.jdbi = jdbi;
+    datasetFieldDao = jdbi.onDemand(DatasetFieldDao.class);
+    datasetDao = jdbi.onDemand(DatasetDao.class);
+  }
+
+  @AfterEach
+  public void tearDown(Jdbi jdbi) {
+    marquez.api.JdbiUtils.cleanDatabase(jdbi);
+  }
+
+  @Test
+  public void testUpsert_withNullType_doesNotDuplicateOnRepeatedUpserts() {
+    final Dataset dataset = DbTestUtils.newDataset(jdbi);
+    final DatasetRow datasetRow =
+        datasetDao.getUuid(dataset.getNamespace().getValue(), dataset.getName().getValue()).get();
+
+    final String fieldName = "modified_at";
+    final Instant now = Instant.now();
+
+    // Simulate the same field, with an unknown/null type, being reported across multiple
+    // OpenLineage events for the same dataset - each upsert uses a freshly-generated candidate
+    // UUID, exactly as OpenLineageDao.upsertFields(...) does for every incoming event.
+    DatasetFieldRow first =
+        datasetFieldDao.upsert(
+            UUID.randomUUID(), now, fieldName, null, null, datasetRow.getUuid());
+    DatasetFieldRow second =
+        datasetFieldDao.upsert(
+            UUID.randomUUID(), now, fieldName, null, null, datasetRow.getUuid());
+    DatasetFieldRow third =
+        datasetFieldDao.upsert(
+            UUID.randomUUID(), now, fieldName, null, null, datasetRow.getUuid());
+
+    // All three upserts must resolve to the *same* underlying row.
+    assertThat(second.getUuid()).isEqualTo(first.getUuid());
+    assertThat(third.getUuid()).isEqualTo(first.getUuid());
+
+    // And only a single dataset_fields row should exist for this field.
+    Integer rowCount =
+        jdbi.withHandle(
+            handle ->
+                handle
+                    .createQuery(
+                        "SELECT count(*) FROM dataset_fields WHERE dataset_uuid = :datasetUuid AND name = :name")
+                    .bind("datasetUuid", datasetRow.getUuid())
+                    .bind("name", fieldName)
+                    .mapTo(Integer.class)
+                    .one());
+    assertThat(rowCount).isEqualTo(1);
+  }
+
+  @Test
+  public void testUpsert_withNullType_isStoredAsUnknownSentinel() {
+    final Dataset dataset = DbTestUtils.newDataset(jdbi);
+    final DatasetRow datasetRow =
+        datasetDao.getUuid(dataset.getNamespace().getValue(), dataset.getName().getValue()).get();
+
+    DatasetFieldRow row =
+        datasetFieldDao.upsert(
+            UUID.randomUUID(), Instant.now(), "unknown_type_field", null, null, datasetRow.getUuid());
+
+    assertThat(row.getType()).isEqualTo("UNKNOWN");
+  }
+
+  @Test
+  public void testUpsert_withRealType_isUnaffected() {
+    final Dataset dataset = DbTestUtils.newDataset(jdbi);
+    final DatasetRow datasetRow =
+        datasetDao.getUuid(dataset.getNamespace().getValue(), dataset.getName().getValue()).get();
+
+    final Instant now = Instant.now();
+    DatasetFieldRow first =
+        datasetFieldDao.upsert(
+            UUID.randomUUID(), now, "typed_field", "VARCHAR", null, datasetRow.getUuid());
+    DatasetFieldRow second =
+        datasetFieldDao.upsert(
+            UUID.randomUUID(), now, "typed_field", "VARCHAR", null, datasetRow.getUuid());
+
+    assertThat(first.getType()).isEqualTo("VARCHAR");
+    assertThat(second.getUuid()).isEqualTo(first.getUuid());
+  }
+}


### PR DESCRIPTION
`DatasetFieldDao.upsert` relies on the `(dataset_uuid, name, type)` unique constraint to turn a repeat upsert of the same field into an `UPDATE`:

```sql
INSERT INTO dataset_fields (uuid, type, created_at, updated_at, dataset_uuid, name, description)
VALUES (:uuid, :type, :now, :now, :datasetUuid, :name, :description)
ON CONFLICT(dataset_uuid, name, type) DO UPDATE SET ...
```

Problem is standard SQL never treats `NULL = NULL` as true for uniqueness/`ON CONFLICT` purposes. Plenty of OpenLineage producers don't report a column type, so any field upserted with `type = NULL` never matches its own previously-inserted row — a fresh row with a new UUID gets inserted every time. Each of those rows independently accumulates its own `column_lineage` edges, so what should be one relationship turns into N, and N grows unbounded with every event. That's the "explosion" from #3083 — the reporter saw 1000x+ row bloat.

```mermaid
flowchart TD
    U["upsert dataset_fields
(dataset_uuid, name, type = NULL)"]
    U --> C{"ON CONFLICT (dataset_uuid, name, type)"}
    C --> Old["Before: type stored as raw NULL"]
    Old --> N1["NULL <> NULL, conflict never matches"]
    N1 --> R1["New row inserted every upsert
N rows for 1 field -> N x column_lineage rows"]
    C --> New["After: type stored as COALESCE(:type, 'UNKNOWN')"]
    New --> N2["'UNKNOWN' = 'UNKNOWN', conflict matches"]
    N2 --> R2["Existing row updated
single dataset_fields row retained"]
```

**Fix:** coalesce a `NULL` type to the sentinel `'UNKNOWN'` before insert. Repeated upserts of an unknown-type field now reliably collide with the row already there. No schema/migration change, no risk to rows that already have a real type — this is the fix suggested in the issue itself. One visible side effect: a field's `type` now shows up as the literal string `"UNKNOWN"` via the API instead of `null` when nothing was reported. Updated `MarquezAppIntegrationTest#testDatasetWithUnknownFieldType` to match.

**Verification:** ran the actual `INSERT ... ON CONFLICT` SQL by hand against a real Postgres 16 instance via `psql`, outside Gradle/Testcontainers (see below for why). Two upserts of the same `(dataset_uuid, name)` with `type = NULL`: before the fix, `count = 2`; after, `count = 1`, and the returned `uuid` was identical across both calls, confirming the second call updated rather than inserted.

Correction on that verification, since I got it wrong in an earlier draft of this description and want to correct it plainly rather than leave it: I'd said the Postgres 16 instance I tested against matched "the version pinned by this repo's own tests." That's not accurate. I went and checked `api/src/test/java/marquez/PostgresContainer.java` (which backs the Testcontainers extension this PR's own new `DatasetFieldDaoTest` uses), plus `docker-compose.yml` and `docker-compose.db.yml` — they all still pin Postgres 14. There's an incomplete, unmerged `postgres-16` branch on the remote, and only two unrelated test files (`DbRetentionTest`, `StatsTest`) touch Postgres 16 today. So my manual verification used Postgres 16 while this repo's actual pinned test infrastructure runs Postgres 14 — a real version mismatch on my part. It doesn't change the fix's correctness though: the relevant SQL semantics here (`NULL` never equals `NULL` for `ON CONFLICT`/unique-constraint purposes) are identical across Postgres 14 and 16.

**Tests:**
- `DatasetFieldDaoTest` (new) — DAO-level: repeated upserts of a null-typed field resolve to the same row/UUID, the stored type becomes `"UNKNOWN"`, and real (non-null) types are unaffected.
- `MarquezAppIntegrationTest#testDatasetWithUnknownFieldType_repeatedUpsertsDoNotDuplicateField` (new) — emits the same dataset with a null-typed field 5 times, mirroring the issue's repro steps, and asserts only one field comes back, not five.
- `testDatasetWithUnknownFieldType` — updated to expect the `"UNKNOWN"` sentinel.

Couldn't run these locally through Gradle — same Testcontainers/Docker API mismatch I keep hitting in this sandbox (bundled `docker-java` defaults to API v1.32, local engine needs >= v1.40; confirmed it's pre-existing by hitting the identical failure on unmodified `RunDaoTest`). `./gradlew :api:compileTestJava` and `:api:testUnit` (118 tests) both pass. Given the local DB test gap, the manual `psql` verification above is what I'm actually leaning on to confirm correctness — would appreciate CI running the full DB-backed suite on this one.

Fixes #3083.
