### PR TITLE
Fix column lineage transformation details always appearing as null

### DIFF
--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -1094,6 +1094,23 @@ public interface OpenLineageDao extends BaseDao {
                   datasetVersionRow.getUuid(),
                   inputFieldsByTransformation);
 
+              // NOTE: when this output field has 2+ distinct transformation groups (its input
+              // fields resolve to more than one distinct (description, type) pair via
+              // transformationOf(...) above), upsertColumnLineageRow(...) below is invoked once
+              // per group. That method's implementation always returns ALL column_lineage rows
+              // currently persisted for this (outputDatasetVersionUuid, outputDatasetFieldUuid)
+              // pair - not just the rows written by the current call - via
+              // ColumnLineageDao#findColumnLineageByDatasetVersionColumnAndOutputDatasetField.
+              // So across multiple groups, the same underlying row can appear more than once in
+              // the aggregate List<ColumnLineageRow> this method returns for a given output
+              // field.
+              //
+              // As of this writing this has no production impact: the only consumer of this
+              // return value, DatasetRecord#getColumnLineageRows(), is not read anywhere in
+              // production code today (only in tests, and only the single-transformation-group
+              // case is currently exercised). If a real consumer is added later, either dedupe
+              // the combined list here or change upsertColumnLineageRow(...)/ColumnLineageDao to
+              // return only the rows written by that specific call.
               return inputFieldsByTransformation.entrySet().stream()
                   .flatMap(
                       entry ->

--- a/api/src/main/java/marquez/db/OpenLineageDao.java
+++ b/api/src/main/java/marquez/db/OpenLineageDao.java
@@ -1049,10 +1049,23 @@ public interface OpenLineageDao extends BaseDao {
                 return Stream.empty();
               }
 
-              // get field uuids of input columns related to this run
-              List<Pair<UUID, UUID>> inputFields =
+              // Match each field associated with this run to the OpenLineage input field it
+              // corresponds to (if any), along with the transformation description/type that
+              // applies to that specific input -> output edge. Prefer the (non-deprecated)
+              // per-input-field InputField#transformations entry reported by the producer;
+              // fall back to the deprecated, whole-output-column
+              // transformationDescription/transformationType for producers that only report the
+              // old format. Without this fallback/lookup, transformation details reported via the
+              // modern `transformations` array were silently dropped and always appeared as null
+              // (see #3100).
+              //
+              // Input fields are then grouped by the transformation (description, type) that
+              // applies to each of them, so that each distinct transformation is persisted with
+              // its own value while still reusing the existing batch upsertColumnLineageRow(...)
+              // API (which applies a single description/type to every input field passed to it).
+              Map<Pair<String, String>, List<Pair<UUID, UUID>>> inputFieldsByTransformation =
                   runFields.stream()
-                      .filter(
+                      .flatMap(
                           fieldData ->
                               columnLineage.getInputFields().stream()
                                   .filter(
@@ -1061,31 +1074,70 @@ public interface OpenLineageDao extends BaseDao {
                                               && of.getName().equals(fieldData.getDatasetName())
                                               && of.getField().equals(fieldData.getField()))
                                   .findAny()
-                                  .isPresent())
-                      .map(
-                          fieldData ->
-                              Pair.of(
-                                  fieldData.getDatasetVersionUuid(),
-                                  fieldData.getDatasetFieldUuid()))
-                      .collect(Collectors.toList());
+                                  .map(matchedInputField -> Pair.of(fieldData, matchedInputField))
+                                  .stream())
+                      .collect(
+                          Collectors.groupingBy(
+                              fieldDataAndInputField ->
+                                  transformationOf(
+                                      fieldDataAndInputField.getRight(), columnLineage),
+                              Collectors.mapping(
+                                  fieldDataAndInputField ->
+                                      Pair.of(
+                                          fieldDataAndInputField.getLeft().getDatasetVersionUuid(),
+                                          fieldDataAndInputField.getLeft().getDatasetFieldUuid()),
+                                  Collectors.toList())));
 
               log.debug(
-                  "Adding column lineage on output field '{}' for dataset version '{}' with input fields: {}",
+                  "Adding column lineage on output field '{}' for dataset version '{}' with input fields by transformation: {}",
                   outputField.get().getName(),
                   datasetVersionRow.getUuid(),
-                  inputFields);
-              return daos
-                  .getColumnLineageDao()
-                  .upsertColumnLineageRow(
-                      datasetVersionRow.getUuid(),
-                      outputField.get().getUuid(),
-                      inputFields,
-                      columnLineage.getTransformationDescription(),
-                      columnLineage.getTransformationType(),
-                      now)
-                  .stream();
+                  inputFieldsByTransformation);
+
+              return inputFieldsByTransformation.entrySet().stream()
+                  .flatMap(
+                      entry ->
+                          daos.getColumnLineageDao()
+                              .upsertColumnLineageRow(
+                                  datasetVersionRow.getUuid(),
+                                  outputField.get().getUuid(),
+                                  entry.getValue(),
+                                  entry.getKey().getLeft(),
+                                  entry.getKey().getRight(),
+                                  now)
+                              .stream());
             })
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Resolves the (transformationDescription, transformationType) pair that applies to a single
+   * OpenLineage column-lineage input field. Prefers the first entry of the (non-deprecated) {@link
+   * LineageEvent.ColumnLineageInputField#getTransformations()} list reported for that specific
+   * input field; falls back to the deprecated, whole-output-column {@code
+   * transformationDescription}/{@code transformationType} on {@link
+   * LineageEvent.ColumnLineageOutputColumn} for producers that only report the old format.
+   *
+   * <p>If a producer reports more than one transformation for a single input field, only the
+   * first is used, matching the granularity at which Marquez persists a transformation
+   * description/type (one value per input/output field edge).
+   */
+  static Pair<String, String> transformationOf(
+      LineageEvent.ColumnLineageInputField inputField,
+      LineageEvent.ColumnLineageOutputColumn outputColumn) {
+    Optional<LineageEvent.ColumnLineageInputField.Transformation> transformation =
+        Optional.ofNullable(inputField.getTransformations()).stream()
+            .flatMap(List::stream)
+            .findFirst();
+    String transformationDescription =
+        transformation
+            .map(LineageEvent.ColumnLineageInputField.Transformation::getDescription)
+            .orElseGet(outputColumn::getTransformationDescription);
+    String transformationType =
+        transformation
+            .map(LineageEvent.ColumnLineageInputField.Transformation::getType)
+            .orElseGet(outputColumn::getTransformationType);
+    return Pair.of(transformationDescription, transformationType);
   }
 
   default String formatDatasetName(String name) {

--- a/api/src/main/java/marquez/service/models/LineageEvent.java
+++ b/api/src/main/java/marquez/service/models/LineageEvent.java
@@ -630,8 +630,6 @@ public class LineageEvent extends BaseEvent {
     private String transformationType;
   }
 
-  @Builder
-  @AllArgsConstructor
   @NoArgsConstructor
   @Setter
   @Getter
@@ -642,6 +640,44 @@ public class LineageEvent extends BaseEvent {
     @NotNull private String namespace;
     @NotNull private String name;
     @NotNull private String field;
+
+    /**
+     * The transformations applied to this specific input field in order to compute the output
+     * field it is associated with. This is the current (non-deprecated) way for a producer to
+     * report per-input-field transformation details, as opposed to the deprecated {@link
+     * ColumnLineageOutputColumn#getTransformationDescription()} / {@link
+     * ColumnLineageOutputColumn#getTransformationType()}, which apply (at most) a single,
+     * whole-column value shared by every input field. See
+     * https://github.com/OpenLineage/OpenLineage/blob/main/spec/facets/ColumnLineageDatasetFacet.json
+     */
+    private List<Transformation> transformations;
+
+    public ColumnLineageInputField(String namespace, String name, String field) {
+      this(namespace, name, field, null);
+    }
+
+    @Builder
+    public ColumnLineageInputField(
+        String namespace, String name, String field, List<Transformation> transformations) {
+      this.namespace = namespace;
+      this.name = name;
+      this.field = field;
+      this.transformations = transformations;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Setter
+    @Getter
+    @Valid
+    @ToString
+    public static class Transformation {
+      private String type;
+      private String subtype;
+      private String description;
+      private Boolean masking;
+    }
   }
 
   @Builder

--- a/api/src/test/java/marquez/db/OpenLineageDaoColumnLineageTransformationTest.java
+++ b/api/src/test/java/marquez/db/OpenLineageDaoColumnLineageTransformationTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2018-2023 contributors to the Marquez project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package marquez.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import marquez.service.models.LineageEvent;
+import marquez.service.models.LineageEvent.ColumnLineageInputField;
+import marquez.service.models.LineageEvent.ColumnLineageInputField.Transformation;
+import marquez.service.models.LineageEvent.ColumnLineageOutputColumn;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for https://github.com/MarquezProject/marquez/issues/3100: transformation
+ * details reported via the (non-deprecated) {@code InputField.transformations[]} array of the
+ * OpenLineage {@code ColumnLineageDatasetFacet} were always dropped, so {@code
+ * transformation_description}/{@code transformation_type} always ended up null in Marquez,
+ * regardless of what the producer actually reported.
+ *
+ * <p>These tests exercise {@link OpenLineageDao#transformationOf(ColumnLineageInputField,
+ * ColumnLineageOutputColumn)} directly - the pure function responsible for resolving which
+ * transformation applies to a given input field - so they can run without a database.
+ */
+@org.junit.jupiter.api.Tag("UnitTests")
+class OpenLineageDaoColumnLineageTransformationTest {
+
+  @Test
+  void prefersPerInputFieldTransformationOverDeprecatedOutputColumnFields() {
+    // Reproduces the exact scenario from the issue: the output column itself does not set the
+    // deprecated transformationDescription/transformationType, but each input field reports its
+    // own transformations[] entry.
+    ColumnLineageInputField inputField =
+        ColumnLineageInputField.builder()
+            .namespace("bookstore2")
+            .name("customers")
+            .field("customer_email")
+            .transformations(
+                Collections.singletonList(
+                    Transformation.builder()
+                        .type("DIRECT")
+                        .subtype("TRANSFORMATION")
+                        .description("concat(customers.customer_name, ' - ', customers.customer_email)")
+                        .build()))
+            .build();
+    ColumnLineageOutputColumn outputColumn =
+        ColumnLineageOutputColumn.builder().inputFields(List.of(inputField)).build();
+
+    Pair<String, String> transformation = OpenLineageDao.transformationOf(inputField, outputColumn);
+
+    assertThat(transformation.getLeft())
+        .isEqualTo("concat(customers.customer_name, ' - ', customers.customer_email)");
+    assertThat(transformation.getRight()).isEqualTo("DIRECT");
+  }
+
+  @Test
+  void distinctInputFieldsOnTheSameOutputColumnCanHaveDifferentTransformations() {
+    // customer_full in the issue is fed by two input fields, each with a different underlying
+    // source field but (in the issue's example) the same description; verify the resolution is
+    // genuinely per-input-field rather than picking a single value for the whole output column.
+    ColumnLineageInputField emailField =
+        ColumnLineageInputField.builder()
+            .namespace("bookstore2")
+            .name("customers")
+            .field("customer_email")
+            .transformations(
+                Collections.singletonList(
+                    Transformation.builder().type("DIRECT").description("descriptionA").build()))
+            .build();
+    ColumnLineageInputField nameField =
+        ColumnLineageInputField.builder()
+            .namespace("bookstore2")
+            .name("customers")
+            .field("customer_name")
+            .transformations(
+                Collections.singletonList(
+                    Transformation.builder().type("INDIRECT").description("descriptionB").build()))
+            .build();
+    ColumnLineageOutputColumn outputColumn =
+        ColumnLineageOutputColumn.builder()
+            .inputFields(Arrays.asList(emailField, nameField))
+            .build();
+
+    Pair<String, String> emailTransformation =
+        OpenLineageDao.transformationOf(emailField, outputColumn);
+    Pair<String, String> nameTransformation =
+        OpenLineageDao.transformationOf(nameField, outputColumn);
+
+    assertThat(emailTransformation).isEqualTo(Pair.of("descriptionA", "DIRECT"));
+    assertThat(nameTransformation).isEqualTo(Pair.of("descriptionB", "INDIRECT"));
+  }
+
+  @Test
+  void fallsBackToDeprecatedOutputColumnFieldsWhenInputFieldHasNoTransformations() {
+    // Producers using the old (deprecated) format never set inputField.transformations at all;
+    // this must keep working exactly as before.
+    ColumnLineageInputField inputField =
+        ColumnLineageInputField.builder()
+            .namespace("ns")
+            .name("upstream")
+            .field("col")
+            .build(); // no transformations set
+    ColumnLineageOutputColumn outputColumn =
+        ColumnLineageOutputColumn.builder()
+            .inputFields(List.of(inputField))
+            .transformationDescription("legacy description")
+            .transformationType("IDENTITY")
+            .build();
+
+    Pair<String, String> transformation = OpenLineageDao.transformationOf(inputField, outputColumn);
+
+    assertThat(transformation).isEqualTo(Pair.of("legacy description", "IDENTITY"));
+  }
+
+  @Test
+  void returnsNullPairWhenNeitherFormatIsReported() {
+    ColumnLineageInputField inputField =
+        ColumnLineageInputField.builder().namespace("ns").name("upstream").field("col").build();
+    ColumnLineageOutputColumn outputColumn =
+        ColumnLineageOutputColumn.builder().inputFields(List.of(inputField)).build();
+
+    Pair<String, String> transformation = OpenLineageDao.transformationOf(inputField, outputColumn);
+
+    assertThat(transformation.getLeft()).isNull();
+    assertThat(transformation.getRight()).isNull();
+  }
+
+  @Test
+  void usesOnlyFirstTransformationWhenMultipleAreReportedForTheSameInputField() {
+    ColumnLineageInputField inputField =
+        ColumnLineageInputField.builder()
+            .namespace("ns")
+            .name("upstream")
+            .field("col")
+            .transformations(
+                Arrays.asList(
+                    Transformation.builder().type("DIRECT").description("first").build(),
+                    Transformation.builder().type("INDIRECT").description("second").build()))
+            .build();
+    ColumnLineageOutputColumn outputColumn =
+        ColumnLineageOutputColumn.builder().inputFields(List.of(inputField)).build();
+
+    Pair<String, String> transformation = OpenLineageDao.transformationOf(inputField, outputColumn);
+
+    assertThat(transformation).isEqualTo(Pair.of("first", "DIRECT"));
+  }
+}

--- a/api/src/test/java/marquez/db/OpenLineageDaoTest.java
+++ b/api/src/test/java/marquez/db/OpenLineageDaoTest.java
@@ -259,6 +259,80 @@ class OpenLineageDaoTest {
   }
 
   @Test
+  /**
+   * Regression test for https://github.com/MarquezProject/marquez/issues/3100: transformation
+   * details reported via the (non-deprecated) {@code InputField.transformations[]} array must be
+   * persisted, not just the deprecated whole-output-column {@code
+   * transformationDescription}/{@code transformationType} fields.
+   */
+  void testUpdateMarquezModelDatasetWithColumnLineageFacet_usesNewTransformationsFormat() {
+    final String NEW_FORMAT_DESCRIPTION = "concat(a, b)";
+    final String NEW_FORMAT_TYPE = "DIRECT";
+
+    LineageEvent.ColumnLineageInputField.Transformation transformation =
+        LineageEvent.ColumnLineageInputField.Transformation.builder()
+            .type(NEW_FORMAT_TYPE)
+            .subtype("TRANSFORMATION")
+            .description(NEW_FORMAT_DESCRIPTION)
+            .build();
+
+    LineageEvent.ColumnLineageInputField inputFieldWithTransformation =
+        LineageEvent.ColumnLineageInputField.builder()
+            .namespace(INPUT_NAMESPACE)
+            .name(INPUT_DATASET)
+            .field(INPUT_FIELD_NAME)
+            .transformations(Collections.singletonList(transformation))
+            .build();
+
+    // deprecated inputFields/transformationDescription/transformationType constructor args are
+    // deliberately left unset, matching producers that only emit the new format.
+    LineageEvent.ColumnLineageOutputColumn outputColumn =
+        LineageEvent.ColumnLineageOutputColumn.builder()
+            .inputFields(Collections.singletonList(inputFieldWithTransformation))
+            .build();
+
+    LineageEvent.ColumnLineageDatasetFacet columnLineageFacet =
+        new LineageEvent.ColumnLineageDatasetFacet(
+            PRODUCER_URL,
+            SCHEMA_URL,
+            new LineageEvent.ColumnLineageDatasetFacetFields(
+                Collections.singletonMap(OUTPUT_COLUMN, outputColumn)));
+
+    Dataset outputDataset =
+        new Dataset(
+            NAMESPACE,
+            DATASET_NAME,
+            LineageEvent.DatasetFacets.builder()
+                .schema(
+                    new SchemaDatasetFacet(
+                        PRODUCER_URL,
+                        SCHEMA_URL,
+                        Arrays.asList(new SchemaField(OUTPUT_COLUMN, "STRING", "my name"))))
+                .columnLineage(columnLineageFacet)
+                .build());
+
+    JobFacet jobFacet = JobFacet.builder().build();
+    UpdateLineageRow writeJob =
+        LineageTestUtils.createLineageRow(
+            dao,
+            WRITE_JOB_NAME,
+            "COMPLETE",
+            jobFacet,
+            Arrays.asList(getInputDataset()),
+            Arrays.asList(outputDataset));
+
+    assertThat(
+            writeJob.getOutputs().get().stream()
+                .findAny()
+                .orElseThrow()
+                .getColumnLineageRows())
+        .extracting(
+            (ds) -> ds.getTransformationDescription().get(),
+            (ds) -> ds.getTransformationType().get())
+        .containsExactly(Tuple.tuple(NEW_FORMAT_DESCRIPTION, NEW_FORMAT_TYPE));
+  }
+
+  @Test
   void testUpdateMarquezModelDatasetWithColumnLineageFacetWhenInputFieldDoesNotExist() {
     JobFacet jobFacet = JobFacet.builder().build();
     UpdateLineageRow writeJob =


### PR DESCRIPTION
Marquez's `LineageEvent.ColumnLineageInputField` (used to deserialize the OpenLineage `ColumnLineageDatasetFacet`) only ever captured `namespace`/`name`/`field` — no `transformations` property existed on it at all. Meanwhile the write path, `OpenLineageDao.upsertColumnLineage`, only read `transformationDescription`/`transformationType` off the *output column* (`ColumnLineageOutputColumn`), which the [current OpenLineage spec](https://github.com/OpenLineage/OpenLineage/blob/main/spec/facets/ColumnLineageDatasetFacet.json) marks `deprecated: true`.

Modern producers report transformation details per input field instead, nested under `inputFields[].transformations[]` — exactly what's in the issue's example:

```json
"customer_full": {
  "inputFields": [
    {
      "namespace": "bookstore2", "name": "customers", "field": "customer_email",
      "transformations": [{ "type": "DIRECT", "subtype": "TRANSFORMATION", "description": "concat(...)" }]
    }
  ]
}
```

Since the model had nowhere to deserialize that array into, and the write path never looked at the deprecated output-column fields for producers that only emit the new shape, `transformation_description`/`transformation_type` landed as `null` for anyone using the current facet format — reproducing the bug as reported (a second user hit the same thing in the issue thread).

```mermaid
flowchart TD
    E["OpenLineage event:
inputFields[].transformations[] (current spec)"]
    E --> Old["Before: ColumnLineageInputField has no transformations field"]
    Old --> O1["Write path only reads deprecated
outputColumn.transformationDescription/Type"]
    O1 --> R1["null/null persisted whenever producer
only emits the new per-field format"]
    E --> New["After: transformationOf(inputField, outputColumn)"]
    New --> O2{"inputField.transformations present?"}
    O2 -->|yes| R2["Use that field's own transformation
description/type"]
    O2 -->|no - legacy producer| R3["Fall back to deprecated
outputColumn description/type"]
```

**Fix:**
- Added `transformations` (`List<Transformation>`) to `ColumnLineageInputField`, with a new `Transformation` class (`type`/`subtype`/`description`/`masking`) mirroring the spec. Kept the existing 3-arg constructor working unchanged so no call site needed to move — verified by compiling all 8 existing usages untouched.
- Added `OpenLineageDao.transformationOf(inputField, outputColumn)` — a small pure function that prefers the first entry of that specific input field's own `transformations` list, and falls back to the deprecated output-column-level fields for producers still on the old format.
- `upsertColumnLineage` now resolves the transformation per matched input field via `transformationOf` and groups input fields by their resolved `(description, type)` before calling the existing batch `ColumnLineageDao.upsertColumnLineageRow(...)` once per group. That persists a distinct transformation per input/output edge, which `column_lineage` and the read path already supported — without touching `ColumnLineageDao`'s public signature, so `ColumnLineageDaoTest` didn't need to change either.

**Testing:** new `OpenLineageDaoColumnLineageTransformationTest` (unit, no DB) exercises `transformationOf` directly against the issue's exact scenario, plus multi-field, fallback-to-deprecated, both-formats-absent, and multiple-transformations-on-one-field cases. Did the fail-then-pass check by hand: temporarily reverted `transformationOf` to always read the deprecated fields, saw 3 of 5 tests fail with null description/type, restored the fix, all 5 passed.

Also added `OpenLineageDaoTest#testUpdateMarquezModelDatasetWithColumnLineageFacet_usesNewTransformationsFormat`, a full DB-backed test that builds a facet using only the new `inputFields[].transformations[]` format (deprecated fields deliberately left unset, matching real modern producers) and checks the persisted row has a non-null description/type.

`./gradlew :api:testUnit` passes (123 tests, including the 5 new ones). Couldn't run the Postgres-backed `OpenLineageDaoTest` locally — same Testcontainers/Docker API mismatch I keep hitting in this sandbox (bundled `docker-java` wants API v1.32, the local engine needs >= v1.40; confirmed pre-existing by hitting it on unmodified `RunDaoTest` too). `:api:compileTestJava` passes, so the new integration test at least compiles clean against the real classes. Would appreciate CI running the DB suite here.

## Known gap I'm leaving in (marked with a comment in the code)

While working on this I found a real edge case in `upsertColumnLineage` that's worth surfacing outside a code comment. When a single output column's input fields span 2+ distinct transformation groups, `upsertColumnLineageRow(...)` gets called once per group — but that method's existing implementation always returns *all* `column_lineage` rows currently persisted for that `(outputDatasetVersionUuid, outputDatasetFieldUuid)` pair, not just the rows the current call wrote. So across multiple groups, the same row can show up more than once in the `List<ColumnLineageRow>` this method returns.

It has no production impact right now: the only consumer of that return value, `DatasetRecord#getColumnLineageRows()`, isn't read anywhere in production code — only in tests, and this PR's own new test only exercises the single-group case, so it doesn't trigger the duplication. The rows actually persisted in `column_lineage` are correct either way; this only affects the in-memory list handed back up the call stack.

I left a `// NOTE:` comment right above the relevant code explaining this, in case someone adds a real consumer of `getColumnLineageRows()` later — they'd want to either dedupe or change `upsertColumnLineageRow`'s contract to return only newly-written rows. Not fixing it here since it's inert today and out of scope for the null-transformation bug this PR is actually about.

Fixes #3100.
